### PR TITLE
fix(ci): remove ARC-specific conditionals from CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        if: ${{ !vars.RUNNER }}
         with:
           node-version: lts/*
           cache: npm
@@ -68,7 +67,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
-        if: ${{ !vars.RUNNER }}
         with:
           node-version: lts/*
 
@@ -104,7 +102,6 @@ jobs:
         working-directory: Vue
         run: npm ci
       - name: Install Playwright browsers
-        if: ${{ !vars.RUNNER }}
         working-directory: Vue
         run: npx playwright install --with-deps chromium
       - name: Start Vue dev server


### PR DESCRIPTION
## Summary
- Remove three `if: ${{ !vars.RUNNER }}` conditionals that skipped `setup-node` and Playwright install on ARC self-hosted runners
- These conditions are no longer needed — all steps now run unconditionally

Closes #3805

## Test plan
- [ ] CI pipeline passes on GitHub Actions (lint, unit, build, e2e all green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to ensure Node setup and Playwright browser installation always execute in the e2e job, removing conditional guards for more consistent build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->