### PR TITLE
fix(img): await nextTick before setting SVG content from cache

### DIFF
--- a/src/modules/home/components/utils/home.img.component.vue
+++ b/src/modules/home/components/utils/home.img.component.vue
@@ -216,7 +216,12 @@ export default {
       this.svgError = false;
 
       if (svgCache.has(src)) {
-        this.svgContent = svgCache.get(src);
+        // Wait for the DOM to process the clear (svgContent = '') before reinserting.
+        // Without nextTick, Vue batches both assignments in the same tick — no real
+        // DOM clear happens, so the SVG elements are never fresh-inserted and CSS
+        // opacity animations don't replay on subsequent views.
+        await this.$nextTick();
+        if (this.img === src) this.svgContent = svgCache.get(src);
         return;
       }
 


### PR DESCRIPTION
## Summary
SVGs in the `homeFeatures` carousel appeared invisible when sliding backward — CSS `opacity: 0 → 1` animations never replayed.

Root cause: `svgContent = ''` and `svgContent = cachedValue` batched in the same synchronous tick → Vue skipped the DOM clear → no fresh element insertion → animations never restart.

Fix: `await nextTick()` between clear and cache-restore forces a real DOM cycle: element removed, then reinserted fresh → CSS animations fire on every view.

Closes #3888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved timing issue with cached SVG image rendering to ensure proper display refresh when the same image is loaded again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->