### PR TITLE
feat(verify): add coverage enforcement to verify skill

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -24,9 +24,10 @@ description: Run quality loop (audit + lint + tests + build) to verify code qual
 
 2. **Lint** — `npm run lint`
 
-3. **Tests** — check if Node API is reachable (`curl -sf http://localhost:3000/api/home`):
-   - **Infra up** → `npm run test:all` (unit + E2E)
-   - **Infra down** → `npm run test:unit` (unit only) + warn: "E2E skipped — run `docker compose -f docker-compose.test.yml up -d` for full coverage"
+3. **Tests + coverage** — check if Node API is reachable (`curl -sf http://localhost:3000/api/home`):
+   - **Infra up** → `npm run test:coverage` (unit + coverage enforcement) then `npm run test:e2e` (Playwright E2E)
+   - **Infra down** → `npm run test:coverage` (unit + coverage) + warn: "E2E skipped — run `docker compose -f docker-compose.test.yml up -d` for full coverage"
+   - If coverage drops below thresholds (vitest.config.js) → fail. Add tests, never lower thresholds.
 
 4. **Build** — `npm run build`
 


### PR DESCRIPTION
## Summary

- `/verify` skill now runs `npm run test:coverage` instead of `npm run test:unit`/`npm run test:all`, enforcing coverage thresholds on every verify pass
- If coverage drops below vitest.config.js thresholds (per-file: statements 70%, branches 60%, functions 70%, lines 70%), verify fails
- Explicit instruction: add tests to meet thresholds, never lower them
- E2E tests (`npm run test:e2e`) still run separately when infra is up

## Test plan

- [ ] Run `/verify` on a branch with passing coverage — should succeed
- [ ] Drop coverage below thresholds — verify should fail at step 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test verification workflow with stricter code coverage enforcement and explicit threshold requirements
  * Separated unit test and end-to-end test execution phases with distinct commands and conditions
  * Coverage drops now block progression and must be resolved through expanded test coverage rather than threshold modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->