### PR TITLE
feat(admin): surface API errors in admin store actions

### DIFF
--- a/src/modules/admin/stores/admin.store.js
+++ b/src/modules/admin/stores/admin.store.js
@@ -35,44 +35,53 @@ export const useAdminStore = defineStore('admin', {
     user: defaultUser(),
     users: [],
     organizations: [],
+    error: null,
   }),
 
   actions: {
     async getUsers(params) {
+      this.error = null;
       try {
         const res = await axios.get(`${apiBase()}/admin/users/page/${params}`);
         this.users = res.data.data;
       } catch (err) {
+        this.error = err?.response?.data?.message || 'Failed to load data';
         console.log(err);
       }
     },
 
     async getUser(params) {
+      this.error = null;
       try {
         const res = await axios.get(`${apiBase()}/admin/users/${params.id}`);
         this.user = res.data.data;
       } catch (err) {
+        this.error = err?.response?.data?.message || 'Failed to load data';
         this.resetUser();
         console.log(err);
       }
     },
 
     async updateUser(params, formData) {
+      this.error = null;
       try {
         const obj = model.clean({ ...this.user, ...formData }, whitelists);
         const res = await axios.put(`${apiBase()}/admin/users/${params.id}`, obj);
         assign(this.user, res.data.data);
       } catch (err) {
+        this.error = err?.response?.data?.message || 'Failed to load data';
         console.log(err);
         throw err;
       }
     },
 
     async deleteUser(params) {
+      this.error = null;
       try {
         await axios.delete(`${apiBase()}/admin/users/${params.id}`);
         this.resetUser();
       } catch (err) {
+        this.error = err?.response?.data?.message || 'Failed to load data';
         console.log(err);
         throw err;
       }
@@ -83,11 +92,13 @@ export const useAdminStore = defineStore('admin', {
     },
 
     async getOrganizations(params) {
+      this.error = null;
       try {
         const url = params ? `${apiBase()}/admin/organizations/page/${params}` : `${apiBase()}/admin/organizations`;
         const res = await axios.get(url);
         this.organizations = res.data.data;
       } catch (err) {
+        this.error = err?.response?.data?.message || 'Failed to load data';
         console.log(err);
       }
     },

--- a/src/modules/admin/tests/admin.store.unit.tests.js
+++ b/src/modules/admin/tests/admin.store.unit.tests.js
@@ -29,6 +29,7 @@ describe('Admin Store', () => {
     const store = useAdminStore();
     expect(store.users).toEqual([]);
     expect(store.organizations).toEqual([]);
+    expect(store.error).toBeNull();
     expect(store.user).toEqual({
       firstName: '',
       lastName: '',
@@ -58,7 +59,7 @@ describe('Admin Store', () => {
       expect(store.users).toEqual(mockUsers);
     });
 
-    it('should handle error', async () => {
+    it('should handle error and set error state', async () => {
       const store = useAdminStore();
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -67,7 +68,35 @@ describe('Admin Store', () => {
       await store.getUsers('0&10');
 
       expect(store.users).toEqual([]);
+      expect(store.error).toBe('Failed to load data');
       expect(consoleLogSpy).toHaveBeenCalled();
+      consoleLogSpy.mockRestore();
+    });
+
+    it('should set error from API response message', async () => {
+      const store = useAdminStore();
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      axios.get.mockRejectedValueOnce({ response: { data: { message: 'Forbidden' } } });
+
+      await store.getUsers('0&10');
+
+      expect(store.error).toBe('Forbidden');
+      consoleLogSpy.mockRestore();
+    });
+
+    it('should clear error on next action call', async () => {
+      const store = useAdminStore();
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      axios.get.mockRejectedValueOnce(new Error('Failed'));
+      await store.getUsers('0&10');
+      expect(store.error).toBe('Failed to load data');
+
+      axios.get.mockResolvedValueOnce({ data: { data: [] } });
+      await store.getUsers('0&10');
+      expect(store.error).toBeNull();
+
       consoleLogSpy.mockRestore();
     });
   });
@@ -95,7 +124,7 @@ describe('Admin Store', () => {
       expect(store.organizations).toEqual(mockOrgs);
     });
 
-    it('should handle error', async () => {
+    it('should handle error and set error state', async () => {
       const store = useAdminStore();
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -104,6 +133,7 @@ describe('Admin Store', () => {
       await store.getOrganizations('0&10');
 
       expect(store.organizations).toEqual([]);
+      expect(store.error).toBe('Failed to load data');
       expect(consoleLogSpy).toHaveBeenCalled();
       consoleLogSpy.mockRestore();
     });
@@ -134,7 +164,7 @@ describe('Admin Store', () => {
       expect(store.user).toMatchObject(updatedUser);
     });
 
-    it('should handle error', async () => {
+    it('should handle error and set error state', async () => {
       const store = useAdminStore();
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -142,6 +172,7 @@ describe('Admin Store', () => {
 
       await expect(store.updateUser({ id: '123' })).rejects.toThrow('Failed');
 
+      expect(store.error).toBe('Failed to load data');
       expect(consoleLogSpy).toHaveBeenCalled();
       consoleLogSpy.mockRestore();
     });
@@ -170,7 +201,7 @@ describe('Admin Store', () => {
       });
     });
 
-    it('should handle error', async () => {
+    it('should handle error and set error state', async () => {
       const store = useAdminStore();
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -178,6 +209,7 @@ describe('Admin Store', () => {
 
       await expect(store.deleteUser({ id: '999' })).rejects.toThrow('Failed');
 
+      expect(store.error).toBe('Failed to load data');
       expect(consoleLogSpy).toHaveBeenCalled();
       consoleLogSpy.mockRestore();
     });

--- a/src/modules/admin/tests/admin.view.unit.tests.js
+++ b/src/modules/admin/tests/admin.view.unit.tests.js
@@ -7,6 +7,7 @@ vi.mock('../stores/admin.store', () => ({
   useAdminStore: () => ({
     users: [],
     organizations: [],
+    error: null,
     getUsers: vi.fn(),
     getOrganizations: vi.fn(),
   }),

--- a/src/modules/admin/views/admin.view.vue
+++ b/src/modules/admin/views/admin.view.vue
@@ -1,6 +1,19 @@
 <template>
   <v-container fluid>
     <PageHeader icon="fa-solid fa-user-tie" title="Admin" />
+    <v-alert
+      v-if="error"
+      type="error"
+      variant="tonal"
+      density="compact"
+      closable
+      class="mx-2 mt-2"
+      :class="config.vuetify.theme.rounded"
+      icon="fa-solid fa-circle-exclamation"
+      @click:close="clearError"
+    >
+      <span class="text-body-medium">{{ error }}</span>
+    </v-alert>
     <v-row class="pa-2 mt-0">
       <v-col cols="12">
         <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded">
@@ -192,6 +205,10 @@ export default {
         && tab.label
         && tab.route);
     },
+    error() {
+      const adminStore = useAdminStore();
+      return adminStore.error;
+    },
     users() {
       const adminStore = useAdminStore();
       return adminStore.users;
@@ -212,6 +229,10 @@ export default {
   methods: {
     roleColor,
     orgColor,
+    clearError() {
+      const adminStore = useAdminStore();
+      adminStore.error = null;
+    },
     isUserActiveOrg(user, membership) {
       const currentOrg = user.currentOrganization?._id || user.currentOrganization?.id || user.currentOrganization;
       const orgId = membership.organizationId?._id || membership.organizationId?.id || membership.organizationId;


### PR DESCRIPTION
## Summary

- Add `error` state to admin Pinia store, populated from API response messages in every catch block and cleared at the start of each action
- Display a closable `v-alert` in `admin.view.vue` when `error` is truthy
- Update store and view unit tests to cover error state initialization, setting, clearing, and API message extraction

Closes #3850

## Scope

- Modules impacted: `admin`
- Cross-module impact: none
- Risk level: `low`

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] All 783 unit tests pass (`npm run test:unit`)
- [ ] CI green