### PR TITLE
ci(dependabot): align with Node stack auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,42 +7,8 @@ updates:
       time: '04:00'
     open-pull-requests-limit: 10
     ignore:
-      - dependency-name: core-js
-        versions:
-          - 3.10.2
-          - 3.11.1
-      - dependency-name: snyk
-        versions:
-          - 1.440.5
-          - 1.445.0
-          - 1.447.0
-          - 1.448.0
-          - 1.450.0
-          - 1.457.0
-          - 1.464.0
-          - 1.486.0
-          - 1.491.0
-          - 1.495.0
-          - 1.505.0
-          - 1.514.0
-          - 1.521.0
-          - 1.522.0
-          - 1.526.0
-          - 1.528.0
-          - 1.532.0
-          - 1.538.0
-          - 1.557.0
-          - 1.563.0
-          - 1.570.0
-      - dependency-name: vuetify
-        versions:
-          - 2.4.11
-      - dependency-name: '@vue/cli-plugin-e2e-cypress'
-        versions:
-          - 4.5.12
-      - dependency-name: '@vue/cli-plugin-vuex'
-        versions:
-          - 4.5.12
-      - dependency-name: '@commitlint/cli'
-        versions:
-          - 12.0.1
+      # eslint-plugin-vue requires eslint ^8 || ^9 — block major bumps until plugin catches up
+      - dependency-name: eslint
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,14 +4,28 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v4
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
-        with:
-          target: minor
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+      - name: Approve patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Aligns the Dependabot workflow and config with the [Node stack](https://github.com/pierreb-devkit/Node).

Supersedes #3529.

## Workflow changes (`dependabot.yml` workflow)

| | Before | After (= Node stack) |
|---|---|---|
| Action | `ahmadnassri/action-dependabot-auto-merge@v2` (third-party) | `dependabot/fetch-metadata@v2` (official) |
| Actor filter | None — runs on all PRs | `github.actor == 'dependabot[bot]'` |
| Approve step | ❌ | ✅ `gh pr review --approve` for patch/minor |
| Auto-merge step | via third-party action | `gh pr merge --auto --squash` for patch/minor |
| Permissions | `contents` + `pull-requests` + `issues` | `contents` + `pull-requests` only |

## Config changes (`.github/dependabot.yml`)

- Remove all obsolete version-specific ignore entries (snyk 1.x, vuetify 2.4.11, old vue-cli plugins…)
- Add `semver-major` ignore for `eslint` and `@eslint/js` — Vue-specific, `eslint-plugin-vue` requires `eslint ^8 || ^9` (fixes the failing PR #3522 pattern)

## How it works now

1. Dependabot opens a PR
2. Workflow fetches metadata to check update type
3. If **patch or minor** → approves the PR + enables auto-merge
4. GitHub waits for all CI checks to pass, then merges automatically
5. **Major** version bumps → workflow skips, PR stays open for manual review