### PR TITLE
refactor(seo): extract shared buildSeoConfig helper

### DIFF
--- a/src/lib/helpers/seo.js
+++ b/src/lib/helpers/seo.js
@@ -1,0 +1,53 @@
+/**
+ * Shared SEO configuration builder.
+ * Used by both the build-time Vite plugin (seo-inject.js) and the runtime
+ * Vue component (app.vue) to ensure consistent meta tags in both contexts.
+ *
+ * @param {object} config - app config object (src/config/index.js)
+ * @returns {{ title: string, lang: string, meta: object[], link: object[], schema: object|null }}
+ */
+export function buildSeoConfig(config) {
+  const app = config?.app || {};
+  const seo = app.seo || {};
+  const og = seo.og || {};
+  const schema = seo.schema || {};
+
+  const meta = [
+    app.description && { name: 'description', content: app.description },
+    app.keywords && { name: 'keywords', content: app.keywords },
+    app.author && { name: 'author', content: app.author },
+    // Open Graph
+    { property: 'og:type', content: og.type || 'website' },
+    app.title && { property: 'og:title', content: app.title },
+    app.description && { property: 'og:description', content: app.description },
+    app.url && { property: 'og:url', content: app.url },
+    og.image && { property: 'og:image', content: og.image },
+    // Twitter Card
+    { name: 'twitter:card', content: og.twitterCard || 'summary' },
+    app.title && { name: 'twitter:title', content: app.title },
+    app.description && { name: 'twitter:description', content: app.description },
+    og.twitterSite && { name: 'twitter:site', content: og.twitterSite },
+    og.image && { name: 'twitter:image', content: og.image },
+  ].filter(Boolean);
+
+  const link = app.url ? [{ rel: 'canonical', href: app.url }] : [];
+
+  const schemaData =
+    schema.enabled && schema.name
+      ? {
+          '@context': 'https://schema.org',
+          '@type': schema.type || 'Person',
+          name: schema.name,
+          url: app.url || undefined,
+          sameAs: schema.sameAs?.length ? schema.sameAs : undefined,
+        }
+      : null;
+
+  return {
+    title: app.title,
+    lang: app.lang || 'en',
+    meta,
+    link,
+    schema: schemaData,
+  };
+}

--- a/src/lib/plugins/seo-inject.js
+++ b/src/lib/plugins/seo-inject.js
@@ -7,66 +7,42 @@
  * @returns {import('vite').Plugin}
  */
 
