### PR TITLE
feat(home): make timeline opposite-side labels optional

### DIFF
--- a/src/modules/home/components/home.steps.component.vue
+++ b/src/modules/home/components/home.steps.component.vue
@@ -8,6 +8,7 @@
 
   CONFIG EXAMPLE (setup object):
   install: {
+    showStepLabel: true,             // Show opposite-side labels (default: false)
     style: {
       section: { background: 'surface' },
       card: { background: 'background' },
@@ -17,7 +18,7 @@
         icon: 'fa-solid fa-download',
         color: '#1abc9c',            // Dot color
         iconColor: 'white',          // Icon color (default: white)
-        title: 'Step 1',             // Opposite side title
+        title: 'Step 1',             // Opposite side title (visible when showStepLabel is true)
         subtitle: 'Installation',
         text: 'Description with **markdown** support.',
         img: '/images/step1.webp',   // Optional image
@@ -43,7 +44,7 @@
             fill-dot
             size="x-large"
           >
-            <template v-if="item.title" #opposite>
+            <template v-if="setup.showStepLabel && item.title" #opposite>
               <h3 class="text-headline-small text-md-headline-medium text-secondary font-weight-bold" v-text="item.title"></h3>
             </template>
             <v-card :class="`${config.vuetify.theme.rounded} my-8 pb-2`" :flat="config.vuetify.theme.flat" :style="cardStyle">


### PR DESCRIPTION
## Summary
- Add `showStepLabel` option to the steps/timeline component setup object (default: `false`)
- The `#opposite` template slot (showing step titles on the opposite side of the timeline) is now conditionally rendered only when `setup.showStepLabel` is `true`
- This is a non-breaking change: existing configs without `showStepLabel` will simply hide the opposite-side labels

Closes #3836

## Test plan
- [ ] Verify timeline renders without opposite-side labels when `showStepLabel` is absent or `false`
- [ ] Verify timeline renders opposite-side labels when `showStepLabel: true` is set
- [ ] Verify no regressions on mobile (compact density)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control the visibility of step labels in the steps component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->