### PR TITLE
fix(home): render SVGs inline to access CSS custom properties

### DIFF
--- a/src/modules/home/components/utils/home.img.component.vue
+++ b/src/modules/home/components/utils/home.img.component.vue
@@ -15,8 +15,8 @@
 
   PROPS:
   - img (String, required): Image source URL
-  - height (String): Custom height (default: responsive 225-350px)
-  - gradient (String): CSS gradient overlay
+  - height (String|Number): Custom height (default: responsive 225-350px); numbers get 'px' appended
+  - gradient (String): CSS gradient overlay (applied in both SVG and raster paths)
   - title (String): Title text displayed on image
   - text (String): Description text displayed on image
   - alt (String): Alt text for accessibility (falls back to title, then empty string for decorative images)
@@ -26,28 +26,40 @@
   - Uses lazy-src for placeholder during loading
   - Displays loading spinner while image loads
   - Applies theme rounded corners automatically
-  - SVG sources are fetched and rendered inline via v-html to inherit page CSS variables
+  - Only relative/local SVG URLs are inlined; absolute URLs use standard <v-img>
+  - SVG content is sanitized (scripts, event handlers, foreignObject removed) before rendering
 -->
 <template>
   <!-- Inline SVG: rendered via v-html so it can access CSS custom properties -->
   <div
     v-if="isSvg"
     :class="['home-img-svg', config.vuetify.theme.rounded]"
-    :style="{ height: computedHeight }"
+    :style="{ height: cssHeight }"
     :aria-label="alt || title || undefined"
+    :aria-hidden="alt || title ? undefined : 'true'"
     role="img"
   >
-    <!-- eslint-disable-next-line vue/no-v-html -- trusted SVG fetched from our own origin -->
-    <div v-if="svgContent" class="home-img-svg__content" v-html="svgContent"></div>
+    <!-- eslint-disable-next-line vue/no-v-html -- sanitized SVG from a relative/local source only -->
+    <div v-if="svgContent" class="home-img-svg__content" v-html="sanitizedSvg"></div>
+    <div v-else-if="svgError" class="d-flex align-center justify-center fill-height">
+      <v-icon color="grey-lighten-2" size="48">mdi-image-off-outline</v-icon>
+    </div>
     <div v-else class="d-flex align-center justify-center fill-height">
       <v-progress-circular color="grey-lighten-4" indeterminate></v-progress-circular>
     </div>
-    <v-card-title v-if="title" class="px-10 text-white text-headline-small font-weight-bold home-img-svg__overlay">
-      {{ title }}
-    </v-card-title>
-    <v-card-text v-if="text" class="px-10 text-white text-body-large pb-5 home-img-svg__overlay">
-      {{ text }}
-    </v-card-text>
+    <div
+      v-if="gradient"
+      class="home-img-svg__gradient"
+      :style="{ backgroundImage: `linear-gradient(${gradient})` }"
+    ></div>
+    <div v-if="title || text" class="home-img-svg__overlay d-flex flex-column justify-space-between fill-height">
+      <v-card-title v-if="title" class="px-10 text-white text-headline-small font-weight-bold">
+        {{ title }}
+      </v-card-title>
+      <v-card-text v-if="text" class="px-10 text-white text-body-large pb-5">
+        {{ text }}
+      </v-card-text>
+    </div>
   </div>
 
   <!-- Raster / non-SVG: standard v-img with lazy loading -->
@@ -56,7 +68,7 @@
     :src="img"
     lazy-src="/images/lazy.webp"
     :class="`${config.vuetify.theme.rounded}`"
-    :height="computedHeight"
+    :height="cssHeight"
     :gradient="gradient"
     :cover="imgMode !== 'contain'"
     :style="imgMode === 'contain' ? 'object-fit: contain' : ''"
@@ -77,6 +89,25 @@
  * @type {Map<string, string>}
  */
 const svgCache = new Map();
