### PR TITLE
fix(config): add missing api section to config.test.js

### DIFF
--- a/src/config/defaults/config.test.js
+++ b/src/config/defaults/config.test.js
@@ -51,5 +51,17 @@ export default {
   },
   header: { display: false },
   footer: { links: [], variant: 'default' },
+  api: {
+    protocol: 'http',
+    host: 'localhost',
+    port: '3000',
+    base: 'api',
+    endPoints: {
+      home: 'home',
+      auth: 'auth',
+      users: 'users',
+      tasks: 'tasks',
+    },
+  },
   cookie: { prefix: 'devkit' },
 };


### PR DESCRIPTION
## Summary
- Add the missing `api` section (protocol, host, port, base, endPoints) to `src/config/defaults/config.test.js`, matching the structure in `config.development.js`
- Fixes downstream test failures: `TypeError: Cannot read properties of undefined (reading 'protocol')`

Closes #3676

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (same results as master; pre-existing failures unrelated to this change)
- [x] `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added API configuration to test environment with endpoint mappings for authentication, users, tasks, and home routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->