### PR TITLE
fix(pull-request skill): reply and resolve all threads including non-actionable

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -121,14 +121,19 @@ After `gh pr ready`, enter an autonomous polling loop. Do not wait for the user 
 ### Loop procedure
 
 ```text
+consecutive_zero = 0
+
 REPEAT:
-  1. Wait for CI            → sleep 30 then gh pr checks <number> --watch
-  2. If CI fails            → fix, /verify, commit, push, GOTO 1
-  3. Grace period           → sleep 180 + adaptive check (see 6b)
-  4. Read all feedback      → unresolved threads only (see 6b)
-  5. If actionable comments → fix all, /verify, commit, push, reply, resolve, GOTO 1
-  6. If non-actionable unresolved threads → reply all explaining why, resolve all, GOTO 4
-  7. If zero unresolved threads → check branch protection (see 6f), then STOP ✓
+  1. Wait for CI                        → sleep 30 then gh pr checks <number> --watch
+  2. If CI fails                        → fix, /verify, commit, push, consecutive_zero=0, GOTO 1
+  3. Grace period                       → sleep 180 + adaptive check (see 6b)
+  4. Re-check pending review checks     → gh pr checks <number> — if any still pending, GOTO 3
+  5. Read all feedback                  → unresolved threads only (see 6b)
+  6. If actionable comments             → fix all, /verify, commit, push, reply, resolve, consecutive_zero=0, GOTO 1
+  7. If non-actionable unresolved       → reply all explaining why, resolve all, consecutive_zero=0, GOTO 5
+  8. If zero unresolved threads         → consecutive_zero++
+                                           if consecutive_zero >= 2 → check branch protection (see 6f), then STOP ✓
+                                           else GOTO 3
 ```
 
 ### 6a. Wait for CI
@@ -241,7 +246,7 @@ Loop back to step 6a. Do not attempt to trigger reviewers — reviews arrive on 
 
 ### 6f. Stop condition
 
-All CI checks pass **and** a complete polling pass (after the grace period) produces **zero unresolved actionable threads**.
+All CI checks pass **and** 2 consecutive polling passes (each after a full grace period) both produce **zero unresolved threads** — this double-pass ensures slow review bots have had time to post before the loop exits.
 
 Before declaring done, check branch protection:
 


### PR DESCRIPTION
## Summary

- What changed: Updated `.claude/skills/pull-request/SKILL.md` — loop step 6 now requires replying to and resolving all open threads (including non-actionable/informational ones); stop condition updated to zero open threads.
- Why: Non-actionable threads were being skipped, leaving unresolved threads on PRs after merging. The stop condition "zero actionable comments" allowed PRs to be marked done with open threads still present.
- Related issues: Closes #3572

## Scope

- Modules impacted: `.claude/skills/pull-request/SKILL.md` (skill definition only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [ ] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — skill file only, no application code changed.
- Mergeability considerations: clean skill-only diff, no conflicts expected with downstream merges.
- Follow-up tasks (optional): Mirror this fix to the Node stack's equivalent pull-request skill if one exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified PR monitoring flow to explicitly handle non-actionable unresolved review threads (reply + resolve) and state progression
  * Expanded guidance for informational items and false positives with examples and when a brief reply is expected
  * Updated CI wait/retry semantics and termination: requires two consecutive grace-period passes with zero unresolved threads before stopping, and re-checks pending checks/reset on fixes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->