### PR TITLE
fix(docker): make docker-compose.test.yml work for downstream projects

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,4 +9,4 @@ COPY . .
 
 EXPOSE 8080
 
-CMD ["npx", "vite", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["sh", "-c", "npm run generateConfig && npx vite --host 0.0.0.0 --port 8080"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,7 +20,7 @@ services:
     environment:
       NODE_ENV: test
       DEVKIT_NODE_db_uri: mongodb://mongo:27017/NodeTest
-      DEVKIT_NODE_cors_origin: '["http://localhost:8080","http://vue:8080"]'
+      DEVKIT_NODE_cors_origin: '["http://localhost:${VUE_PORT:-8080}","http://vue:8080"]'
       DEVKIT_NODE_cors_credentials: "true"
     depends_on:
       mongo:


### PR DESCRIPTION
## Summary
- Replace hardcoded `../Node` context with configurable `${NODE_CONTEXT:-../Node}` env var so downstream projects (lou_vue, comes_vue, etc.) can point to their own Node sibling
- Add `vue` service with new `Dockerfile.dev` running Vite dev server, making the compose fully self-contained (Mongo + Node + Vue) for Playwright E2E
- Add `VUE_PORT` env var (default 8080) for port flexibility

## Test plan
- [ ] Run `docker compose -f docker-compose.test.yml up --build` in devkit Vue — all three services start
- [ ] Run `NODE_CONTEXT=../lou_node docker compose -f docker-compose.test.yml up --build` in lou_vue — Node resolves correctly
- [ ] Verify Playwright E2E tests pass against the compose stack

Closes #3789