### PR TITLE
docs(skills): add multi-entity naming rule and config-driven value guidance

### DIFF
--- a/.claude/skills/create-module/SKILL.md
+++ b/.claude/skills/create-module/SKILL.md
@@ -65,7 +65,7 @@ Business values (plans, roles, feature flags) should be driven by module config,
 
 Pattern:
 - Define in `src/modules/{module}/config/{module}.development.config.js` (and env-specific variants)
-- Import in stores/composables
+- Access via the centralized config service (`import config from '@/lib/services/config'`)
 
 ### 7. Verify & report
 

--- a/.claude/skills/naming/SKILL.md
+++ b/.claude/skills/naming/SKILL.md
@@ -24,7 +24,7 @@ Audit or apply the project's file and folder naming conventions.
 | --------- | ------------------------------- | ------------------------- |
 | Component | `{module}.{name}.component.vue` | `home.hero.component.vue` |
 | View      | `{module}.{name}.view.vue`      | `auth.signin.view.vue`    |
-| Store     | `{module}[.{name}].store.js`    | `tasks.store.js`          |
+| Store     | `{module}.store.js`             | `tasks.store.js`          |
 | Router    | `{module}.router.js`            | `users.router.js`         |
 | Unit Test | `{target}.unit.tests.js`        | `home.store.unit.tests.js`  |
 | E2E Test  | `{target}.e2e.tests.js`         | `auth.signup.e2e.tests.js`  |
@@ -35,15 +35,15 @@ Audit or apply the project's file and folder naming conventions.
 
 ### Multi-entity modules
 
-When a module contains multiple entities (e.g., `billing` with `subscription`), files are still prefixed by the **module name**, not the entity:
+When a module contains multiple entities (e.g., `billing` with `subscription`), components and views add an entity segment after the module prefix. Stores keep the simple `{module}.store.js` pattern (one store per module).
 
 | Correct | Wrong |
 | --- | --- |
-| `billing.subscription.store.js` | `subscription.store.js` |
 | `billing.pricingCard.component.vue` | `PricingCard.component.vue` |
 | `billing.plans.view.vue` | `plans.view.vue` |
+| `billing.store.js` | `subscription.store.js` |
 
-Pattern: `{module}.{entity}[.{name}].{type}.{ext}`
+Pattern (components/views): `{module}.{entity}[.{name}].{type}.{ext}`
 
 ### Case conventions in code
 


### PR DESCRIPTION
## Summary
- Add multi-entity module naming section to `/naming` skill (files prefixed by module name, not entity)
- Add config-driven values guidance to `/create-module` skill (business values in module config, not hardcoded)

## Test plan
- [ ] Verify naming skill renders correctly and examples use Vue conventions
- [ ] Verify create-module skill step numbering is correct after insertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced module creation guidance with best practices for using configuration files to manage business values (plans, roles, feature flags) instead of hardcoding them
  * Updated naming conventions for store files and multi-entity modules to provide greater naming flexibility and structure clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->