### PR TITLE
fix(datatable): increase per page select width to 100px

### DIFF
--- a/src/modules/core/components/core.datatable.component.vue
+++ b/src/modules/core/components/core.datatable.component.vue
@@ -112,7 +112,7 @@
         density="compact"
         variant="outlined"
         hide-details
-        style="max-width: 80px"
+        style="max-width: 100px"
         :class="config.vuetify.theme.rounded"
       ></v-select>
       <v-btn :disabled="options.page <= 1" variant="text" icon size="small" class="ml-2" @click="switchPage('-')">


### PR DESCRIPTION
## Summary
- Increase `v-select` max-width from 80px to 100px so larger values like "100" are not cropped

## Test plan
- [x] Visual check: per page select displays "100" without clipping

Closes #3778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted pagination dropdown width for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->