### PR TITLE
feat(home): support custom section background in all home components

### DIFF
--- a/src/modules/home/components/home.about.component.vue
+++ b/src/modules/home/components/home.about.component.vue
@@ -126,11 +126,12 @@ export default {
       };
     },
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
   },

--- a/src/modules/home/components/home.articles.component.vue
+++ b/src/modules/home/components/home.articles.component.vue
@@ -121,11 +121,12 @@ export default {
       };
     },
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
     steps() {

--- a/src/modules/home/components/home.capabilities.component.vue
+++ b/src/modules/home/components/home.capabilities.component.vue
@@ -144,11 +144,12 @@ export default {
       };
     },
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
     cardStyle() {

--- a/src/modules/home/components/home.contact.component.vue
+++ b/src/modules/home/components/home.contact.component.vue
@@ -92,11 +92,12 @@ export default {
       };
     },
     sectionStyle() {
+      const hasCustomBg = this.config.home.contact?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.config.home.contact),
         ...colorModeStyle(this.config.home.contact?.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
     contact() {

--- a/src/modules/home/components/home.cta.component.vue
+++ b/src/modules/home/components/home.cta.component.vue
@@ -103,11 +103,12 @@ export default {
      * @returns {Object}
      */
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
   },

--- a/src/modules/home/components/home.faq.component.vue
+++ b/src/modules/home/components/home.faq.component.vue
@@ -140,11 +140,12 @@ export default {
      * @returns {Object}
      */
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
     /**

--- a/src/modules/home/components/home.gallery.component.vue
+++ b/src/modules/home/components/home.gallery.component.vue
@@ -147,11 +147,12 @@ export default {
     },
     sectionStyle() {
       if (!this.theme?.current?.colors) return { ...style('section', this.setup), ...colorModeStyle(this.setup.colorMode) };
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
     steps() {

--- a/src/modules/home/components/home.presentation.component.vue
+++ b/src/modules/home/components/home.presentation.component.vue
@@ -77,11 +77,12 @@ export default {
       return this.setup.variant || 'default';
     },
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
     containerStyle() {

--- a/src/modules/home/components/home.services.component.vue
+++ b/src/modules/home/components/home.services.component.vue
@@ -92,11 +92,12 @@ export default {
       };
     },
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
     cardStyle() {

--- a/src/modules/home/components/home.social.component.vue
+++ b/src/modules/home/components/home.social.component.vue
@@ -112,11 +112,12 @@ export default {
       };
     },
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
         overflow: 'hidden',
         '--gradient-bg-color': bgColor,
       };

--- a/src/modules/home/components/home.steps.component.vue
+++ b/src/modules/home/components/home.steps.component.vue
@@ -99,11 +99,12 @@ export default {
       };
     },
     sectionStyle() {
+      const hasCustomBg = this.setup?.style?.section?.background;
       const bgColor = this.variant === 'alternate' ? this.theme.current.colors.surface : this.theme.current.colors.background;
       return {
         ...style('section', this.setup),
         ...colorModeStyle(this.setup.colorMode),
-        background: bgColor,
+        ...(hasCustomBg ? {} : { background: bgColor }),
       };
     },
     cardStyle() {


### PR DESCRIPTION
## Summary
- Applies the `hasCustomBg` pattern to all 11 home section components (about, articles, capabilities, contact, cta, faq, gallery, presentation, services, social, steps)
- Only `home.features.component.vue` already had this fix; all others were overriding any custom gradient/background with the theme fallback `bgColor`
- When `style.section.background` is set in config, the theme fallback is now skipped; otherwise behavior is unchanged

Closes #3870

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] 877 unit tests pass (`npm run test:coverage`)
- [x] Build passes (`npm run build`)
- [ ] Manual: set `style.section.background` on any section config and verify the custom background renders correctly