### PR TITLE
docs(billing): add module README

### DIFF
--- a/src/modules/billing/README.md
+++ b/src/modules/billing/README.md
@@ -7,7 +7,7 @@ Stripe billing UI with quota display.
 ### `useQuota()`
 
 ```js
-import { useQuota } from '../composables/billing.useQuota.js';
+import { useQuota } from './composables/billing.useQuota.js';
 
 const { plan, usage, limits, canDo, usagePercent, refresh } = useQuota();
 
@@ -19,17 +19,17 @@ if (!canDo('documents', 'create')) {
 ### `useBilling()`
 
 ```js
-import { useBilling } from '../composables/billing.useBilling.js';
+import { useBilling } from './composables/billing.useBilling.js';
 
 const { currentPlan, isPlanActive, hasPlan } = useBilling();
 ```
 
 ## Components
 
-### `<BillingUsageBar>`
+### `<BillingUsageBarComponent>`
 
 ```vue
-<BillingUsageBar resource="documents" action="create" label="Documents" />
+<BillingUsageBarComponent resource="documents" action="create" label="Documents" />
 ```
 
 Auto-colored progress bar (green/orange/red). Shows "Unlimited" for uncapped plans.
@@ -41,11 +41,11 @@ Auto-colored progress bar (green/orange/red). Shows "Unlimited" for uncapped pla
 <BillingUpgradePrompt requiredPlan="starter" />
 
 <!-- With usage context -->
-<BillingUpgradePrompt requiredPlan="starter" resource="documents" action="create" label="documents" />
+<BillingUpgradePrompt requiredPlan="starter" resource="documents" action="create" label="Documents" />
 ```
 
-### `<BillingPlanBadge>`
+### `<BillingPlanBadgeComponent>`
 
 ```vue
-<BillingPlanBadge :plan="currentPlan" />
+<BillingPlanBadgeComponent :plan="currentPlan" />
 ```


### PR DESCRIPTION
## Summary
- Add billing module README with composables and components guide
- Covers: useQuota, useBilling composables; BillingUsageBar, BillingUpgradePrompt, BillingPlanBadge components

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (689 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Billing module documentation covering quota management, billing information retrieval, and UI components for billing status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->