### PR TITLE
fix(seo-inject): add JSON-LD structured data injection

### DIFF
--- a/src/lib/plugins/seo-inject.js
+++ b/src/lib/plugins/seo-inject.js
@@ -129,7 +129,8 @@ export function seoInjectPlugin(config) {
           ...(schema.sameAs?.length && { sameAs: schema.sameAs }),
           ...(og.image && { image: og.image }),
         };
-        tags.push(`  <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`);
+        const safeJson = JSON.stringify(jsonLd).replace(/</g, '\\u003c');
+        tags.push(`  <script type="application/ld+json">${safeJson}</script>`);
       }
 
       // Robustly update lang attribute on <html> tag

--- a/src/lib/plugins/tests/seo-inject.spec.js
+++ b/src/lib/plugins/tests/seo-inject.spec.js
@@ -382,6 +382,30 @@ describe('seoInjectPlugin', () => {
       expect(jsonLd.sameAs).toBeUndefined();
       expect(jsonLd.image).toBeUndefined();
     });
+
+    it('escapes "</script>" in schema values to prevent tag injection', () => {
+      const config = {
+        app: {
+          title: 'App',
+          description: '</script><script>alert("xss")</script>',
+          url: 'https://example.com',
+          seo: {
+            schema: { enabled: true, type: 'Person', name: 'Test' },
+          },
+        },
+      };
+      const result = transform(config);
+      // The raw "</script>" must not appear inside the JSON-LD block
+      const scriptBlocks = result.match(/<script[^>]*>/g) || [];
+      const ldBlocks = scriptBlocks.filter((s) => s.includes('application/ld+json'));
+      expect(ldBlocks).toHaveLength(1);
+      // Extract everything between the JSON-LD opening tag and the next </script>
+      const ldMatch = result.match(/<script type="application\/ld\+json">(.*?)<\/script>/);
+      expect(ldMatch).not.toBeNull();
+      // The escaped JSON should parse correctly and contain the original value
+      const jsonLd = JSON.parse(ldMatch[1]);
+      expect(jsonLd.description).toBe('</script><script>alert("xss")</script>');
+    });
   });
 
   describe('handles missing config gracefully', () => {


### PR DESCRIPTION
## Summary

- What changed: Added JSON-LD structured data injection to the `seo-inject` Vite plugin
- Why: The config system supports `seo.schema` with `enabled`, `type`, `name`, `jobTitle`, `sameAs`, etc., but the plugin had no code to read these values or emit a `<script type="application/ld+json">` block
- Related issues: Closes #3664

## Scope

- Modules impacted: `src/lib/plugins/seo-inject.js`
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: JSON-LD values are intentionally NOT HTML-escaped since they live inside a JSON string within a `<script>` tag, not in HTML attributes. The values come from build-time config (not user input).
- Mergeability considerations: Minimal change — adds a new block after the Twitter Card section with no modifications to existing code.
- Follow-up tasks: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JSON-LD structured data injection to enhance SEO. When schema is enabled, relevant metadata including type, name, URL, and description are automatically injected into the page head.

* **Tests**
  * Added comprehensive test suite covering JSON-LD functionality, including validation of required fields and conditional inclusion of optional metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->