### PR TITLE
feat(home): support right alignment in homeContentComponent

### DIFF
--- a/src/modules/home/components/utils/home.content.component.vue
+++ b/src/modules/home/components/utils/home.content.component.vue
@@ -9,7 +9,7 @@
 
   PROPS:
   - setup (Object, required): Content object
-  - alignment (String): 'left' or 'center' - default: 'left'
+  - alignment (String): 'left' | 'center' | 'right' - default: 'left'
   - variant (String): 'default' or 'card' - default: 'default' (card adds padding to elements)
   - color (String): 'default' | 'light' | 'dark' - default: 'default'
     * default: primary/secondary/medium-emphasis colors
@@ -38,9 +38,9 @@
 -->
 <template>
   <div>
-    <v-card-title :class="[computedAlignment === 'center' ? 'text-center' : 'text-left', variant === 'default' ? 'pa-0' : '']">
+    <v-card-title :class="[alignmentClass, variant === 'default' ? 'pa-0' : '']">
       <!-- Level 1: Icon + Title (inline) -->
-      <div v-if="setup.icon || setup.title" :class="['d-flex align-center ga-2 my-0', computedAlignment === 'center' ? 'justify-center' : '']">
+      <div v-if="setup.icon || setup.title" :class="['d-flex align-center ga-2 my-0', justifyClass]">
         <v-icon v-if="setup.icon" size="x-small" :color="themeColor || 'primary'">{{ setup.icon }}</v-icon>
         <span
           v-if="setup.title"
@@ -63,7 +63,7 @@
       </component>
     </v-card-title>
 
-    <v-card-text v-if="setup.text" :class="[computedAlignment === 'center' ? 'text-center' : 'text-left', variant === 'default' ? 'pa-0' : '']">
+    <v-card-text v-if="setup.text" :class="[alignmentClass, variant === 'default' ? 'pa-0' : '']">
       <VMarkdown
         :class="['text-body-large', 'font-weight-regular my-4', themeColor ? '' : 'text-medium-emphasis']"
         :style="themeColor ? { color: themeColor } : ''"
@@ -73,7 +73,7 @@
 
     <v-card-actions
       v-if="setup.button && setup.button.title && setup.button.link"
-      :class="[variant === 'default' ? 'pa-0' : '', computedAlignment === 'center' ? 'justify-center' : '']"
+      :class="[variant === 'default' ? 'pa-0' : '', justifyClass]"
     >
       <v-btn
         :href="setup.button.link"
