### PR TITLE
ci(dependabot): use native auto-merge and clean up config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,42 +7,8 @@ updates:
       time: '04:00'
     open-pull-requests-limit: 10
     ignore:
-      - dependency-name: core-js
-        versions:
-          - 3.10.2
-          - 3.11.1
-      - dependency-name: snyk
-        versions:
-          - 1.440.5
-          - 1.445.0
-          - 1.447.0
-          - 1.448.0
-          - 1.450.0
-          - 1.457.0
-          - 1.464.0
-          - 1.486.0
-          - 1.491.0
-          - 1.495.0
-          - 1.505.0
-          - 1.514.0
-          - 1.521.0
-          - 1.522.0
-          - 1.526.0
-          - 1.528.0
-          - 1.532.0
-          - 1.538.0
-          - 1.557.0
-          - 1.563.0
-          - 1.570.0
-      - dependency-name: vuetify
-        versions:
-          - 2.4.11
-      - dependency-name: '@vue/cli-plugin-e2e-cypress'
-        versions:
-          - 4.5.12
-      - dependency-name: '@vue/cli-plugin-vuex'
-        versions:
-          - 4.5.12
-      - dependency-name: '@commitlint/cli'
-        versions:
-          - 12.0.1
+      # eslint-plugin-vue requires eslint ^8 || ^9 — block major bumps until plugin catches up
+      - dependency-name: eslint
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,14 +4,23 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v4
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
         with:
-          target: minor
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `ahmadnassri/action-dependabot-auto-merge@v2` (third-party, less maintained) with the official `dependabot/fetch-metadata@v2` + `gh pr merge --auto`
- Auto-merge is now fully gated on CI passing (native GitHub auto-merge handles this)
- Only minor and patch updates get auto-merged — major version bumps require manual review
- Filter on `github.actor == 'dependabot[bot]'` so the workflow only runs on Dependabot PRs
- Remove `issues: write` permission (not needed)

## dependabot.yml config

- Remove obsolete version-specific ignore entries (snyk 1.x, vuetify 2.4.11, old cli-plugin-*…)
- Add `semver-major` ignore for `eslint` and `@eslint/js` — `eslint-plugin-vue` requires `^8 || ^9`, so v10+ bumps would break CI until the plugin catches up

## How auto-merge now works

1. Dependabot opens a PR
2. This workflow runs, checks the update type via `dependabot/fetch-metadata`
3. If minor or patch → `gh pr merge --auto --squash` is called
4. GitHub waits for all required CI checks to pass, then merges automatically
5. Major version bumps → workflow skips, PR stays open for manual review