### PR TITLE
feat(ci): skip setup-node and playwright install on self-hosted runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        if: ${{ !vars.RUNNER }}
         with:
           node-version: lts/*
           cache: npm
@@ -67,6 +68,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
+        if: ${{ !vars.RUNNER }}
         with:
           node-version: lts/*
 
@@ -102,6 +104,7 @@ jobs:
         working-directory: Vue
         run: npm ci
       - name: Install Playwright browsers
+        if: ${{ !vars.RUNNER }}
         working-directory: Vue
         run: npx playwright install --with-deps chromium
       - name: Start Vue dev server


### PR DESCRIPTION
## Summary
- Add `if: ${{ !vars.RUNNER }}` to `setup-node` steps in both `lint-unit-build` and `e2e` jobs
- Add `if: ${{ !vars.RUNNER }}` to the "Install Playwright browsers" step in the `e2e` job
- When `vars.RUNNER` is set (self-hosted), these tools are pre-installed so the steps are skipped

Closes #3802

## Test plan
- [ ] CI passes on GitHub-hosted runner (vars.RUNNER unset) — all steps run normally
- [ ] CI passes on self-hosted runner (vars.RUNNER set) — setup-node and playwright install are skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to conditionally skip Node.js setup and browser installation steps based on runner configuration, optimizing workflow execution time in certain environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->