### PR TITLE
fix(config): generateConfig ignores module env-specific configs

### DIFF
--- a/scripts/generateConfig.js
+++ b/scripts/generateConfig.js
@@ -124,7 +124,7 @@ const getConfiguration = async () => {
 
     const STANDARD_ENVS = new Set(['development', 'production', 'test']);
     const hasEnvVarOverrides = Object.keys(process.env).some((key) => key.startsWith('DEVKIT_VUE_'));
-    const hasModuleOverrides = discoverModuleConfigs(env).length > 0;
+    const hasModuleOverrides = Object.keys(moduleEnv).length > 0;
     if (!STANDARD_ENVS.has(env) && !globalEnv && !hasEnvVarOverrides && !hasModuleOverrides) {
       console.warn(`+ Warning: NODE_ENV="${env}" but no ${env}.config.js found in src/config/defaults/ — using development defaults. Downstream projects should create config files (see README).`);
     }


### PR DESCRIPTION
## Summary

`discoverModuleConfigs()` hardcoded `.development.config.js` suffix, so module-level environment overrides (e.g. `home.trawl.config.js`, `auth.trawl.config.js`) were never loaded by `generateConfig.js`.

## Changes

- `discoverModuleConfigs(env)` now accepts an `env` parameter (defaults to `'development'`) and matches `*.{env}.config.js`
- `loadModuleConfigs(env)` passes `env` through to discovery
- Step 3 in `getConfiguration()` loads module env configs before global env overrides when `NODE_ENV !== 'development'`
- Warning check updated to suppress false warnings when module-level overrides exist

## Why

Downstream projects with custom `NODE_ENV` (e.g. `trawl`, `comes`) got default DevKit content for any module-level config override. Discovered on trawl_vue where `home.trawl.config.js` (new landing page) was invisible in production.

Closes #3826

## Validation

- [x] Lint passes
- [x] Tests + coverage pass
- [x] Build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration loader now supports environment-specific override discovery and composition, automatically applying module and global overrides for the active environment.

* **Bug Fixes**
  * Suppresses misleading “no environment config” warnings when valid environment-specific module overrides are present, reducing false alerts during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->