### PR TITLE
docs(readme): clarify AI tools require client install

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ docker-compose up
 
 ## :robot: AI Setup
 
-This stack ships with configurations for Claude Code, GitHub Copilot, and OpenAI Codex — all work immediately after cloning.
+This stack ships preconfigured instruction and prompt files for Claude Code, GitHub Copilot, and OpenAI Codex. Each tool requires its own client installation and authentication — the repository provides the configuration so it works out-of-the-box once the tool is set up.
 
 | Tool              | Config                                                              |
 | ----------------- | ------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Update AI Setup section intro to clarify each tool requires its own client install
- Aligns Vue README wording with Node stack

## Scope

- Modules impacted: none (docs only)
- Cross-module impact: none
- Risk level: `low`

## Validation

- [x] No code change — documentation only