### PR TITLE
fix(home): equalize capabilities card heights across tabs

### DIFF
--- a/src/modules/home/components/home.capabilities.component.vue
+++ b/src/modules/home/components/home.capabilities.component.vue
@@ -226,12 +226,15 @@ export default {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.25s ease;
+  transition:
+    opacity 0.25s ease,
+    visibility 0s linear 0.25s;
 }
 
 .capabilities-stack__item--active {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
+  transition-delay: 0s;
 }
 </style>

--- a/src/modules/home/components/home.capabilities.component.vue
+++ b/src/modules/home/components/home.capabilities.component.vue
@@ -44,57 +44,63 @@
         <home-tabs v-model="activeIndex" :items="setup.items" :color-mode="setup.colorMode" @update:model-value="onTabChange" />
 
         <!-- Feature Content -->
-        <v-window v-model="activeIndex" class="mt-1">
-          <v-window-item
-            v-for="(item, index) in setup.items"
-            :key="item.id"
-            :value="index"
-            eager
-            transition="fade-transition"
-            reverse-transition="fade-transition"
-          >
-            <v-card :class="`${config.vuetify.theme.rounded}`" :flat="config.vuetify.theme.flat" :style="cardStyle" class="mx-3">
-              <v-row :class="item.reversed ? 'flex-row-reverse' : ''" align="center">
-                <!-- Text Content -->
-                <v-col cols="12" md="6" class="pa-8">
-                  <homeContentComponent
-                    :key="`text-${index}`"
-                    :setup="{ subtitle: item.title, text: item.description, button: item.cta }"
-                    variant="card"
-                    alignment="left"
-                  />
-                </v-col>
-
-                <!-- Image -->
-                <v-col cols="12" md="6" class="pa-8">
-                  <div v-if="item.video" :class="`py-6`">
-                    <video-player
-                      :src="item.video.file"
-                      :controls="false"
-                      :poster="item.video.poster"
-                      :background-color="item.video.background || setup.style?.video?.background || '#101115'"
-                      :rounded="config.vuetify.theme.rounded"
-                      :playback-rate="item.video.playbackRate || 1.0"
-                      loop
-                      muted
-                      autoplay
-                      fluid
+        <!--
+          CSS grid stack keeps all items rendered in a single grid cell so the
+          container height matches the tallest item. Prevents vertical jump
+          when switching tabs (see #3945).
+        -->
+        <v-col cols="12" class="pa-0 mt-1">
+          <div class="capabilities-stack">
+            <div
+              v-for="(item, index) in setup.items"
+              :key="item.id"
+              class="capabilities-stack__item"
+              :class="{ 'capabilities-stack__item--active': activeIndex === index }"
+              :aria-hidden="activeIndex !== index"
+            >
+              <v-card :class="`${config.vuetify.theme.rounded}`" :flat="config.vuetify.theme.flat" :style="cardStyle" class="mx-3">
+                <v-row :class="item.reversed ? 'flex-row-reverse' : ''" align="center">
+                  <!-- Text Content -->
+                  <v-col cols="12" md="6" class="pa-8">
+                    <homeContentComponent
+                      :key="`text-${index}`"
+                      :setup="{ subtitle: item.title, text: item.description, button: item.cta }"
+                      variant="card"
+                      alignment="left"
                     />
-                  </div>
-                  <v-img
-                    v-if="item.image"
-                    :src="item.image"
-                    :alt="item.title"
-                    :class="`${config.vuetify.theme.rounded}`"
-                    cover
-                    eager
-                    aspect-ratio="16/9"
-                  ></v-img>
-                </v-col>
-              </v-row>
-            </v-card>
-          </v-window-item>
-        </v-window>
+                  </v-col>
+
+                  <!-- Image -->
+                  <v-col cols="12" md="6" class="pa-8">
+                    <div v-if="item.video" :class="`py-6`">
+                      <video-player
+                        :src="item.video.file"
+                        :controls="false"
+                        :poster="item.video.poster"
+                        :background-color="item.video.background || setup.style?.video?.background || '#101115'"
+                        :rounded="config.vuetify.theme.rounded"
+                        :playback-rate="item.video.playbackRate || 1.0"
+                        loop
+                        muted
+                        autoplay
+                        fluid
+                      />
+                    </div>
+                    <v-img
+                      v-if="item.image"
+                      :src="item.image"
+                      :alt="item.title"
+                      :class="`${config.vuetify.theme.rounded}`"
+                      cover
+                      eager
+                      aspect-ratio="16/9"
+                    ></v-img>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </div>
+          </div>
+        </v-col>
       </v-row>
     </v-container>
   </section>
@@ -204,4 +210,28 @@ export default {
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+/*
+ * Stack all capability items in a single grid cell so the container height
+ * matches the tallest item. Prevents the vertical jump when switching tabs
+ * (see #3945). Only the active item is visible; others stay in the layout
+ * to keep the grid cell sized to the tallest child.
+ */
+.capabilities-stack {
+  display: grid;
+}
+
+.capabilities-stack__item {
+  grid-area: 1 / 1;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.capabilities-stack__item--active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+</style>


### PR DESCRIPTION
## Summary

- What changed: Replace `v-window` in `home.capabilities.component.vue` with a CSS grid stack so all capability items share a single grid cell.
- Why: `v-window` shrinks to the active item's height, causing the container to jump vertically when switching tabs (each tab has different text/image heights). The grid stack sizes to the tallest child, keeping the container height stable across tabs.
- Related issues: Closes #3945

## Scope

- Modules impacted: `home` (capabilities component only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

> No unit test added — the fix is a pure CSS/layout change on a template already uncovered by unit tests in the home module. Behavior (active index, hash deep-link, keyboard nav) is unchanged.

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: no API/config change, purely visual layout fix; generic across all downstream projects (no project-specific assumptions)
- How it works:
  - All items render in a single `display: grid` cell via `grid-area: 1 / 1`
  - Only the active item is visible (`opacity`, `visibility`, `pointer-events`), others stay in layout so the cell keeps the tallest height
  - Fade transition preserved via CSS `transition: opacity 0.25s ease`
  - `defaultActiveId`, hash deep-linking, ArrowLeft/Right nav remain untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Capabilities section's tabbed content display with improved rendering and adjusted transition animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->