### PR TITLE
fix(coverage): exclude bootstrapper files with 0% coverage

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -34,9 +34,16 @@ export default defineConfig({
         'src/lib/plugins/**/*.js',
         'src/modules/*/stores/**/*.js',
         'src/modules/app/app.store.js',
-        'src/modules/app/app.vue',
       ],
-      exclude: ['node_modules/', '**/tests/**', '**/*.config.{js,cjs,mjs,ts}', '**/dist/**'],
+      exclude: [
+        'node_modules/',
+        '**/tests/**',
+        '**/*.config.{js,cjs,mjs,ts}',
+        '**/dist/**',
+        'src/lib/plugins/index.js',
+        'src/lib/plugins/vuetify.js',
+        'src/lib/services/config.js',
+      ],
       thresholds: {
         statements: 85,
         branches: 75,


### PR DESCRIPTION
## Summary

- What changed: Exclude side-effect-only bootstrapper files (`lib/plugins/index.js`, `lib/plugins/vuetify.js`, `lib/services/config.js`) and `app.vue` from coverage collection
- Why: These files have 0% coverage because they contain no testable logic (plugin setup, style imports, config re-export). They drag down coverage thresholds and cause failures in downstream projects with fewer tested files.
- Related issues: Closes #3624

## Scope

- Modules impacted: none (config-only change)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [ ] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: downstream projects inherit improved thresholds automatically
- Coverage before: 96.64% statements — after: 98.81% statements (0% files removed from collection)