### PR TITLE
feat(home): render icon on the right of title when alignment='right'

### DIFF
--- a/src/modules/home/components/utils/home.content.component.vue
+++ b/src/modules/home/components/utils/home.content.component.vue
@@ -40,7 +40,7 @@
   <div>
     <v-card-title :class="[alignmentClass, variant === 'default' ? 'pa-0' : '']">
       <!-- Level 1: Icon + Title (inline) -->
-      <div v-if="setup.icon || setup.title" :class="['d-flex align-center ga-2 my-0', justifyClass, titleRowReverseClass]">
+      <div v-if="setup.icon || setup.title" :class="['d-flex align-center ga-2 my-0', titleRowClass]">
         <v-icon v-if="setup.icon" size="x-small" :color="themeColor || 'primary'">{{ setup.icon }}</v-icon>
         <span
           v-if="setup.title"
@@ -151,12 +151,26 @@ export default {
       return 'justify-start';
     },
     /**
-     * Reverses DOM order of the icon+title row so the icon sits on the right of
-     * the title when `computedAlignment === 'right'`. Only applies to that row —
-     * must NOT leak onto `v-card-actions` where it would flip the button layout.
+     * Justify + (optional) row-reverse class for the icon+title row only.
+     *
+     * When `computedAlignment === 'right'`, the row is visually reversed via
+     * `flex-row-reverse` so the icon sits on the right side of the title.
+     * Because `flex-row-reverse` also inverts the main axis, `justify-end`
+     * would push items to the LEFT edge, so we use `justify-start` instead —
+     * under a reversed row `flex-start` is the right edge, which is what we
+     * want for a right-aligned block.
+     *
+     * Note: `flex-row-reverse` only changes the visual order, not the DOM
+     * order. Assistive tech still reads `[icon][title]`, so screen-reader
+     * order is preserved.
+     *
+     * Scoped to the title row only — `v-card-actions` keeps using
+     * `justifyClass` so button content order is untouched.
+     * @returns {string} space-separated utility classes
      */
