### PR TITLE
ci: align CI with Node stack — single LTS, no matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,16 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [22.x, 24.x]
-
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
           cache: 'npm'
       - name: Run tests
         run: |
@@ -28,7 +24,6 @@ jobs:
           npm run lint
           npm run test:coverage
       - name: Upload coverage reports to Codecov
-        if: matrix.node-version == 'lts/*'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Aligns `CI.yml` with the [Node stack](https://github.com/pierreb-devkit/Node/blob/master/.github/workflows/CI.yml).

## Changes

| | Before | After (= Node stack) |
|---|---|---|
| Node versions | matrix `[22.x, 24.x]` | single `lts/*` |
| Step name | `Use Node.js ${{ matrix.node-version }}` | `Use Node.js LTS` |
| Codecov condition | `if: matrix.node-version == 'lts/*'` | none (always runs) |

## Only intentional difference with Node

`UV_USE_IO_URING=0 npm run build` — Vue-specific build step, not present in Node.