@@ -108,6 +108,7 @@ export default {
     alignment: {
       type: String,
       default: 'left',
+      validator: (value) => ['left', 'center', 'right'].includes(value),
     },
     variant: {
       type: String,
@@ -136,7 +137,18 @@ export default {
   },
   computed: {
     computedAlignment() {
-      return this.setup.alignment || this.alignment;
+      const value = this.setup.alignment || this.alignment;
+      return ['left', 'center', 'right'].includes(value) ? value : 'left';
+    },
+    alignmentClass() {
+      if (this.computedAlignment === 'center') return 'text-center';
+      if (this.computedAlignment === 'right') return 'text-right';
+      return 'text-left';
+    },
+    justifyClass() {
+      if (this.computedAlignment === 'center') return 'justify-center';
+      if (this.computedAlignment === 'right') return 'justify-end';
+      return 'justify-start';
     },
     themeColor() {
       if (this.color === 'light') {

--- a/src/modules/home/tests/home.content.component.unit.tests.js
+++ b/src/modules/home/tests/home.content.component.unit.tests.js
@@ -1,0 +1,139 @@
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { beforeEach, describe, it, expect } from 'vitest';
+import HomeContentComponent from '../components/utils/home.content.component.vue';
+
+/**
+ * Stub VMarkdown (registered globally via plugin in prod) so mount does not fail.
+ */
+const globalOpts = (vuetify) => ({
+  plugins: [vuetify],
+  stubs: {
+    VMarkdown: { name: 'VMarkdown', props: ['source'], template: '<div class="mock-markdown">{{ source }}</div>' },
+  },
+});
+
+const baseSetup = {
+  icon: 'fa-solid fa-star',
+  title: 'Section',
+  subtitle: 'Heading',
+  text: 'Some **markdown** text.',
+  button: { title: 'Go', link: '/go' },
+};
+
+describe('HomeContentComponent', () => {
+  let vuetify;
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives });
+  });
+
+  // --- computedAlignment ---
+
+  it('defaults alignment to left', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup } },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.vm.computedAlignment).toBe('left');
+    expect(wrapper.vm.alignmentClass).toBe('text-left');
+    expect(wrapper.vm.justifyClass).toBe('justify-start');
+  });
+
+  it('supports center alignment via prop', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup }, alignment: 'center' },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.vm.computedAlignment).toBe('center');
+    expect(wrapper.vm.alignmentClass).toBe('text-center');
+    expect(wrapper.vm.justifyClass).toBe('justify-center');
+  });
+
+  it('supports right alignment via prop', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup }, alignment: 'right' },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.vm.computedAlignment).toBe('right');
+    expect(wrapper.vm.alignmentClass).toBe('text-right');
+    expect(wrapper.vm.justifyClass).toBe('justify-end');
+  });
+
+  it('setup.alignment overrides the prop alignment', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup, alignment: 'right' }, alignment: 'left' },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.vm.computedAlignment).toBe('right');
+  });
+
+  it('falls back to left when alignment is an unknown value', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup, alignment: 'bogus' } },
+      global: globalOpts(vuetify),
+    });
+    expect(wrapper.vm.computedAlignment).toBe('left');
+    expect(wrapper.vm.alignmentClass).toBe('text-left');
+    expect(wrapper.vm.justifyClass).toBe('justify-start');
+  });
+
+  // --- DOM classes ---
+
+  it('applies text-right and justify-end classes in the DOM when right-aligned', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup }, alignment: 'right' },
+      global: globalOpts(vuetify),
+    });
+    const title = wrapper.findComponent({ name: 'VCardTitle' });
+    expect(title.classes()).toContain('text-right');
+    const iconRow = title.find('div.d-flex');
+    expect(iconRow.classes()).toContain('justify-end');
+    const text = wrapper.findComponent({ name: 'VCardText' });
+    expect(text.classes()).toContain('text-right');
+    const actions = wrapper.findComponent({ name: 'VCardActions' });
+    expect(actions.classes()).toContain('justify-end');
+  });
+
+  it('applies text-center and justify-center classes in the DOM when center-aligned', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup }, alignment: 'center' },
+      global: globalOpts(vuetify),
+    });
+    const title = wrapper.findComponent({ name: 'VCardTitle' });
+    expect(title.classes()).toContain('text-center');
+    const iconRow = title.find('div.d-flex');
+    expect(iconRow.classes()).toContain('justify-center');
+    const text = wrapper.findComponent({ name: 'VCardText' });
+    expect(text.classes()).toContain('text-center');
+    const actions = wrapper.findComponent({ name: 'VCardActions' });
+    expect(actions.classes()).toContain('justify-center');
+  });
+
+  it('applies text-left and justify-start classes in the DOM when left-aligned', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup }, alignment: 'left' },
+      global: globalOpts(vuetify),
+    });
+    const title = wrapper.findComponent({ name: 'VCardTitle' });
+    expect(title.classes()).toContain('text-left');
+    const iconRow = title.find('div.d-flex');
+    expect(iconRow.classes()).toContain('justify-start');
+    const text = wrapper.findComponent({ name: 'VCardText' });
+    expect(text.classes()).toContain('text-left');
+    const actions = wrapper.findComponent({ name: 'VCardActions' });
+    expect(actions.classes()).toContain('justify-start');
+  });
+
+  // --- prop validator ---
+
+  it('validator accepts left, center, right and rejects others', () => {
+    const { validator } = HomeContentComponent.props.alignment;
+    expect(validator('left')).toBe(true);
+    expect(validator('center')).toBe(true);
+    expect(validator('right')).toBe(true);
+    expect(validator('bogus')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Extend `homeContentComponent` `alignment` to accept `'left' | 'center' | 'right'` (previously only left/center via a ternary).
- Replace the scattered text-align and justify ternaries in the template with two computeds `alignmentClass` (`text-left|center|right`) and `justifyClass` (`justify-start|center|end`) applied consistently to `v-card-title`, icon row, `v-card-text` and `v-card-actions`.
- Add a prop validator and sanitize `computedAlignment` so unknown values fall back to `'left'`, preserving existing behavior for every current config.
- Add unit tests covering all three alignments (computed values + DOM classes) and the prop validator.

Used by downstream configs like `home.trawl.config.js` `aboutFeatures` where the illustration is right-anchored and the text block should follow.

Closes #3944

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:unit` — 906/906 passing (9 new tests in `home.content.component.unit.tests.js`)
- [x] Existing consumers (`home.about`, `home.features`, `home.capabilities`, `home.services`, `home.steps`, `home.gallery`, `home.faq`, `home.contact`) unchanged — left/center behavior preserved
- [ ] Visual check downstream once rolled into trawl_vue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added right alignment option to expand layout flexibility alongside existing left and center alignment choices
  * Improved alignment handling with enhanced validation that automatically defaults invalid values to left alignment, ensuring consistent component behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->