### PR TITLE
fix(navigation): clean mobile glass navigation

### DIFF
--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -181,7 +181,7 @@ export default {
     drawerStyle() {
       if (this.isGlass) {
         const isMobile = this.$vuetify.display.mobile;
-        const applyInset = this.isInset && (!isMobile || this.drawer);
+        const applyLeftInset = this.isInset && (!isMobile || this.drawer);
         return {
           ...liquidGlassStyle({
             vuetifyTheme: this.theme,
@@ -191,7 +191,15 @@ export default {
               color: this.theme.current.colors.onSurface,
             },
           }),
-          ...(applyInset ? { margin: '12px', height: 'calc(100% - 24px)', borderRadius: '16px' } : {}),
+          ...(this.isInset
+            ? {
+                marginTop: '12px',
+                marginBottom: '12px',
+                marginLeft: applyLeftInset ? '12px' : '0',
+                height: 'calc(100% - 24px)',
+                borderRadius: '16px',
+              }
+            : {}),
         };
       }
       return { background: this.navBackground };

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -180,17 +180,16 @@ export default {
      */
     drawerStyle() {
       if (this.isGlass) {
-        const isMobile = this.$vuetify.display.mobile;
         return {
           ...liquidGlassStyle({
             vuetifyTheme: this.theme,
-            variant: this.isInset && !isMobile ? 'card' : 'header',
+            variant: this.isInset ? 'card' : 'header',
             border: 'none',
             extras: {
               color: this.theme.current.colors.onSurface,
             },
           }),
-          ...(this.isInset && !isMobile ? { margin: '12px', height: 'calc(100% - 24px)', borderRadius: '16px' } : {}),
+          ...(this.isInset ? { margin: '12px', height: 'calc(100% - 24px)', borderRadius: '16px' } : {}),
         };
       }
       return { background: this.navBackground };

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -5,16 +5,15 @@
       v-if="$vuetify.display.mobile && !drawer"
       :flat="config.vuetify.theme.flat"
       icon
-      size="small"
       :style="{
         color: navColor,
         background: isGlass ? undefined : `${navBackground}99`,
         ...glassButtonStyle,
       }"
-      style="position: fixed; top: 10px; left: 8px; z-index: 9999"
+      style="position: fixed; top: 7px; left: 5px; z-index: 9999"
       @click="drawer = true"
     >
-      <v-icon icon="fa-solid fa-bars" size="small"></v-icon>
+      <v-icon icon="fa-solid fa-bars"></v-icon>
     </v-btn>
     <!-- Navigation drawer -->
     <v-navigation-drawer

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -180,6 +180,8 @@ export default {
      */
     drawerStyle() {
       if (this.isGlass) {
+        const isMobile = this.$vuetify.display.mobile;
+        const applyInset = this.isInset && (!isMobile || this.drawer);
         return {
           ...liquidGlassStyle({
             vuetifyTheme: this.theme,
@@ -189,7 +191,7 @@ export default {
               color: this.theme.current.colors.onSurface,
             },
           }),
-          ...(this.isInset ? { margin: '12px', height: 'calc(100% - 24px)', borderRadius: '16px' } : {}),
+          ...(applyInset ? { margin: '12px', height: 'calc(100% - 24px)', borderRadius: '16px' } : {}),
         };
       }
       return { background: this.navBackground };

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -32,9 +32,9 @@
         >
           <template #prepend>
             <v-icon
-              v-if="config.app.title"
+              v-if="config.app.title && !($vuetify.display.mobile && !isGlass)"
               :style="{ color: navColor, opacity: 1 }"
-              :icon="$vuetify.display.mobile && !isGlass ? 'nothing' : config.app.icon"
+              :icon="config.app.icon"
               size="large"
               class="ms-n1"
             ></v-icon>
@@ -196,6 +196,7 @@ export default {
                 marginTop: '12px',
                 marginBottom: '12px',
                 marginLeft: applyLeftInset ? '12px' : '0',
+                marginRight: '12px',
                 height: 'calc(100% - 24px)',
                 borderRadius: '16px',
               }

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -2,7 +2,7 @@
   <div v-if="isLoggedIn && hasOrganization">
     <!-- Mobile drawer acces -->
     <v-btn
-      v-if="$vuetify.display.mobile"
+      v-if="$vuetify.display.mobile && !drawer"
       :flat="config.vuetify.theme.flat"
       icon
       :style="{
@@ -11,7 +11,7 @@
         ...glassButtonStyle,
       }"
       style="position: fixed; top: 7px; left: 5px; z-index: 9999"
-      @click="drawer = !drawer"
+      @click="drawer = true"
     >
       <v-icon icon="fa-solid fa-bars"></v-icon>
     </v-btn>
@@ -21,7 +21,8 @@
       :floating="config.vuetify.theme.navigation.drawer.floating"
       :style="drawerStyle"
       :expand-on-hover="$vuetify.display.mobile ? false : config.vuetify.theme.navigation.drawer.expand"
-      :rail="config.vuetify.theme.navigation.drawer.rail"
+      :rail="$vuetify.display.mobile ? false : config.vuetify.theme.navigation.drawer.rail"
+      :temporary="$vuetify.display.mobile"
       :elevation="0"
     >
       <!-- Logo / drawer on mobile-->
@@ -110,7 +111,7 @@
 /**
  * Module dependencies.
  */
-import { useTheme } from 'vuetify';
+import { useTheme, useDisplay } from 'vuetify';
 import { useAuthStore } from '../../auth/stores/auth.store';
 import { useCoreStore } from '../stores/core.store';
 import { liquidGlassStyle } from '../../../lib/helpers/theme';
@@ -122,7 +123,7 @@ export default {
   data() {
     const theme = useTheme();
     return {
-      drawer: true,
+      drawer: !useDisplay().mobile.value,
       theme,
     };
   },
@@ -179,16 +180,17 @@ export default {
      */
     drawerStyle() {
       if (this.isGlass) {
+        const isMobile = this.$vuetify.display.mobile;
         return {
           ...liquidGlassStyle({
             vuetifyTheme: this.theme,
-            variant: this.isInset ? 'card' : 'header',
+            variant: this.isInset && !isMobile ? 'card' : 'header',
             border: 'none',
             extras: {
               color: this.theme.current.colors.onSurface,
             },
           }),
-          ...(this.isInset ? { margin: '12px', height: 'calc(100% - 24px)', borderRadius: '16px' } : {}),
+          ...(this.isInset && !isMobile ? { margin: '12px', height: 'calc(100% - 24px)', borderRadius: '16px' } : {}),
         };
       }
       return { background: this.navBackground };

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -34,7 +34,7 @@
             <v-icon
               v-if="config.app.title"
               :style="{ color: navColor, opacity: 1 }"
-              :icon="$vuetify.display.mobile ? 'nothing' : config.app.icon"
+              :icon="$vuetify.display.mobile && !isGlass ? 'nothing' : config.app.icon"
               size="large"
               class="ms-n1"
             ></v-icon>

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -5,15 +5,16 @@
       v-if="$vuetify.display.mobile && !drawer"
       :flat="config.vuetify.theme.flat"
       icon
+      size="small"
       :style="{
         color: navColor,
         background: isGlass ? undefined : `${navBackground}99`,
         ...glassButtonStyle,
       }"
-      style="position: fixed; top: 7px; left: 5px; z-index: 9999"
+      style="position: fixed; top: 10px; left: 8px; z-index: 9999"
       @click="drawer = true"
     >
-      <v-icon icon="fa-solid fa-bars"></v-icon>
+      <v-icon icon="fa-solid fa-bars" size="small"></v-icon>
     </v-btn>
     <!-- Navigation drawer -->
     <v-navigation-drawer

--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row class="mx-4 my-1" align="center" :style="rowStyle">
+  <v-row class="mx-4 my-1" align="center" :style="$slots.tabs ? { minHeight: '56px' } : null">
     <template v-if="$slots.tabs">
       <!-- Tabs mode: tabs replace icon + title -->
       <slot name="tabs"></slot>
@@ -49,13 +49,6 @@ export default {
     avatarColor: {
       type: String,
       default: 'primary',
-    },
-  },
-  computed: {
-    rowStyle() {
-      const base = this.$slots.tabs ? { minHeight: '56px' } : {};
-      if (this.$vuetify.display.mobile) base.paddingLeft = '48px';
-      return base;
     },
   },
 };

--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -11,7 +11,7 @@
           <v-icon :icon="icon" size="small" color="white"></v-icon>
         </v-avatar>
       </slot>
-      <div :class="$vuetify.display.mobile ? 'ml-6' : 'ml-2'">
+      <div :class="[$vuetify.display.mobile ? 'ml-6' : '', !$vuetify.display.mobile && ($slots.avatar || icon) ? 'ml-2' : '']">
         <h2 class="text-title-large font-weight-medium" :class="titleClass" style="line-height: 1;">
           <slot name="title">{{ title }}</slot>
         </h2>

--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -1,12 +1,12 @@
 <template>
-  <v-row class="mx-4 my-1" align="center" :style="$slots.tabs ? { minHeight: '56px' } : null">
+  <v-row class="mx-4 my-1" align="center" :style="rowStyle">
     <template v-if="$slots.tabs">
       <!-- Tabs mode: tabs replace icon + title -->
       <slot name="tabs"></slot>
     </template>
     <template v-else>
       <!-- Standard mode: icon + title -->
-      <slot name="avatar">
+      <slot v-if="!$vuetify.display.mobile" name="avatar">
         <v-avatar v-if="icon" :color="avatarColor" size="40" class="mr-3">
           <v-icon :icon="icon" size="small" color="white"></v-icon>
         </v-avatar>
@@ -49,6 +49,13 @@ export default {
     avatarColor: {
       type: String,
       default: 'primary',
+    },
+  },
+  computed: {
+    rowStyle() {
+      const base = this.$slots.tabs ? { minHeight: '56px' } : {};
+      if (this.$vuetify.display.mobile) base.paddingLeft = '48px';
+      return base;
     },
   },
 };

--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -7,11 +7,11 @@
     <template v-else>
       <!-- Standard mode: icon + title -->
       <slot v-if="!$vuetify.display.mobile" name="avatar">
-        <v-avatar v-if="icon" :color="avatarColor" size="40" class="mr-3">
+        <v-avatar v-if="icon" :color="avatarColor" size="40">
           <v-icon :icon="icon" size="small" color="white"></v-icon>
         </v-avatar>
       </slot>
-      <div>
+      <div class="ml-3">
         <h2 class="text-title-large font-weight-medium" :class="titleClass" style="line-height: 1;">
           <slot name="title">{{ title }}</slot>
         </h2>

--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -11,7 +11,7 @@
           <v-icon :icon="icon" size="small" color="white"></v-icon>
         </v-avatar>
       </slot>
-      <div class="ml-3">
+      <div class="ml-4">
         <h2 class="text-title-large font-weight-medium" :class="titleClass" style="line-height: 1;">
           <slot name="title">{{ title }}</slot>
         </h2>

--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -11,7 +11,7 @@
           <v-icon :icon="icon" size="small" color="white"></v-icon>
         </v-avatar>
       </slot>
-      <div class="ml-4">
+      <div :class="$vuetify.display.mobile ? 'ml-6' : 'ml-2'">
         <h2 class="text-title-large font-weight-medium" :class="titleClass" style="line-height: 1;">
           <slot name="title">{{ title }}</slot>
         </h2>


### PR DESCRIPTION
## Summary

- Mobile drawer in glass mode now hides cleanly and opens in the same inset glass card style as desktop
- Burger button disappears once the drawer is open, reappears when closed
- Drawer always opens expanded (text + icons), never as rail, on mobile
- App logo stays visible on mobile in glass mode
- \`core.pageHeader\` hides the avatar on mobile and rebalances the title left margin (ml-2 desktop / ml-6 mobile) so the burger no longer collides with the page title

## Details

- \`core.navigation.component.vue\`:
  - \`:temporary=\"mobile\"\`, \`:rail=false\` and initial \`drawer=false\` on mobile
  - Burger \`v-if=\"mobile && !drawer\"\`
  - Glass inset keeps \`marginTop/marginBottom/height/borderRadius\` constant so the drawer doesn't jump in height during the slide; only \`marginLeft\` is dropped while closed to avoid the 12px sliver left visible by Vuetify's \`translateX(-100%)\` transform
  - App icon shown on mobile when glass is active
- \`core.pageHeader.component.vue\`:
  - Avatar hidden via \`v-if=\"!mobile\"\`
  - Horizontal spacing moved from avatar \`mr-3\` to title \`ml-2\` (desktop) / \`ml-6\` (mobile) so the title has breathing room with or without the avatar

## Test plan

- [ ] Desktop glass + inset: unchanged (inset card, rail if configured)
- [ ] Mobile glass closed: drawer fully off-screen, no sliver, burger visible
- [ ] Mobile glass open: inset card (margin + border-radius), no rail, text visible, burger hidden
- [ ] Slide animation: no height jump, no sliver reappearing mid-slide
- [ ] Mobile page headers: avatar hidden, title doesn't overlap burger
- [ ] Non-glass mobile: behavior unchanged