### PR TITLE
feat(home): add configurable cols to services component

### DIFF
--- a/src/modules/home/components/home.services.component.vue
+++ b/src/modules/home/components/home.services.component.vue
@@ -9,6 +9,7 @@
   CONFIG EXAMPLE (setup object):
   ressources: {
     title: 'Resources',
+    cols: 3, // optional — 2, 3, 4, or 6 (must divide 12 evenly)
     style: {
       section: { background: 'background' },
       card: { background: 'surface' },
@@ -36,7 +37,7 @@
         <v-col cols="12">
           <homeContentComponent :setup="setup"></homeContentComponent>
         </v-col>
-        <v-col v-for="(item, i) in setup.content" :key="i" cols="12" sm="12" md="4" data-aos="fade">
+        <v-col v-for="(item, i) in setup.content" :key="i" cols="12" sm="12" :md="colSize" data-aos="fade">
           <v-card :class="`py-6 px-2 ${config.vuetify.theme.rounded}`" :flat="config.vuetify.theme.flat" :style="cardStyle">
             <v-btn icon :color="item.color ? item.color : 'primary'" width="50" height="50" class="text-white ml-3 mb-4">
               <v-icon :icon="item.serviceIcon" size="x-medium"></v-icon>
@@ -77,6 +78,10 @@ export default {
     };
   },
   computed: {
+    colSize() {
+      const cols = [2, 3, 4, 6].includes(this.setup.cols) ? this.setup.cols : 3;
+      return 12 / cols;
+    },
     variant() {
       return this.setup.variant || 'default';
     },


### PR DESCRIPTION
## Summary
- Add `setup.cols` option to `HomeServicesComponent` (valid values: 2, 3, 4, 6) to control grid columns
- Defaults to 3 columns (current behavior) when not specified or invalid
- Updates component doc comment with the new config option

## Test plan
- [ ] Verify default behavior unchanged (3 columns on md+ screens)
- [ ] Test `cols: 2` renders 2 columns (md=6)
- [ ] Test `cols: 4` renders 4 columns (md=3)
- [ ] Test `cols: 6` renders 6 columns (md=2)
- [ ] Test invalid value (e.g. `cols: 5`) falls back to 3 columns
- [ ] Verify mobile still renders full width

Closes #3853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable grid column sizing for services display. The layout now supports flexible column counts (2, 3, 4, or 6) per row on medium screens, with a default of 3 columns, allowing better control over card presentation density.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->