### PR TITLE
docs(feature): add ERRORS.md step to self-review checklist

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -102,6 +102,9 @@ Follow layered approach: **UI → Store → API**. Each layer references only th
 - [ ] Tests added
 - [ ] Tests: unit tests (`*.unit.tests.js`) for all changes. E2E (`*.e2e.tests.js`) only if the change affects a critical user flow (auth, org onboarding, invite/join).
 
+**Error documentation:**
+- [ ] If a non-obvious bug was fixed, document it in `ERRORS.md` (root of repo) with: symptom, root cause, fix
+
 ### 7b. Elegance check
 
 For non-trivial changes: pause and ask yourself "is there a simpler or more elegant approach?" If the current implementation feels hacky, refactor before proceeding.


### PR DESCRIPTION
## Summary
- Adds an **Error documentation** checklist item to the `/feature` skill's self-review phase
- Non-obvious bug fixes should be documented in `ERRORS.md` (symptom, root cause, fix) so future sessions avoid repeat debugging

Closes #3813

## Test plan
- [ ] Verify the skill file renders correctly in `.claude/skills/feature/SKILL.md`
- [ ] Confirm no other files were changed