### PR TITLE
feat(pageHeader): add tabs slot as alternative to icon + title

### DIFF
--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row class="mx-4 my-1" align="center" :style="$slots.tabs ? 'min-height: 56px' : ''">
+  <v-row class="mx-4 my-1" align="center" :style="$slots.tabs ? { minHeight: '56px' } : null">
     <template v-if="$slots.tabs">
       <!-- Tabs mode: tabs replace icon + title -->
       <slot name="tabs"></slot>


### PR DESCRIPTION
## Summary
- Add `tabs` slot to `CorePageHeader` that replaces icon + title area with navigation tabs
- Tabs mode detected via `$slots.tabs` — backward compatible, no script changes
- `min-height: 56px` in tabs mode for consistent header height

## Test plan
- [x] Existing pages without `#tabs` slot render unchanged
- [x] Lint + unit tests pass
- [x] Build succeeds

Closes #3780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page header now automatically switches between a tabs-focused layout and the traditional avatar + title/subtitle layout.
  * Tabs layout enforces consistent vertical spacing for a cleaner appearance.
  * Existing action area and previous header behavior remain supported for backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->