### PR TITLE
fix(lodash): use lodash-es imports for proper tree-shaking

### DIFF
--- a/src/lib/middlewares/model.js
+++ b/src/lib/middlewares/model.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 /**
  * @desc Function to clean object (pick from model, remove null values)

--- a/src/lib/plugins/lodash.js
+++ b/src/lib/plugins/lodash.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 /**
  * Plugin setup.

--- a/src/modules/core/tests/core.datatable.component.spec.js
+++ b/src/modules/core/tests/core.datatable.component.spec.js
@@ -4,7 +4,7 @@ import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
-import _ from 'lodash';
+import _ from 'lodash-es';
 import CoreDatatable from '../components/core.datatable.component.vue';
 
 vi.mock('../../users/components/user.avatar.component.vue', () => ({


### PR DESCRIPTION
## Summary

- What changed: Replace `import _ from 'lodash'` with `import _ from 'lodash-es'` in 3 files
- Why: Enable tree-shaking — the codebase depends on `lodash-es` but 3 files imported from `lodash` (CommonJS), pulling the entire bundle
- Related issues: Closes #3631

## Scope

- Modules impacted: `core` (test), `lib` (plugin, middleware)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: trivial import path change, no conflict risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal library dependencies for improved compatibility and optimization. No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->