+
+/**
+ * Regex to detect relative/local URLs (starts with / but not //, or ./ or ../).
+ * @type {RegExp}
+ */
+const LOCAL_URL_RE = /^(?:\/(?!\/)|\.{1,2}\/)/;
+
+/**
+ * Sanitize raw SVG markup by removing dangerous elements and attributes.
+ * @param {string} raw - Raw SVG markup string.
+ * @returns {string} Sanitized SVG markup safe for v-html rendering.
+ */
+function sanitizeSvg(raw) {
+  return raw
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+    .replace(/<foreignObject[\s\S]*?>[\s\S]*?<\/foreignObject>/gi, '')
+    .replace(/\son[a-z]+\s*=\s*(?:'[^']*'|"[^"]*"|[^\s>]+)/gi, '')
+    .replace(/\s(?:href|xlink:href)\s*=\s*(['"])javascript:[\s\S]*?\1/gi, '');
+}
 
 /**
  * Component definition.
@@ -101,7 +132,7 @@ export default {
       default: '',
     },
     height: {
-      type: String,
+      type: [String, Number],
       default: '',
     },
     /**
@@ -125,19 +156,42 @@ export default {
   data() {
     return {
       svgContent: '',
+      svgError: false,
     };
   },
   computed: {
-    /** Whether the image source is an SVG file. */
+    /**
+     * Whether the image source is an SVG file that should be inlined.
+     * Only relative/local URLs are inlined; absolute URLs fall back to v-img.
+     * @returns {boolean} True when the source is a local SVG.
+     */
     isSvg() {
-      return this.img && this.img.toLowerCase().endsWith('.svg');
+      return this.img && this.img.toLowerCase().endsWith('.svg') && LOCAL_URL_RE.test(this.img);
     },
-    /** Responsive height matching original v-img behaviour. */
+    /**
+     * Responsive height matching original v-img behaviour.
+     * @returns {string|number} Height value (may be a number from props).
+     */
     computedHeight() {
       if (this.height) return this.height;
       if (this.$vuetify.display.xsAndDown) return '225px';
       if (this.$vuetify.display.smAndDown) return '300px';
       return '350px';
+    },
+    /**
+     * Normalize height to a valid CSS value (append 'px' to bare numbers).
+     * @returns {string} CSS-ready height string.
+     */
+    cssHeight() {
+      const h = this.computedHeight;
+      return typeof h === 'number' ? `${h}px` : h;
+    },
+    /**
+     * Sanitized SVG markup safe for v-html rendering.
+     * @returns {string} Cleaned SVG content.
+     */
+    sanitizedSvg() {
+      return this.svgContent ? sanitizeSvg(this.svgContent) : '';
     },
   },
   watch: {
@@ -150,10 +204,16 @@ export default {
     /**
      * Fetch the SVG source and store its markup for inline rendering.
      * Results are cached so repeated mounts/navigations don't re-fetch.
+     * Clears previous content before fetching to avoid stale renders.
+     * @returns {Promise<void>} Resolves when SVG loading and caching handling is complete.
      */
     async fetchSvg() {
       if (!this.isSvg) return;
       const src = this.img;
+
+      // Clear previous content to avoid showing stale SVG during fetch.
+      this.svgContent = '';
+      this.svgError = false;
 
       if (svgCache.has(src)) {
         this.svgContent = svgCache.get(src);
@@ -162,15 +222,22 @@ export default {
 
       try {
         const res = await fetch(src);
-        if (!res.ok) return;
+        if (!res.ok) {
+          if (this.img === src) this.svgError = true;
+          return;
+        }
         const text = await res.text();
         // Basic sanity check: only accept actual SVG markup.
-        if (!text.includes('<svg')) return;
+        if (!text.includes('<svg')) {
+          if (this.img === src) this.svgError = true;
+          return;
+        }
         svgCache.set(src, text);
         // Guard against race condition if img changed while fetching.
         if (this.img === src) this.svgContent = text;
       } catch {
-        // Silently fall back — the container stays empty / shows spinner.
+        // Show error state instead of infinite spinner.
+        if (this.img === src) this.svgError = true;
       }
     },
   },
@@ -201,9 +268,17 @@ export default {
   max-height: 100%;
 }
 
+.home-img-svg__gradient {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
 .home-img-svg__overlay {
   position: absolute;
-  left: 0;
-  right: 0;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
 }
 </style>

--- a/src/modules/home/tests/home.img.component.unit.tests.js
+++ b/src/modules/home/tests/home.img.component.unit.tests.js
@@ -1,0 +1,285 @@
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest';
+import HomeImgComponent from '../components/utils/home.img.component.vue';
+
+const mockConfig = {
+  vuetify: { theme: { rounded: 'rounded-xl', maxWidth: '1200px', flat: false } },
+};
+
+/**
+ * Build global options with Vuetify + config global property.
+ * @param {object} vuetify - Vuetify instance.
+ * @returns {object} Vue test-utils global config.
+ */
+const globalOpts = (vuetify) => ({
+  plugins: [vuetify],
+  config: {
+    globalProperties: { config: mockConfig },
+  },
+});
+
+/**
+ * Counter to generate unique SVG URLs per test (avoids module-level cache collisions).
+ * @type {number}
+ */
+let urlCounter = 0;
+
+/**
+ * Generate a unique local SVG URL for test isolation.
+ * @returns {string} Unique relative SVG path.
+ */
+function uniqueSvgUrl() {
+  urlCounter += 1;
+  return `/images/test-${urlCounter}.svg`;
+}
+
+describe('HomeImgComponent', () => {
+  let vuetify;
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives });
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders v-img for non-SVG sources', () => {
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: '/images/photo.webp' },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.findComponent({ name: 'VImg' }).exists()).toBe(true);
+    expect(wrapper.find('.home-img-svg').exists()).toBe(false);
+  });
+
+  it('renders inline SVG container for local .svg sources', () => {
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: uniqueSvgUrl() },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.find('.home-img-svg').exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'VImg' }).exists()).toBe(false);
+  });
+
+  it('falls back to v-img for absolute SVG URLs', () => {
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: 'https://example.com/icon.svg' },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.findComponent({ name: 'VImg' }).exists()).toBe(true);
+    expect(wrapper.find('.home-img-svg').exists()).toBe(false);
+  });
+
+  it('fetches and renders SVG content inline', async () => {
+    const url = uniqueSvgUrl();
+    const svgMarkup = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>';
+    fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(svgMarkup) });
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.find('.home-img-svg__content').exists()).toBe(true);
+    });
+    expect(wrapper.find('.home-img-svg__content').html()).toContain('<circle');
+  });
+
+  it('shows loading state while SVG is being fetched', async () => {
+    const url = uniqueSvgUrl();
+    // fetch never resolves — spinner branch should be active.
+    fetch.mockReturnValueOnce(new Promise(() => {}));
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url },
+      global: globalOpts(vuetify),
+    });
+    await wrapper.vm.$nextTick();
+
+    // No svgContent and no svgError → loading branch renders.
+    expect(wrapper.find('.home-img-svg').exists()).toBe(true);
+    expect(wrapper.find('.home-img-svg__content').exists()).toBe(false);
+    expect(wrapper.vm.svgError).toBe(false);
+    expect(wrapper.vm.svgContent).toBe('');
+  });
+
+  it('sets svgError when fetch fails', async () => {
+    const url = uniqueSvgUrl();
+    fetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.vm.svgError).toBe(true);
+    });
+    expect(wrapper.vm.svgContent).toBe('');
+  });
+
+  it('sets svgError when response is not ok', async () => {
+    const url = uniqueSvgUrl();
+    fetch.mockResolvedValueOnce({ ok: false });
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.vm.svgError).toBe(true);
+    });
+    expect(wrapper.vm.svgContent).toBe('');
+  });
+
+  it('sets svgError when response is not valid SVG', async () => {
+    const url = uniqueSvgUrl();
+    fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('<html>not svg</html>') });
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.vm.svgError).toBe(true);
+    });
+    expect(wrapper.vm.svgContent).toBe('');
+  });
+
+  it('sanitizes script tags from SVG content', async () => {
+    const url = uniqueSvgUrl();
+    const malicious = '<svg><script>alert("xss")</script><circle r="10"/></svg>';
+    fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(malicious) });
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.find('.home-img-svg__content').exists()).toBe(true);
+    });
+    const html = wrapper.find('.home-img-svg__content').html();
+    expect(html).not.toContain('<script');
+    expect(html).toContain('<circle');
+  });
+
+  it('sanitizes event handler attributes from SVG content', async () => {
+    const url = uniqueSvgUrl();
+    const malicious = '<svg><rect onclick="alert(1)" r="10"/></svg>';
+    fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(malicious) });
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.find('.home-img-svg__content').exists()).toBe(true);
+    });
+    expect(wrapper.find('.home-img-svg__content').html()).not.toContain('onclick');
+  });
+
+  it('applies gradient overlay in SVG path', async () => {
+    const url = uniqueSvgUrl();
+    const svgMarkup = '<svg><circle r="10"/></svg>';
+    fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(svgMarkup) });
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url, gradient: 'to bottom, rgba(0,0,0,.1), rgba(0,0,0,.7)' },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.find('.home-img-svg__content').exists()).toBe(true);
+    });
+    const gradientEl = wrapper.find('.home-img-svg__gradient');
+    expect(gradientEl.exists()).toBe(true);
+  });
+
+  it('renders title and text in overlay container for SVG path', async () => {
+    const url = uniqueSvgUrl();
+    const svgMarkup = '<svg><circle r="10"/></svg>';
+    fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(svgMarkup) });
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url, title: 'Hello', text: 'World' },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.find('.home-img-svg__content').exists()).toBe(true);
+    });
+    const overlay = wrapper.find('.home-img-svg__overlay');
+    expect(overlay.exists()).toBe(true);
+    expect(overlay.text()).toContain('Hello');
+    expect(overlay.text()).toContain('World');
+  });
+
+  it('sets aria-hidden when no alt or title is provided', () => {
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: uniqueSvgUrl() },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.find('.home-img-svg').attributes('aria-hidden')).toBe('true');
+  });
+
+  it('sets aria-label when alt is provided', () => {
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: uniqueSvgUrl(), alt: 'Hero illustration' },
+      global: globalOpts(vuetify),
+    });
+    const svg = wrapper.find('.home-img-svg');
+    expect(svg.attributes('aria-label')).toBe('Hero illustration');
+    expect(svg.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('normalizes numeric height to px string', () => {
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: uniqueSvgUrl(), height: 200 },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.find('.home-img-svg').attributes('style')).toContain('height: 200px');
+  });
+
+  it('passes string height through unchanged', () => {
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: uniqueSvgUrl(), height: '50vh' },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.find('.home-img-svg').attributes('style')).toContain('height: 50vh');
+  });
+
+  it('clears previous SVG when img changes', async () => {
+    const url1 = uniqueSvgUrl();
+    const url2 = uniqueSvgUrl();
+    const svg1 = '<svg><circle r="10"/></svg>';
+    const svg2 = '<svg><rect width="10" height="10"/></svg>';
+    fetch
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(svg1) })
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(svg2) });
+
+    const wrapper = mount(HomeImgComponent, {
+      props: { img: url1 },
+      global: globalOpts(vuetify),
+    });
+
+    await vi.waitFor(() => {
+      expect(wrapper.find('.home-img-svg__content').html()).toContain('<circle');
+    });
+
+    await wrapper.setProps({ img: url2 });
+
+    await vi.waitFor(() => {
+      expect(wrapper.find('.home-img-svg__content').html()).toContain('<rect');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- SVGs loaded via `<v-img>` / `<img>` are sandboxed and cannot access Vuetify CSS custom properties (`--v-theme-*`), causing theme colors to be invisible
- Detect `.svg` sources in `HomeImgComponent`, fetch their markup via `fetch()`, and render inline via `v-html` so they inherit page CSS variables
- In-memory cache (`Map`) avoids duplicate network requests across mounts/navigations
- Preserves responsive height, loading spinner, gradient overlay, and title/text slots for non-SVG images

## Test plan
- [ ] Verify SVG images on home page render with correct Vuetify theme colors
- [ ] Verify raster images (webp/png/jpg) still render via `<v-img>` as before
- [ ] Verify responsive height breakpoints work for both SVG and raster paths
- [ ] Verify SVG cache prevents duplicate fetch calls on re-mount

Closes #3849