### PR TITLE
chore(scripts): align npm scripts and docs with Node stack

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,16 +7,17 @@
 
 ## Canonical commands
 
-- Dev: `npm run dev`
+- Dev: `npm run dev` (alias: `npm start`)
 - Build: `npm run build`
 - Preview: `npm run preview`
-- Tests: `npm test` (watch) or `npm run test:unit`
+- Tests: `npm test` / `npm run test:watch` (watch) or `npm run test:unit` (one-shot)
 - Coverage: `npm run test:coverage`
 - Lint: `npm run lint`
 - Lint fix: `npm run lint:fix`
 - Format: `npm run format`
 - Generate config: `npm run generateConfig`
 - Commit: `npm run commit`
+- Release (CI): `npm run release:auto`
 
 ## Available prompts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,20 +12,24 @@ The `.claude/` folder contains embedded settings, skills, and agents that are av
 
 ## Canonical commands
 
-| Command       | Script                   | Description                                  |
-| ------------- | ------------------------ | -------------------------------------------- |
-| **Dev**       | `npm run dev`            | Start dev server at `http://localhost:8080/` |
-| **Build**     | `npm run build`          | Build for production                         |
-| **Preview**   | `npm run preview`        | Preview production build locally             |
-| **Test**      | `npm test`               | Run tests in watch mode                      |
-| **Unit test** | `npm run test:unit`      | Run unit tests                               |
-| **Coverage**  | `npm run test:coverage`  | Generate test coverage                       |
-| **Lint**      | `npm run lint`           | Check code quality                           |
-| **Lint fix**  | `npm run lint:fix`       | Auto-fix linting issues                      |
-| **Format**    | `npm run format`         | Format with Prettier                         |
-| **Config**    | `npm run generateConfig` | Generate config from env vars                |
-| **Commit**    | `npm run commit`         | Commit with commitizen                       |
-| **Docker**    | `docker-compose up`      | Start with docker-compose                    |
+| Command          | Script                   | Description                                  |
+| ---------------- | ------------------------ | -------------------------------------------- |
+| **Dev**          | `npm run dev`            | Start dev server at `http://localhost:8080/` |
+| **Dev (alias)**  | `npm start`              | Alias for `npm run dev`                      |
+| **Build**        | `npm run build`          | Build for production                         |
+| **Preview**      | `npm run preview`        | Preview production build locally             |
+| **Test**         | `npm test`               | Run tests in watch mode                      |
+| **Test watch**   | `npm run test:watch`     | Run tests in watch mode (explicit alias)     |
+| **Unit test**    | `npm run test:unit`      | Run unit tests once (one-shot)               |
+| **Coverage**     | `npm run test:coverage`  | Generate test coverage                       |
+| **Lint**         | `npm run lint`           | Check code quality                           |
+| **Lint fix**     | `npm run lint:fix`       | Auto-fix linting issues                      |
+| **Format**       | `npm run format`         | Format with Prettier                         |
+| **Config**       | `npm run generateConfig` | Generate config from env vars                |
+| **Migration**    | `npm run check:migration`| Check Vite migration compatibility           |
+| **Commit**       | `npm run commit`         | Commit with commitizen                       |
+| **Release (CI)** | `npm run release:auto`   | Semantic release for CI                      |
+| **Docker**       | `docker-compose up`      | Start with docker-compose                    |
 
 ## Preflight
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm install
 ### Development
 
 ```bash
-npm run dev
+npm run dev   # or: npm start
 ```
 
 Runs dev server with hot-reload at `http://localhost:8080/`
@@ -74,7 +74,8 @@ npm run preview    # Preview production build locally
 
 ```bash
 npm test                  # Run tests in watch mode
-npm run test:unit         # Run unit tests
+npm run test:watch        # Run tests in watch mode (explicit alias)
+npm run test:unit         # Run unit tests once (one-shot)
 npm run test:coverage     # Generate coverage report
 ```
 
@@ -92,7 +93,7 @@ npm run format            # Format code with Prettier
 
 ```bash
 npm run commit                                    # Commit with commitizen
-npm run release -- --first-release                # First release
+npm run release -- --first-release                # First release (standard-version)
 npm run release -- --release-as 1.1.1             # Release specific version
 GITHUB_TOKEN=xxx npm run release:auto             # Semantic release (CI)
 ```

--- a/package.json
+++ b/package.json
@@ -20,13 +20,16 @@
     "url": "https://github.com/weareopensource/Vue.git"
   },
   "scripts": {
+    "start": "npm run dev",
     "dev": "npm run generateConfig && npm run vite:dev",
     "build": "npm run generateConfig && npm run vite:build",
     "preview": "npm run generateConfig && npm run vite:preview",
     "vite:dev": "vite",
     "vite:build": "vite build",
     "vite:preview": "vite preview",
-    "test:unit": "vitest",
+    "test": "vitest",
+    "test:unit": "vitest run",
+    "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -35,8 +38,8 @@
     "generateConfig": "node ./scripts/generateConfig.js",
     "check:migration": "node ./scripts/check-vite-migration.js",
     "release": "npx semantic-release",
-    "snyk-protect": "snyk protect",
-    "test": "vitest"
+    "release:auto": "npx semantic-release",
+    "snyk-protect": "snyk protect"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.2.0",


### PR DESCRIPTION
## Summary

Aligns Vue stack npm scripts and documentation with the Node stack for cross-stack consistency.

## Script changes (`package.json`)

| Script | Before | After |
|--------|--------|-------|
| `start` | missing | `npm run dev` (alias) |
| `test:unit` | `vitest` (watch mode — bug) | `vitest run` (one-shot) |
| `test:watch` | missing | `vitest` (explicit alias) |
| `release:auto` | missing | `npx semantic-release` (was already documented in README but script didn't exist) |

## Documentation changes

- **CLAUDE.md**: added `start`, `test:watch`, `check:migration`, `release:auto` rows; clarified one-shot vs watch
- **README.md**: added `npm start` alias, `test:watch`, clarified `test:unit` as one-shot
- **copilot-instructions.md**: added `release:auto`, clarified watch vs one-shot test modes

## Scope

- Modules impacted: none (scripts/docs only)
- Cross-module impact: none
- Risk level: `low`

## Validation

- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (now correctly one-shot)
- [x] `npm run build` passes