### PR TITLE
fix(config): replace _.merge with deepMerge to fix array handling

### DIFF
--- a/scripts/generateConfig.js
+++ b/scripts/generateConfig.js
@@ -5,7 +5,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 
 /**
- * @desc Deep merge two objects, replacing arrays instead of merging by index.
+ * Deep merge two objects, replacing arrays instead of merging by index.
  * @param {Object} target - Base object
  * @param {Object} source - Override object
  * @returns {Object} Merged result (new object, inputs are not mutated)


### PR DESCRIPTION
## Summary

- What changed: Replaced `_.merge` from lodash with a custom `deepMerge` function in `scripts/generateConfig.js` that replaces arrays instead of merging them by index
- Why: `_.merge` merges arrays by index, causing downstream projects with shorter arrays to inherit extra items from defaults (e.g. 3 stats defined but 4th from defaults leaks through)
- Related issues: Closes #3628

## Scope

- Modules impacted: none (build script only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: same config merge semantics for non-array values; only arrays change behavior (replace instead of index-merge)
- Follow-up tasks: same fix needed on Node stack (pierreb-devkit/Node#3198)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal configuration merging mechanism to improve handling of module settings and environment-specific overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->