### PR TITLE
fix: apply Copilot feedback from rebrand PR

### DIFF
--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-stack
-description: Merge the latest changes from the WeAreOpenSource Vue stack repository into a downstream project. Use when pulling stack updates, syncing with upstream via `git merge vue-stack/master`, or resolving merge conflicts from stack updates.
+description: Merge the latest changes from the Devkit Vue stack repository into a downstream project. Use when pulling stack updates, syncing with upstream via `git merge devkit-vue/master`, or resolving merge conflicts from stack updates.
 ---
 
 # Update Stack Skill
@@ -12,19 +12,19 @@ Pure git workflow for merging stack updates while preserving downstream customiz
 ### 1. Add the stack remote (if not already added)
 
 ```bash
-git remote add vue-stack https://github.com/weareopensource/Vue.git
+git remote add devkit-vue https://github.com/pierreb-devkit/Vue.git
 ```
 
 ### 2. Fetch the latest stack changes
 
 ```bash
-git fetch vue-stack
+git fetch devkit-vue
 ```
 
 ### 3. Merge the stack updates
 
 ```bash
-git merge vue-stack/master
+git merge devkit-vue/master
 ```
 
 ### 4. Handle conflicts

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## :book: Presentation
 
-A Vue 3 / Vuetify 3 / Vite / JWT stack that can run as a standalone frontend or in a fullstack setup with another repo (ex: [Node](https://github.com/pierreb-devkit/Node), [Swift](https://github.com/pierreb-devkit/Swift)).
+A Vue 3 / Vuetify 3 / Vite / JWT stack that can be run as a standalone frontend or in a fullstack setup with another repo (ex: [Node](https://github.com/pierreb-devkit/Node), [Swift](https://github.com/pierreb-devkit/Swift)).
 
 Designed to be cloned into downstream projects and kept up-to-date via `git merge` from the stack repo.
 
@@ -15,8 +15,8 @@ Designed to be cloned into downstream projects and kept up-to-date via `git merg
 | Subject      | Informations                                                                                                                                                                                                                                                                                               |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Architecture | Layered Architecture : everything is separated in layers, and the upper layers are abstractions of the lower ones, that's why every layer should only reference the immediate lower layer (vertical modules architecture)                                                                                   |
-| Security     | JWT Stateless - have a look on [Node](https://github.com/pierreb-devkit/Node) stack for more informations                                                                                                                                                                                                  |
-| CI           | [Github Action](https://github.com/pierreb-devkit/Vue/actions)                                                                                                                                                                                                                                             |
+| Security     | JWT Stateless - take a look at the [Node](https://github.com/pierreb-devkit/Node) stack for more information                                                                                                                                                                                                  |
+| CI           | [GitHub Actions](https://github.com/pierreb-devkit/Vue/actions)                                                                                                                                                                                                                                             |
 | Linter       | [ESLint](https://github.com/eslint/eslint) ecmaVersion 10 (2019)                                                                                                                                                                                                                                           |
 | Developer    | [Dependabot](https://dependabot.com/) - [Snyk](https://snyk.io/test/github/pierreb-devkit/vue) <br> [semantic-release](https://github.com/semantic-release/semantic-release) - [commitlint](https://github.com/conventional-changelog/commitlint) - [commitizen](https://github.com/commitizen/cz-cli) |
 | Dependencies | [npm](https://www.npmjs.com)                                                                                                                                                                                                                                                                               |
@@ -51,7 +51,7 @@ npm install
 ### Development
 
 ```bash
-npm start        # or npm run dev
+npm run dev
 ```
 
 Runs dev server with hot-reload at `http://localhost:8080/`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,36 +1,36 @@
 version: '3'
 
 services:
-  weareopensourceVue:
-    container_name: weareopensourceVue
-    image: weareopensource/vue:latest
+  devkitVue:
+    container_name: devkitVue
+    image: pierreb/vue:latest
     restart: always
     ports:
       - 8080:80
     volumes:
-      - weareopensourceVue:/data
+      - devkitVue:/data
     networks:
       - frontend
     depends_on:
-      - weareopensourceNode
+      - devkitNode
     environment:
-      - 'WAOS_VUE_api_host=waosnode'
+      - 'WAOS_VUE_api_host=devkitnode'
 
-  weareopensourceNode:
-    container_name: weareopensourceNode
-    image: weareopensource/node:latest
+  devkitNode:
+    container_name: devkitNode
+    image: pierreb/node:latest
     restart: always
     ports:
       - 3000:3000
     volumes:
-      - weareopensourceNode:/data
+      - devkitNode:/data
     networks:
       - frontend
       - backend
     depends_on:
       - mongo
     environment:
-      - 'WAOS_NODE_db_uri=mongodb://mongo:27017/WaosNodeDev'
+      - 'WAOS_NODE_db_uri=mongodb://mongo:27017/DevkitNodeDev'
       - 'WAOS_NODE_host=0.0.0.0'
 
   mongo:
@@ -49,6 +49,6 @@ networks:
     driver: bridge
 
 volumes:
-  weareopensourceVue:
-  weareopensourceNode:
+  devkitVue:
+  devkitNode:
   mongo:


### PR DESCRIPTION
## Summary

Follow-up of #3514 — addresses the valid Copilot review comments that were missed before merging.

- **README**: fix grammar (`can be run`, `GitHub Actions`, `more information`)
- **README**: replace `npm start` with `npm run dev` (`start` script doesn't exist in `package.json`)
- **docker-compose.yml**: rebrand service names, container names, volumes and images from `weareopensource` to `pierreb/devkit`
- **update-stack skill**: align remote name (`vue-stack` → `devkit-vue`) and repo URL to `pierreb-devkit/Vue`

## Test plan

- [ ] `npm run dev` starts the dev server correctly
- [ ] `docker-compose up` resolves images from `pierreb/vue:latest` and `pierreb/node:latest`
- [ ] `/update-stack` skill uses `devkit-vue` remote consistently with the README

🤖 Generated with [Claude Code](https://claude.ai/claude-code)