### PR TITLE
feat(home): add imgMode prop to features cards for SVG illustrations

### DIFF
--- a/src/modules/home/components/home.features.component.vue
+++ b/src/modules/home/components/home.features.component.vue
@@ -19,6 +19,7 @@
       {
         subtitle: 'Product Name',
         img: '/images/card01.webp',
+        imgMode: 'cover',      // 'cover' (default) or 'contain' for SVG illustrations
         text: 'Description with **markdown** support.',
         reversed: false,       // Image position (false = top, true = bottom)
         fullWidth: false,      // Full width card
@@ -60,14 +61,14 @@
               <v-row align="center" justify="center" class="pa-0">
                 <v-col v-for="(item, i) in content" :key="i" cols="12" :md="item.fullWidth ? 12 : setup.content.length > 1 ? 6 : 12">
                   <v-card :class="`${config.vuetify.theme.rounded}`" :flat="config.vuetify.theme.flat" :style="style('card', { style: item.style })">
-                    <homeImgComponent v-if="item.img && !item.reversed" :img="item.img"></homeImgComponent>
+                    <homeImgComponent v-if="item.img && !item.reversed" :img="item.img" :img-mode="item.imgMode"></homeImgComponent>
                     <homeContentComponent
                       :setup="item"
                       :alignment="item.alignment || 'center'"
                       :color="item.color || 'default'"
                       variant="card"
                     ></homeContentComponent>
-                    <homeImgComponent v-if="item.img && item.reversed" :img="item.img"></homeImgComponent>
+                    <homeImgComponent v-if="item.img && item.reversed" :img="item.img" :img-mode="item.imgMode"></homeImgComponent>
                   </v-card>
                 </v-col>
               </v-row>

--- a/src/modules/home/components/utils/home.img.component.vue
+++ b/src/modules/home/components/utils/home.img.component.vue
@@ -19,6 +19,7 @@
   - title (String): Title text displayed on image
   - text (String): Description text displayed on image
   - alt (String): Alt text for accessibility (falls back to title, then empty string for decorative images)
+  - imgMode (String): Image fit mode — 'cover' (default) or 'contain' for SVG illustrations
 
   NOTES:
   - Uses lazy-src for placeholder during loading
@@ -32,7 +33,8 @@
     :class="`${config.vuetify.theme.rounded}`"
     :height="height || ($vuetify.display.xsAndDown ? '225px' : $vuetify.display.smAndDown ? '300px' : '350px')"
     :gradient="gradient"
-    cover
+    :cover="imgMode !== 'contain'"
+    :style="imgMode === 'contain' ? 'object-fit: contain' : ''"
     :alt="alt || title || ''"
   >
     <template #placeholder>
@@ -78,6 +80,15 @@ export default {
     alt: {
       type: String,
       default: '',
+    },
+    /**
+     * Image fit mode: 'cover' (default) fills the area, 'contain' fits the
+     * entire image inside (useful for SVG illustrations).
+     * @type {string}
+     */
+    imgMode: {
+      type: String,
+      default: 'cover',
     },
   },
 };


### PR DESCRIPTION
## Summary
- Add `imgMode` prop to `homeImgComponent` supporting `'cover'` (default) and `'contain'` modes
- Pass `imgMode` from features card config through to the img component
- When `imgMode` is `'contain'`, disables `cover` and applies `object-fit: contain` so SVG illustrations display without cropping

## Test plan
- [x] ESLint passes (0 errors)
- [x] All 744 unit tests pass
- [ ] Verify visually with a card config using `imgMode: 'contain'` and an SVG image

Closes #3839