### PR TITLE
chore(ci): add timeout-minutes to dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 5` to the dependabot auto-merge job, matching the Node devkit

## Test plan
- [ ] CI passes on this PR
- [ ] Next dependabot PR triggers the workflow with the timeout set

Closes #3807