### PR TITLE
feat(billing): scaffold billing module with store, router, and views

### DIFF
--- a/src/config/defaults/development.config.js
+++ b/src/config/defaults/development.config.js
@@ -56,6 +56,7 @@ export default {
       auth: 'auth',
       account: 'account',
       tasks: 'tasks',
+      billing: 'billing',
     },
   },
   cookie: {

--- a/src/config/defaults/test.config.js
+++ b/src/config/defaults/test.config.js
@@ -61,6 +61,7 @@ export default {
       auth: 'auth',
       users: 'users',
       tasks: 'tasks',
+      billing: 'billing',
     },
   },
   cookie: { prefix: 'devkit' },

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -12,8 +12,9 @@ import organizations from '../organizations/router/organizations.router';
 import admin from '../admin/router/admin.router';
 import users from '../users/router/users.router';
 import tasks from '../tasks/router/tasks.router';
+import billing from '../billing/router/billing.router';
 
-const routes = [].concat(home, auth, organizations, admin, users, tasks);
+const routes = [].concat(home, auth, organizations, admin, users, tasks, billing);
 
 /**
  * Router configuration.
@@ -25,7 +26,7 @@ const getRouter = () => {
   });
   // Routes that don't require an organization
   const orgExemptPrefixes = ['/users', '/admin'];
-  const orgExemptExact = ['/signin', '/signup', '/forgot', '/reset', '/token', '/verify-email', '/organization-required', '/invite'];
+  const orgExemptExact = ['/signin', '/signup', '/forgot', '/reset', '/token', '/verify-email', '/organization-required', '/invite', '/pricing'];
 
   /**
    * Handle global navigation checks (title, auth, org requirement, CASL access).

--- a/src/modules/billing/config/billing.config.js
+++ b/src/modules/billing/config/billing.config.js
@@ -1,0 +1,50 @@
+/**
+ * Billing plans static marketing content.
+ */
+export const plans = [
+  {
+    id: 'free',
+    name: 'Free',
+    tagline: 'Pour d\u00e9couvrir',
+    highlighted: false,
+    cta: 'Get Started',
+    features: [
+      { text: '1 project', included: true },
+      { text: '3 team members', included: true },
+      { text: 'Community support', included: true },
+      { text: 'Advanced analytics', included: false },
+    ],
+  },
+  {
+    id: 'starter',
+    name: 'Starter',
+    tagline: 'Pour les \u00e9quipes',
+    highlighted: false,
+    cta: 'Get Started',
+    features: [
+      { text: '10 projects', included: true },
+      { text: '10 team members', included: true },
+      { text: 'Email support', included: true },
+      { text: 'Advanced analytics', included: false },
+    ],
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    tagline: 'Pour les pros',
+    highlighted: true,
+    badge: 'Most Popular',
+    cta: 'Get Started',
+    features: [
+      { text: 'Unlimited projects', included: true },
+      { text: 'Unlimited members', included: true },
+      { text: 'Priority support', included: true },
+      { text: 'Advanced analytics', included: true },
+    ],
+  },
+];
+
+/**
+ * Exports.
+ */
+export default plans;

--- a/src/modules/billing/router/billing.router.js
+++ b/src/modules/billing/router/billing.router.js
@@ -1,0 +1,33 @@
+/**
+ * Module dependencies.
+ */
+import pricing from '../views/Pricing.view.vue';
+import billing from '../views/Billing.view.vue';
+
+/**
+ * Router configuration.
+ */
+export default [
+  {
+    path: '/pricing',
+    name: 'Pricing',
+    component: pricing,
+    meta: {
+      display: false,
+      footer: true,
+    },
+  },
+  {
+    path: '/billing',
+    name: 'Billing',
+    component: billing,
+    meta: {
+      display: false,
+      requiresAuth: true,
+    },
+  },
+];
+
+/**
+ * Exports.
+ */