+import { buildSeoConfig } from '../helpers/seo.js';
+
 const escapeHtml = (str) =>
   String(str).replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#x27;' }[char]));
 
 export function seoInjectPlugin(config) {
-  const app = config?.app || {};
-  const seo = app.seo || {};
-  const og = seo.og || {};
-
   return {
     name: 'seo-inject',
     transformIndexHtml(html) {
-      const tags = [];
+      const { title, lang, meta, link } = buildSeoConfig(config);
 
-      if (app.description)
-        tags.push(`  <meta name="description" content="${escapeHtml(app.description)}">`);
-      if (app.keywords)
-        tags.push(`  <meta name="keywords" content="${escapeHtml(app.keywords)}">`);
-      if (app.author)
-        tags.push(`  <meta name="author" content="${escapeHtml(app.author)}">`);
-      if (app.url)
-        tags.push(`  <link rel="canonical" href="${escapeHtml(app.url)}">`);
-
-      // Open Graph
-      if (app.title)
-        tags.push(`  <meta property="og:title" content="${escapeHtml(app.title)}">`);
-      if (app.description)
-        tags.push(`  <meta property="og:description" content="${escapeHtml(app.description)}">`);
-      tags.push(`  <meta property="og:type" content="${escapeHtml(og.type || 'website')}">`);
-      if (app.url)
-        tags.push(`  <meta property="og:url" content="${escapeHtml(app.url)}">`);
-      if (og.image)
-        tags.push(`  <meta property="og:image" content="${escapeHtml(og.image)}">`);
-
-      // Twitter Card
-      tags.push(`  <meta name="twitter:card" content="${escapeHtml(og.twitterCard || 'summary')}">`);
-      if (app.title)
-        tags.push(`  <meta name="twitter:title" content="${escapeHtml(app.title)}">`);
-      if (app.description)
-        tags.push(`  <meta name="twitter:description" content="${escapeHtml(app.description)}">`);
-      if (og.twitterSite)
-        tags.push(`  <meta name="twitter:site" content="${escapeHtml(og.twitterSite)}">`);
-      if (og.image)
-        tags.push(`  <meta name="twitter:image" content="${escapeHtml(og.image)}">`);
+      const tags = [
+        ...meta.map((m) =>
+          m.property
+            ? `  <meta property="${escapeHtml(m.property)}" content="${escapeHtml(m.content)}">`
+            : `  <meta name="${escapeHtml(m.name)}" content="${escapeHtml(m.content)}">`,
+        ),
+        ...link.map((l) => `  <link rel="${escapeHtml(l.rel)}" href="${escapeHtml(l.href)}">`),
+      ];
 
       // Robustly update lang attribute on <html> tag
       let result = html.replace(/<html([^>]*)>/i, (match, attrs) => {
-        const lang = escapeHtml(app.lang || 'en');
+        const escapedLang = escapeHtml(lang);
         const updatedAttrs = /lang="/i.test(attrs)
-          ? attrs.replace(/lang="[^"]*"/i, `lang="${lang}"`)
-          : `${attrs} lang="${lang}"`;
+          ? attrs.replace(/lang="[^"]*"/i, `lang="${escapedLang}"`)
+          : `${attrs} lang="${escapedLang}"`;
         return `<html${updatedAttrs}>`;
       });
 
       // Replace existing <title> tag
-      const documentTitle = escapeHtml(app.title || 'App');
+      const documentTitle = escapeHtml(title || 'App');
       if (/<title>.*<\/title>/i.test(result)) {
         result = result.replace(/<title>.*<\/title>/i, `<title>${documentTitle}</title>`);
       }
 
-      // Inject tags before </head> (replace only the first occurrence)
+      // Inject tags before </head>
       result = result.replace(/<\/head>/i, `${tags.join('\n')}\n  </head>`);
 
       return result;

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -32,6 +32,7 @@ import { useHead } from '@unhead/vue';
 import { useTheme } from 'vuetify';
 import { useAuthStore } from '../auth/stores/auth.store';
 import { setupInterceptors } from '../../lib/services/axios';
+import { buildSeoConfig } from '../../lib/helpers/seo.js';
 import waosHeader from '../core/components/core.header.component.vue';
 import waosNav from '../core/components/core.navigation.component.vue';
 import waosFooter from '../core/components/core.footer.component.vue';
@@ -68,49 +69,16 @@ export default {
     },
   },
   created() {
-    const { app } = this.config;
-    const seo = app.seo || {};
-    const og = seo.og || {};
-    const schema = seo.schema || {};
-
-    const meta = [
-      ...(app.description ? [{ name: 'description', content: app.description }] : []),
-      ...(app.keywords ? [{ name: 'keywords', content: app.keywords }] : []),
-      ...(app.author ? [{ name: 'author', content: app.author }] : []),
-      // Open Graph
-      { property: 'og:type', content: og.type || 'website' },
-      ...(app.title ? [{ property: 'og:title', content: app.title }] : []),
-      ...(app.description ? [{ property: 'og:description', content: app.description }] : []),
-      ...(app.url ? [{ property: 'og:url', content: app.url }] : []),
-      ...(og.image ? [{ property: 'og:image', content: og.image }] : []),
-      // Twitter Card
-      { name: 'twitter:card', content: og.twitterCard || 'summary' },
-      ...(app.title ? [{ name: 'twitter:title', content: app.title }] : []),
-      ...(app.description ? [{ name: 'twitter:description', content: app.description }] : []),
-      ...(og.twitterSite ? [{ name: 'twitter:site', content: og.twitterSite }] : []),
-      ...(og.image ? [{ name: 'twitter:image', content: og.image }] : []),
-    ];
-
-    const link = app.url ? [{ rel: 'canonical', href: app.url }] : [];
-
-    const script = schema.enabled && schema.name
-      ? [{
-          type: 'application/ld+json',
-          innerHTML: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': schema.type || 'Person',
-            name: schema.name,
-            url: app.url || undefined,
-            sameAs: schema.sameAs?.length ? schema.sameAs : undefined,
-          }),
-        }]
+    const seoData = buildSeoConfig(this.config);
+    const script = seoData.schema
+      ? [{ type: 'application/ld+json', innerHTML: JSON.stringify(seoData.schema) }]
       : [];
 
     useHead({
-      title: app.title,
-      htmlAttrs: { lang: app.lang || 'en' },
-      meta,
-      link,
+      title: seoData.title,
+      htmlAttrs: { lang: seoData.lang },
+      meta: seoData.meta,
+      link: seoData.link,
       script,
     });
 


### PR DESCRIPTION
## Summary

Resolves the code duplication Copilot comment from PR #3516.

- Extract shared SEO tag-building logic into `src/lib/helpers/seo.js` (`buildSeoConfig`)
- `seo-inject.js` (build-time) uses it to render HTML tag strings
- `app.vue` (runtime) uses it to feed `useHead()`
- Single source of truth for which tags are generated and under what conditions

## Changes

| File | Change |
|---|---|
| `src/lib/helpers/seo.js` | New shared helper |
| `src/lib/plugins/seo-inject.js` | Refactored to use `buildSeoConfig` |
| `src/modules/app/app.vue` | Refactored to use `buildSeoConfig` |

## Test plan

- [x] All 230 unit tests pass (`npm run test:unit`)
- [x] Existing `seo-inject.spec.js` and `app.vue.spec.js` cover the behaviour end-to-end