### PR TITLE
feat(update-stack): report upstream issues when verify fails on stack code

### DIFF
--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -61,11 +61,27 @@ If `/verify` failures originate from **stack module code** (`home`, `auth`, `use
 - **Stack code failure:** error occurs in unmodified stack module files (resolved with `--theirs`)
 - **Conflict resolution mistake:** error occurs in files you manually merged or in downstream-only modules
 
-**Issue format:**
-- Title: short description of the failure
-- Body: failing command output, affected file(s), and steps to reproduce
+**Create the issue:**
 
-This ensures upstream regressions are tracked and fixed at the source.
+```bash
+gh issue create \
+  --repo pierreb-devkit/Vue \
+  --title "fix(scope): <short description>" \
+  --body "$(cat <<'BODY'
+## Problem
+<failing command output>
+
+## Affected file(s)
+<list>
+
+## Steps to reproduce
+<steps>
+BODY
+)" \
+  --label "Fix"
+```
+
+Proceed to Phase 2 and track the upstream fix separately — do not block downstream alignment on it.
 
 ---
 


### PR DESCRIPTION
## Summary

- What changed: Added step 3bis to the update-stack skill that instructs Claude to open a GitHub issue on the upstream stack repo when `/verify` failures originate from stack module code
- Why: Upstream regressions introduced by stack merges were going untracked — this ensures they are reported at the source
- Related issues: Closes #3625

## Scope

- Modules impacted: none (skill config only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [ ] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: none — only touches `.claude/skills/update-stack/SKILL.md`
- Follow-up tasks: apply same change to Node stack (separate PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified verification guidance to better explain when failures are regressions versus originating in stack modules.
  * Added a new "Report stack issues" subsection with a step-by-step process for filing upstream issues and labeling them for tracking.
  * Expanded instructions on diagnosing failure origins and advising to continue Phase 2 while tracking upstream fixes separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->