### PR TITLE
feat(ci): support configurable RUNNER variable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   lint-unit-build:
     name: Lint, Unit Tests & Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.event.pusher.name != 'web-flow')
     steps:
@@ -42,7 +42,7 @@ jobs:
 
   e2e:
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.event.pusher.name != 'web-flow')
     services:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release:
     name: Semantic Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Replace hardcoded `runs-on: ubuntu-latest` with `runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}` in all workflow files
- Affected: CI.yml (both jobs), release.yml, dependabot.yml
- Allows overriding the runner per-repo via GitHub Actions variables

## Test plan
- [ ] CI passes on this PR (proves the expression evaluates correctly with no variable set)
- [ ] Verify `vars.RUNNER` override works when configured in repo settings

Closes #3792