### PR TITLE
fix(footer): transparent background on link list

### DIFF
--- a/src/modules/core/components/core.footer.component.vue
+++ b/src/modules/core/components/core.footer.component.vue
@@ -11,7 +11,7 @@
         >
           <v-card color="transparent" :flat="config.vuetify.theme.flat" :style="custom && custom.section ? custom.section : null">
             <v-card-title class="text-center text-title-medium font-weight-bold text-medium-emphasis">{{ title }}</v-card-title>
-            <v-list :style="custom && custom.section ? custom.section : null" density="compact">
+            <v-list class="bg-transparent" :style="custom && custom.section ? custom.section : null" density="compact">
               <v-list-item v-for="(item, idx) in items" :key="idx" class="justify-center" @click="navigate(item.url)">
                 <v-list-item-title>
                   <v-icon size="14" class="mr-2 text-onSurface text-medium-emphasis">{{ item.icon }}</v-icon>


### PR DESCRIPTION
## Summary

- Add `bg-transparent` Vuetify utility class to `<v-list>` in `core.footer.component.vue`
- Fixes white background mismatch on the link list in light mode — the `<v-card>` already had `color="transparent"` but the inner `<v-list>` was still rendering `background: rgb(255, 255, 255)`
- `bg-transparent` sets `background: transparent !important` via Vuetify utility

Closes #3862

## Test plan

- [ ] Verify footer link list has transparent background in light mode
- [ ] Verify footer link list has transparent background in dark mode
- [ ] Lint passes
- [ ] All 880 unit tests pass
- [ ] Build succeeds