### PR TITLE
fix(home): isSvg handles URLs with query strings and fragments

### DIFF
--- a/src/modules/home/components/utils/home.img.component.vue
+++ b/src/modules/home/components/utils/home.img.component.vue
@@ -166,7 +166,11 @@ export default {
      * @returns {boolean} True when the source is a local SVG.
      */
     isSvg() {
-      return this.img && this.img.toLowerCase().endsWith('.svg') && LOCAL_URL_RE.test(this.img);
+      if (!this.img) return false;
+      // Strip query string (?v=N cache-buster) and fragment (#id) before extension check
+      // so URLs like '/images/foo.svg?v=2' are still inlined.
+      const pathOnly = this.img.split('?')[0].split('#')[0].toLowerCase();
+      return pathOnly.endsWith('.svg') && LOCAL_URL_RE.test(this.img);
     },
     /**
      * Responsive height matching original v-img behaviour.

--- a/src/modules/home/tests/home.img.component.unit.tests.js
+++ b/src/modules/home/tests/home.img.component.unit.tests.js
@@ -299,16 +299,20 @@ describe('HomeImgComponent', () => {
   describe('isSvg URL detection', () => {
     /**
      * Mount a component with a given img and return whether the inline SVG branch rendered.
+     * Uses an immediately-resolving failed fetch so `fetchSvg()` settles synchronously
+     * and unmounts the wrapper before returning to avoid leaking DOM/instances between tests.
      * @param {string} img - Image URL to test.
      * @returns {boolean} True if the inline SVG container is rendered.
      */
     const mountsAsInlineSvg = (img) => {
-      fetch.mockReturnValueOnce(new Promise(() => {}));
+      fetch.mockResolvedValueOnce({ ok: false });
       const wrapper = mount(HomeImgComponent, {
         props: { img },
         global: globalOpts(vuetify),
       });
-      return wrapper.find('.home-img-svg').exists();
+      const isInline = wrapper.find('.home-img-svg').exists();
+      wrapper.unmount();
+      return isInline;
     };
 
     it('inlines plain local .svg', () => {

--- a/src/modules/home/tests/home.img.component.unit.tests.js
+++ b/src/modules/home/tests/home.img.component.unit.tests.js
@@ -296,6 +296,54 @@ describe('HomeImgComponent', () => {
     }));
   });
 
+  describe('isSvg URL detection', () => {
+    /**
+     * Mount a component with a given img and return whether the inline SVG branch rendered.
+     * @param {string} img - Image URL to test.
+     * @returns {boolean} True if the inline SVG container is rendered.
+     */
+    const mountsAsInlineSvg = (img) => {
+      fetch.mockReturnValueOnce(new Promise(() => {}));
+      const wrapper = mount(HomeImgComponent, {
+        props: { img },
+        global: globalOpts(vuetify),
+      });
+      return wrapper.find('.home-img-svg').exists();
+    };
+
+    it('inlines plain local .svg', () => {
+      expect(mountsAsInlineSvg('/images/foo.svg')).toBe(true);
+    });
+
+    it('inlines local .svg with single query param (cache-buster)', () => {
+      expect(mountsAsInlineSvg('/images/foo.svg?v=2')).toBe(true);
+    });
+
+    it('inlines local .svg with multiple query params', () => {
+      expect(mountsAsInlineSvg('/images/foo.svg?v=2&t=3')).toBe(true);
+    });
+
+    it('inlines local .svg with fragment', () => {
+      expect(mountsAsInlineSvg('/images/foo.svg#frag')).toBe(true);
+    });
+
+    it('inlines local .svg with both query and fragment', () => {
+      expect(mountsAsInlineSvg('/images/foo.svg?v=2#frag')).toBe(true);
+    });
+
+    it('does NOT inline absolute SVG URLs (even with query string)', () => {
+      expect(mountsAsInlineSvg('https://cdn.example/foo.svg?v=5')).toBe(false);
+    });
+
+    it('does NOT inline non-SVG local paths', () => {
+      expect(mountsAsInlineSvg('/images/foo.png')).toBe(false);
+    });
+
+    it('does NOT inline non-SVG local paths with query string', () => {
+      expect(mountsAsInlineSvg('/images/foo.png?v=2')).toBe(false);
+    });
+  });
+
   it('clears previous SVG when img changes', async () => {
     const url1 = uniqueSvgUrl();
     const url2 = uniqueSvgUrl();


### PR DESCRIPTION
## Summary

- Fix `isSvg()` in `home.img.component.vue` to strip `?query` and `#fragment` before the `.endsWith('.svg')` extension check.
- Cache-busted URLs like `/images/foo.svg?v=2` are now inlined via `v-html` (the documented `/svg-generator` behaviour), so SVGs referencing Vuetify theme CSS vars (`rgb(var(--v-theme-surface))`) resolve correctly in both light and dark mode.
- Adds 8 unit tests covering `.svg`, `.svg?v=2`, `.svg?v=2&t=3`, `.svg#frag`, `.svg?v=2#frag`, absolute URLs with query, `.png`, and `.png?v=2`.

## Root cause

`'foo.svg?v=3'.endsWith('.svg')` is `false`, so the inline branch was skipped and the file fell through to `<v-img>` — rendering the SVG as a raster-like `<img>` where internal CSS custom property references never resolve. The result: SVGs that depend on `rgb(var(--v-theme-...))` showed solid black in light mode. Hit while polishing the trawl.me landing page (`trawl-dev-pipeline.svg`, `trawl-business-alert.svg`).

This was fixed once in #471 but lost during the stack update in #474.

## Fix

```js
isSvg() {
  if (!this.img) return false;
  const pathOnly = this.img.split('?')[0].split('#')[0].toLowerCase();
  return pathOnly.endsWith('.svg') && LOCAL_URL_RE.test(this.img);
},
```

3-line change, no behaviour change for URLs without a query string.

## Downstream

`comes-io/trawl_vue` PR #475 carries an identical hotfix on the `feat/landing-polish-v4` branch. Once this devkit PR merges, the downstream copy can be reverted and picked up from the next stack update.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:coverage` — 941/941 passing, coverage thresholds intact
- [x] `npm run build`

Fixes #3949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG detection: local SVGs with query strings or fragments are correctly inlined; absolute SVG URLs and non‑SVG images are not treated as inline SVGs. Falsy/empty image values are handled safely.

* **Tests**
  * Added tests covering SVG detection across local vs absolute URLs, query parameters, fragments, and non‑SVG cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->