--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -1,0 +1,105 @@
+/**
+ * Module dependencies.
+ */
+import { defineStore } from 'pinia';
+import axios from '../../../lib/services/axios';
+import config from '../../../lib/services/config';
+
+/**
+ * @desc Build the base API URL from config.
+ * @returns {string} Base API URL
+ */
+const apiBase = () => `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
+
+/**
+ * Store definition.
+ */
+export const useBillingStore = defineStore('billing', {
+  state: () => ({
+    plans: [],
+    subscription: null,
+    loading: false,
+  }),
+
+  actions: {
+    /**
+     * @desc Fetch available billing plans (public).
+     * @returns {Promise<Array>} Resolved list of plans
+     */
+    async fetchPlans() {
+      this.loading = true;
+      try {
+        const api = apiBase();
+        const res = await axios.get(`${api}/${config.api.endPoints.billing}/plans`);
+        this.plans = res.data.data;
+        return this.plans;
+      } catch (err) {
+        console.log(err);
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /**
+     * @desc Fetch current subscription for the active organization.
+     * @returns {Promise<Object>} Resolved subscription object
+     */
+    async fetchSubscription() {
+      this.loading = true;
+      try {
+        const api = apiBase();
+        const res = await axios.get(`${api}/${config.api.endPoints.billing}/subscription`);
+        this.subscription = res.data.data;
+        return this.subscription;
+      } catch (err) {
+        console.log(err);
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /**
+     * @desc Create a Stripe Checkout session and redirect.
+     * @param {string} priceId - The Stripe price ID
+     * @returns {Promise<Object>} Resolved checkout data with URL
+     */
+    async createCheckout(priceId) {
+      this.loading = true;
+      try {
+        const api = apiBase();
+        const res = await axios.post(`${api}/${config.api.endPoints.billing}/checkout`, {
+          priceId,
+          successUrl: `${window.location.origin}/billing?success=true`,
+          cancelUrl: `${window.location.origin}/pricing`,
+        });
+        return res.data.data;
+      } catch (err) {
+        console.log(err);
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /**
+     * @desc Open Stripe Customer Portal and redirect.
+     * @returns {Promise<void>}
+     */
+    async openPortal() {
+      this.loading = true;
+      try {
+        const api = apiBase();
+        const res = await axios.post(`${api}/${config.api.endPoints.billing}/portal`);
+        window.location.href = res.data.data.url;
+      } catch (err) {
+        console.log(err);
+      } finally {
+        this.loading = false;
+      }
+    },
+  },
+});
+
+/**
+ * Exports.
+ */
+export default useBillingStore;

--- a/src/modules/billing/views/Billing.view.vue
+++ b/src/modules/billing/views/Billing.view.vue
@@ -1,0 +1,5 @@
+<template>
+  <v-container>
+    <h1>Billing</h1>
+  </v-container>
+</template>

--- a/src/modules/billing/views/Pricing.view.vue
+++ b/src/modules/billing/views/Pricing.view.vue
@@ -1,0 +1,5 @@
+<template>
+  <v-container>
+    <h1>Pricing</h1>
+  </v-container>
+</template>


### PR DESCRIPTION
## Summary
- Scaffold `src/modules/billing/` with store, router, views, and static config
- Store exposes `fetchPlans`, `fetchSubscription`, `createCheckout`, and `openPortal` actions targeting the Node billing API
- Router adds `/pricing` (public) and `/billing` (auth required) routes with placeholder views
- Static marketing config defines free/starter/pro plan tiers
- Registers `billing` endpoint in development and test config defaults
- Registers billing routes in `app.router.js` and adds `/pricing` to org-exempt list

## Test plan
- [x] ESLint passes on all new/modified files
- [x] All 601 unit tests pass
- [ ] Manual: visit `/pricing` — renders placeholder heading
- [ ] Manual: sign in, visit `/billing` — renders placeholder heading
- [ ] Manual: unauthenticated `/billing` redirects to `/signin`

Closes #3712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Pricing page showcasing available billing plans with features and comparison details
  * Added a Billing dashboard for subscription and account management
  * Integrated Stripe checkout for purchasing billing plans
  * Integrated Stripe customer portal for managing active subscriptions
  * Introduced three plan tiers: Free, Starter, and Pro with distinct features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->