### PR TITLE
fix(features): remount carousel cards on step change to replay SVG animations

### DIFF
--- a/src/modules/home/components/home.features.component.vue
+++ b/src/modules/home/components/home.features.component.vue
@@ -77,7 +77,7 @@
           >
             <v-carousel-item v-for="n in steps + 1" :key="n">
               <v-row align="center" justify="center" class="pa-0">
-                <v-col v-for="(item, i) in content" :key="i" cols="12" :md="item.fullWidth ? 12 : setup.content.length > 1 ? 6 : 12">
+                <v-col v-for="(item, i) in content" :key="`${step}-${i}`" cols="12" :md="item.fullWidth ? 12 : setup.content.length > 1 ? 6 : 12">
                   <v-card :class="`${config.vuetify.theme.rounded}`" :flat="config.vuetify.theme.flat" :style="style('card', { style: item.style })">
                     <homeImgComponent v-if="item.img && !item.reversed" :img="item.img" :img-mode="item.imgMode"></homeImgComponent>
                     <homeContentComponent


### PR DESCRIPTION
## Summary
- Carousel SVG illustrations became invisible when sliding backward — CSS `opacity: 0→1` animations never replayed
- Root cause: `:key="i"` caused Vue to patch existing DOM nodes instead of remounting on step change
- Fix: `:key="\`${step}-${i}\`"` — forces full remount on every slide, fresh SVG insertion, fresh animations

Closes #3886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed carousel rendering when navigating between steps to ensure items properly maintain state and display correctly during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->