### PR TITLE
fix(skill): escalate stack-level review comments to upstream repo

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -215,29 +215,37 @@ gh api repos/$OWNER/$REPO/issues/$PR/comments --paginate | jq 'map({id, user: .u
 
 When running on a **downstream project** (not the stack repo itself), classify each actionable comment before fixing:
 
-1. **Check if the comment targets a stack-level file** — a file that exists in the upstream stack repo (e.g. `src/modules/core/`, `src/lib/`, config files, skill files). Use the `devkit-vue` remote to verify:
+1. **Check if the comment targets a stack-level file** — a file that exists in the upstream stack repo. Ensure the remote is available, then check:
    ```bash
+   # Ensure the devkit-vue remote exists and is fetched (update-stack skill sets this up)
+   git remote get-url devkit-vue >/dev/null 2>&1 || git remote add devkit-vue git@github.com:<stack-owner>/<stack-repo>.git
+   git fetch devkit-vue master --quiet 2>/dev/null
+
+   # Check if the file exists in the upstream
    git ls-tree --name-only -r devkit-vue/master -- <file-path>
    ```
    If the file exists in the upstream, it is **stack-level**.
 
 2. **Stack-level comment** → do NOT fix locally. Instead:
-   - Create an issue on the stack repo with the review feedback:
+   - Create an issue on the stack repo with the review feedback (use a heredoc to avoid shell escaping issues):
      ```bash
-     gh issue create --repo <stack-owner>/<stack-repo> \
+     ISSUE_URL=$(gh issue create --repo <stack-owner>/<stack-repo> \
        --title "fix(<scope>): <summary from review comment>" \
-       --body "Reported by CodeRabbit on <downstream-owner>/<downstream-repo>#<PR>.
+       --body "$(cat <<'BODY'
+     Reported by CodeRabbit on <downstream-owner>/<downstream-repo>#<PR>.
 
      ## Review comment
      <full comment body>
 
      ## File
-     \`<file-path>\`" \
-       --label "Fix"
+     `<file-path>`
+     BODY
+     )" \
+       --label "Fix")
      ```
-   - Reply to the review thread explaining the comment has been escalated:
+   - Reply to the review thread with the created issue link:
      ```
-     This comment targets stack-level code from the upstream Devkit Vue repo. Created <stack-repo>#<issue-number> to track the fix upstream.
+     This comment targets stack-level code from the upstream Devkit Vue repo. Created $ISSUE_URL to track the fix upstream.
      ```
    - Resolve the thread
 


### PR DESCRIPTION
## Summary

- What changed: Added section 6b-bis to the pull-request skill that classifies review comments on downstream projects as stack-level or downstream-only
- Why: When running on downstream projects (e.g. Lou), CodeRabbit sometimes posts nitpick comments about patterns from the upstream stack. The skill was fixing them locally, causing downstream divergence.
- Related issues: Closes #3604

## Scope

- Modules impacted: `.claude/skills/pull-request`
- Cross-module impact: `none`
- Risk level: `low` — skill documentation change only, no code logic

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [ ] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: None
- Mergeability considerations: None — additive skill doc change
- Follow-up tasks (optional): Test on next downstream PR run