-    titleRowReverseClass() {
-      return this.computedAlignment === 'right' ? 'flex-row-reverse' : '';
+    titleRowClass() {
+      if (this.computedAlignment === 'right') return 'justify-start flex-row-reverse';
+      return this.justifyClass;
     },
     themeColor() {
       if (this.color === 'light') {

--- a/src/modules/home/components/utils/home.content.component.vue
+++ b/src/modules/home/components/utils/home.content.component.vue
@@ -40,7 +40,7 @@
   <div>
     <v-card-title :class="[alignmentClass, variant === 'default' ? 'pa-0' : '']">
       <!-- Level 1: Icon + Title (inline) -->
-      <div v-if="setup.icon || setup.title" :class="['d-flex align-center ga-2 my-0', justifyClass]">
+      <div v-if="setup.icon || setup.title" :class="['d-flex align-center ga-2 my-0', justifyClass, titleRowReverseClass]">
         <v-icon v-if="setup.icon" size="x-small" :color="themeColor || 'primary'">{{ setup.icon }}</v-icon>
         <span
           v-if="setup.title"
@@ -149,6 +149,14 @@ export default {
       if (this.computedAlignment === 'center') return 'justify-center';
       if (this.computedAlignment === 'right') return 'justify-end';
       return 'justify-start';
+    },
+    /**
+     * Reverses DOM order of the icon+title row so the icon sits on the right of
+     * the title when `computedAlignment === 'right'`. Only applies to that row —
+     * must NOT leak onto `v-card-actions` where it would flip the button layout.
+     */
+    titleRowReverseClass() {
+      return this.computedAlignment === 'right' ? 'flex-row-reverse' : '';
     },
     themeColor() {
       if (this.color === 'light') {

--- a/src/modules/home/tests/home.content.component.unit.tests.js
+++ b/src/modules/home/tests/home.content.component.unit.tests.js
@@ -97,6 +97,37 @@ describe('HomeContentComponent', () => {
     expect(actions.classes()).toContain('justify-end');
   });
 
+  it('reverses icon+title row order (flex-row-reverse) when right-aligned so the icon hugs the right edge', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup }, alignment: 'right' },
+      global: globalOpts(vuetify),
+    });
+    const title = wrapper.findComponent({ name: 'VCardTitle' });
+    const iconRow = title.find('div.d-flex');
+    expect(iconRow.classes()).toContain('flex-row-reverse');
+    // must not leak onto v-card-actions (would flip button content order)
+    const actions = wrapper.findComponent({ name: 'VCardActions' });
+    expect(actions.classes()).not.toContain('flex-row-reverse');
+  });
+
+  it('does NOT apply flex-row-reverse to the icon+title row when left-aligned', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup }, alignment: 'left' },
+      global: globalOpts(vuetify),
+    });
+    const iconRow = wrapper.findComponent({ name: 'VCardTitle' }).find('div.d-flex');
+    expect(iconRow.classes()).not.toContain('flex-row-reverse');
+  });
+
+  it('does NOT apply flex-row-reverse to the icon+title row when center-aligned', () => {
+    const wrapper = mount(HomeContentComponent, {
+      props: { setup: { ...baseSetup }, alignment: 'center' },
+      global: globalOpts(vuetify),
+    });
+    const iconRow = wrapper.findComponent({ name: 'VCardTitle' }).find('div.d-flex');
+    expect(iconRow.classes()).not.toContain('flex-row-reverse');
+  });
+
   it('applies text-center and justify-center classes in the DOM when center-aligned', () => {
     const wrapper = mount(HomeContentComponent, {
       props: { setup: { ...baseSetup }, alignment: 'center' },

--- a/src/modules/home/tests/home.content.component.unit.tests.js
+++ b/src/modules/home/tests/home.content.component.unit.tests.js
@@ -89,8 +89,6 @@ describe('HomeContentComponent', () => {
     });
     const title = wrapper.findComponent({ name: 'VCardTitle' });
     expect(title.classes()).toContain('text-right');
-    const iconRow = title.find('div.d-flex');
-    expect(iconRow.classes()).toContain('justify-end');
     const text = wrapper.findComponent({ name: 'VCardText' });
     expect(text.classes()).toContain('text-right');
     const actions = wrapper.findComponent({ name: 'VCardActions' });
@@ -104,7 +102,12 @@ describe('HomeContentComponent', () => {
     });
     const title = wrapper.findComponent({ name: 'VCardTitle' });
     const iconRow = title.find('div.d-flex');
+    // flex-row-reverse visually swaps icon + title
     expect(iconRow.classes()).toContain('flex-row-reverse');
+    // under flex-row-reverse, justify-start = right edge (main axis is inverted)
+    // so we MUST use justify-start (not justify-end) to hug the right edge
+    expect(iconRow.classes()).toContain('justify-start');
+    expect(iconRow.classes()).not.toContain('justify-end');
     // must not leak onto v-card-actions (would flip button content order)
     const actions = wrapper.findComponent({ name: 'VCardActions' });
     expect(actions.classes()).not.toContain('flex-row-reverse');
@@ -117,6 +120,7 @@ describe('HomeContentComponent', () => {
     });
     const iconRow = wrapper.findComponent({ name: 'VCardTitle' }).find('div.d-flex');
     expect(iconRow.classes()).not.toContain('flex-row-reverse');
+    expect(iconRow.classes()).toContain('justify-start');
   });
 
   it('does NOT apply flex-row-reverse to the icon+title row when center-aligned', () => {
@@ -126,6 +130,7 @@ describe('HomeContentComponent', () => {
     });
     const iconRow = wrapper.findComponent({ name: 'VCardTitle' }).find('div.d-flex');
     expect(iconRow.classes()).not.toContain('flex-row-reverse');
+    expect(iconRow.classes()).toContain('justify-center');
   });
 
   it('applies text-center and justify-center classes in the DOM when center-aligned', () => {


### PR DESCRIPTION
## Summary

- What changed: `home.content.component.vue` now applies `flex-row-reverse` to the icon+title flex row when `computedAlignment === 'right'`, via a dedicated `titleRowReverseClass` computed. Visually the icon moves to the right of the title text, hugging the right edge.
- Why: PR #3947 added the `alignment='right'` option, but the DOM order stayed `[icon][title]`. Only the whole flex block was pushed right via `justify-end`, so the icon still rendered on the LEFT of the title. This fixes the visual to match reader expectations.
- Related issues: Fixes #3951

## Scope

- Modules impacted: `home`
- Cross-module impact: `none`
- Risk level: `low`

The reversal is scoped to the icon+title row only — `v-card-actions` intentionally still uses `justifyClass` (not `titleRowReverseClass`) so the button icon layout is untouched.

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` (home.content.component: 12/12 — 3 new tests for flex-row-reverse behavior, positive + 2 negative)
- [x] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: tiny diff, isolated to a single component + its unit test, backwards compatible (default alignment unchanged)
- Follow-up tasks: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed icon and title layout to properly reverse when content is right-aligned

* **Tests**
  * Added tests validating icon/title layout behavior across alignment options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->