### PR TITLE
docs: add PostHog analytics and Vite 8 migration guides

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -8,6 +8,8 @@ Breaking changes and upgrade notes for downstream projects.
 
 Vite 8 replaces Rollup with **Rolldown**. `manualChunks` as an object is no longer supported — must be a function.
 
+**Node.js requirement:** Rolldown requires Node.js `^20.19.0` or `>=22.12.0`. Upgrading to Vite 8 will fail on older Node versions (including CI/build images) until they are updated.
+
 **Action for downstream:** If your `vite.config.js` overrides `manualChunks`, convert the object to a function:
 
 ```js
@@ -47,13 +49,13 @@ All features are no-op when `key` is empty — safe to deploy without PostHog.
 
 | Feature | File | Notes |
 |---------|------|-------|
-| PostHog plugin | `lib/plugins/posthog.js` | Auto-init, conditional on config |
-| Analytics helpers | `lib/helpers/analytics.js` | `capture()`, `capturePageview()`, `isPosthogReady()` |
-| `usePostHog` composable | `modules/analytics/composables/` | Access PostHog instance |
-| `useFeatureFlag` composable | `modules/analytics/composables/` | Reactive feature flag ref |
-| Page view tracking | `modules/app/app.router.js` | `capturePageview()` in `router.afterEach` |
-| User identify | `auth.store.js` | `posthog.identify()` on signin, `posthog.reset()` on signout |
-| Org group | `organizations.store.js` | `posthog.group('company', ...)` on org switch |
+| PostHog plugin | `src/lib/plugins/posthog.js` | Auto-init, conditional on config |
+| Analytics helpers | `src/lib/helpers/analytics.js` | `capture()`, `capturePageview()`, `isPosthogReady()` |
+| `usePostHog` composable | `src/modules/analytics/composables/analytics.usePostHog.js` | Access PostHog instance |
+| `useFeatureFlag` composable | `src/modules/analytics/composables/analytics.useFeatureFlag.js` | Reactive feature flag ref |
+| Page view tracking | `src/modules/app/app.router.js` | `capturePageview()` in `router.afterEach` |
+| User identify | `src/modules/auth/stores/auth.store.js` | `posthog.identify()` on signin, `posthog.reset()` on signout |
+| Org group | `src/modules/organizations/stores/organizations.store.js` | `posthog.group('company', ...)` on org switch |
 
 ### Action for downstream
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -90,6 +90,11 @@ export default defineConfig(({ mode }) => {
       sourcemap: mode !== 'production',
       rollupOptions: {
         output: {
+          /**
+           * Assign chunk names for selected vendor modules.
+           * @param {string} id Bundler module identifier.
+           * @returns {string|undefined} Chunk name when matched; otherwise undefined.
+           */
           manualChunks(id) {
             if (id.includes('node_modules')) {
               if (['vue', 'vue-router', 'pinia'].some((pkg) => id.includes(`/${pkg}/`))) return 'vue-vendor';


### PR DESCRIPTION
## Summary

- Add PostHog Analytics migration section to MIGRATIONS.md documenting config, included features, and downstream action items
- Covers PostHog plugin, analytics helpers, composables, page view tracking, user identify, and org group analytics

## Test plan

- [ ] Verify MIGRATIONS.md renders correctly on GitHub
- [ ] Confirm section placement is between Vite 8 and Liquid Glass sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded build tooling to the latest major version.
  * Refactored build configuration with structural changes.

* **Documentation**
  * Added migration guides documenting infrastructure updates and analytics configuration with examples and integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->