### PR TITLE
fix(footer): transparent card background

### DIFF
--- a/src/modules/core/components/core.footer.component.vue
+++ b/src/modules/core/components/core.footer.component.vue
@@ -9,7 +9,7 @@
           :md="12 / links.filter((section) => section.items).length"
           class="text-center"
         >
-          <v-card :flat="config.vuetify.theme.flat" :style="custom && custom.section ? custom.section : null">
+          <v-card color="transparent" :flat="config.vuetify.theme.flat" :style="custom && custom.section ? custom.section : null">
             <v-card-title class="text-center text-title-medium font-weight-bold text-medium-emphasis">{{ title }}</v-card-title>
             <v-list :style="custom && custom.section ? custom.section : null" density="compact">
               <v-list-item v-for="(item, idx) in items" :key="idx" class="justify-center" @click="navigate(item.url)">


### PR DESCRIPTION
## Summary

- Closes #3862
- Adds `color="transparent"` to `<v-card>` in footer link blocks so cards inherit the footer section background instead of defaulting to Vuetify surface color

## Fix

`src/modules/core/components/core.footer.component.vue` line 12: added `color="transparent"` attribute to `<v-card>`.

## Test plan

- [x] Lint passes
- [x] Unit tests pass (867 tests)
- [x] Build passes
- [ ] Visual: footer link sections should render without white/surface-color card backgrounds breaking the footer color