### PR TITLE
fix(docker): node-api port mismatch in docker-compose.test.yml

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,6 +19,7 @@ services:
       - "3000:3001"
     environment:
       NODE_ENV: test
+      DEVKIT_NODE_api_port: "3001"
       DEVKIT_NODE_db_uri: mongodb://mongo:27017/NodeTest
       DEVKIT_NODE_cors_origin: '["http://localhost:${VUE_PORT:-8080}","http://vue:8080"]'
       DEVKIT_NODE_cors_credentials: "true"


### PR DESCRIPTION
## Summary

Adds `DEVKIT_NODE_api_port: "3001"` to the `node-api` service environment in `docker-compose.test.yml` so Node actually listens on port 3001 inside the container.

## Why

The container port mapping is `3000:3001` and the healthcheck hits `localhost:3001`, but Node's test config defaults to port 3000. Without the explicit env var, Node never binds to 3001 and the healthcheck always fails, making E2E tests unreliable.

## Scope

- `docker-compose.test.yml`: one line added (`DEVKIT_NODE_api_port: "3001"`)

## Validation

- [x] Lint passes
- [x] Unit tests + coverage pass
- [x] Build passes
- [x] E2E skipped (infra not running locally)

Closes #3809