### PR TITLE
fix(seo): skip runtime JSON-LD when seo-inject handles schema

### DIFF
--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -70,7 +70,6 @@ export default {
     const { app } = this.config;
     const seo = app.seo || {};
     const og = seo.og || {};
-    const schema = seo.schema || {};
 
     const meta = [
       ...(app.description ? [{ name: 'description', content: app.description }] : []),
@@ -92,25 +91,15 @@ export default {
 
     const link = app.url ? [{ rel: 'canonical', href: app.url }] : [];
 
-    const script = schema.enabled && schema.name
-      ? [{
-          type: 'application/ld+json',
-          innerHTML: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': schema.type || 'Person',
-            name: schema.name,
-            url: app.url || undefined,
-            sameAs: schema.sameAs?.length ? schema.sameAs : undefined,
-          }),
-        }]
-      : [];
+    // JSON-LD structured data is handled at build time by seo-inject when
+    // schema.enabled is true, so the runtime useHead call must not inject a
+    // second block.  See #3677.
 
     useHead({
       title: app.title,
       htmlAttrs: { lang: app.lang || 'en' },
       meta,
       link,
-      script,
     });
 
     // Configure axios interceptors

--- a/src/modules/app/tests/app.vue.spec.js
+++ b/src/modules/app/tests/app.vue.spec.js
@@ -132,30 +132,11 @@ describe('App.vue — SEO (useHead)', () => {
   });
 
   describe('Schema.org JSON-LD', () => {
-    it('does not inject script when schema.enabled is false', () => {
-      mountApp(makeConfig());
-      const { script } = useHeadMock.mock.calls[0][0];
-      expect(script).toHaveLength(0);
-    });
-
-    it('injects JSON-LD script when schema.enabled is true', () => {
+    it('does not inject runtime JSON-LD (handled by seo-inject at build time)', () => {
       const config = makeConfig({ seo: { schema: { enabled: true, type: 'Person', name: 'Test App', sameAs: ['https://github.com/test-user'] } } });
       mountApp(config);
-      const { script } = useHeadMock.mock.calls[0][0];
-      expect(script).toHaveLength(1);
-      expect(script[0].type).toBe('application/ld+json');
-
-      const ld = JSON.parse(script[0].innerHTML);
-      expect(ld['@type']).toBe('Person');
-      expect(ld.name).toBe('Test App');
-      expect(ld.sameAs).toContain('https://github.com/test-user');
-    });
-
-    it('does not inject JSON-LD when schema.enabled is true but name is empty', () => {
-      const config = makeConfig({ seo: { schema: { enabled: true, type: 'Person', name: '', sameAs: [] } } });
-      mountApp(config);
-      const { script } = useHeadMock.mock.calls[0][0];
-      expect(script).toHaveLength(0);
+      const call = useHeadMock.mock.calls[0][0];
+      expect(call.script).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Remove runtime JSON-LD injection from `app.vue` `useHead()` call, which was duplicating the build-time `seo-inject` plugin output when `seo.schema.enabled` is true
- Remove the now-unused `schema` variable from the `created()` hook
- Update tests to verify `useHead` no longer receives a `script` property

Closes #3677

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run test:unit` passes (app.vue.spec.js — 11 tests green)
- [ ] `npm run build` passes
- [ ] With `seo.schema.enabled: true`, only one JSON-LD block appears in the built HTML (from seo-inject), not two

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modified JSON-LD schema injection to occur at build time instead of runtime.

* **Tests**
  * Updated test coverage to align with build-time schema injection approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->