### PR TITLE
feat(navigation): support external links in sidenav (#3954)

### DIFF
--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -45,7 +45,7 @@
       <v-divider :color="navColor" :thickness="isGlass ? 1 : 3" :style="isGlass ? { opacity: 0.15 } : {}"></v-divider>
       <!-- Navigation -->
       <v-list :style="listStyle" nav>
-        <v-list-item v-for="item in nav" :key="item.path" :to="item.path">
+        <v-list-item v-for="item in nav" :key="item.path" v-bind="navItemBind(item)">
           <template #prepend>
             <v-icon
               :icon="item.meta.icon"
@@ -62,7 +62,7 @@
       <template #append>
         <!-- Bottom nav items -->
         <v-list v-if="navBottom.length" :style="listStyle" nav>
-          <v-list-item v-for="item in navBottom" :key="item.path" :to="item.path">
+          <v-list-item v-for="item in navBottom" :key="item.path" v-bind="navItemBind(item)">
             <template #prepend>
               <v-icon
                 :icon="item.meta.icon"
@@ -232,6 +232,24 @@ export default {
     coreStore.refreshNav(authStore.isLoggedIn);
   },
   methods: {
+    /**
+     * @desc Build the v-bind props for a sidenav item — external link (`meta.href`)
+     *       resolves to `{ href, target, rel }` so Vuetify renders an anchor tag
+     *       (and never applies the active-route styling), internal routes resolve
+     *       to `{ to }` and keep the default router-link behavior.
+     * @param {Object} item - Nav item from the core store (route record).
+     * @returns {Object} Props bag to spread onto `<v-list-item>`.
+     */
+    navItemBind(item) {
+      if (item?.meta?.href) {
+        return {
+          href: item.meta.href,
+          target: item.meta.target || '_blank',
+          rel: item.meta.rel || 'noopener',
+        };
+      }
+      return { to: item.path };
+    },
     async signout() {
       const authStore = useAuthStore();
       const coreStore = useCoreStore();

--- a/src/modules/core/tests/core.navigation.component.unit.tests.js
+++ b/src/modules/core/tests/core.navigation.component.unit.tests.js
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { setActivePinia, createPinia } from 'pinia';
+
+// Mock vuetify composables used in the component script setup
+vi.mock('vuetify', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useTheme: () => ({
+      name: 'light',
+      current: { colors: { onSurface: '#111111', background: '#ffffff' } },
+    }),
+    useDisplay: () => ({ mobile: { value: false } }),
+  };
+});
+
+// Mock auth store — report logged in + org so the drawer actually renders
+vi.mock('../../auth/stores/auth.store', () => ({
+  useAuthStore: () => ({
+    isLoggedIn: true,
+    user: { currentOrganization: { _id: 'org1', name: 'Org' } },
+    serverConfig: { organizations: { enabled: false } },
+    signout: vi.fn(),
+  }),
+}));
+
+// Mock core store — we inject our own nav + navBottom arrays per test
+const coreStoreState = vi.hoisted(() => ({ nav: [], navBottom: [], refreshNav: () => {} }));
+vi.mock('../stores/core.store', () => ({
+  useCoreStore: () => coreStoreState,
+}));
+
+import CoreNavigation from '../components/core.navigation.component.vue';
+
+/**
+ * @desc Minimal config mock — only the keys the component reads.
+ * @returns {Object}
+ */
+const makeConfig = () => ({
+  app: { title: 'Test App', icon: 'fa-solid fa-cube' },
+  header: { socials: [] },
+  vuetify: {
+    theme: {
+      flat: false,
+      footer: true,
+      navigation: {
+        color: '#000000',
+        background: '#ffffff',
+        glass: false,
+        inset: false,
+        drawer: { floating: false, expand: false, rail: false },
+      },
+    },
+  },
+});
+
+/**
+ * @desc Mount the navigation component with the given nav + navBottom arrays.
+ * @param {Object} opts
+ * @param {Array}  opts.nav - items for the main nav list
+ * @param {Array}  opts.navBottom - items for the bottom nav list
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountNav = ({ nav = [], navBottom = [] } = {}) => {
+  coreStoreState.nav = nav;
+  coreStoreState.navBottom = navBottom;
+  const vuetify = createVuetify({ components, directives });
+  return mount(CoreNavigation, {
+    global: {
+      plugins: [vuetify],
+      mocks: {
+        config: makeConfig(),
+        $vuetify: { display: { mobile: false } },
+      },
+      stubs: {
+        'router-link': { template: '<a><slot /></a>' },
+        // Stub v-navigation-drawer to a plain wrapper — the real one needs a <v-layout> ancestor
+        'v-navigation-drawer': { template: '<div class="v-navigation-drawer"><slot /><slot name="append" /></div>' },
+      },
+    },
+  });
+};
+
+describe('core.navigation.component — navItemBind', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    coreStoreState.nav = [];
+    coreStoreState.navBottom = [];
+  });
+
+  it('returns { to } for a regular internal route', () => {
+    const wrapper = mountNav();
+    const bind = wrapper.vm.navItemBind({ path: '/tasks', meta: { icon: 'fa-solid fa-list', display: true } });
+    expect(bind).toEqual({ to: '/tasks' });
+    expect(bind.href).toBeUndefined();
+  });
+
+  it('returns { href, target, rel } for an external link with meta.href', () => {
+    const wrapper = mountNav();
+    const bind = wrapper.vm.navItemBind({
+      path: '/api-docs',
+      meta: { icon: 'fa-solid fa-book', display: true, href: 'https://api.trawl.me/api/docs' },
+    });
+    expect(bind).toEqual({
+      href: 'https://api.trawl.me/api/docs',
+      target: '_blank',
+      rel: 'noopener',
+    });
+    expect(bind.to).toBeUndefined();
+  });
+
+  it('honors explicit meta.target when provided', () => {
+    const wrapper = mountNav();
+    const bind = wrapper.vm.navItemBind({
+      path: '/docs',
+      meta: { icon: 'i', display: true, href: 'https://example.com', target: '_self' },
+    });
+    expect(bind.target).toBe('_self');
+  });
+
+  it('honors explicit meta.rel when provided', () => {
+    const wrapper = mountNav();
+    const bind = wrapper.vm.navItemBind({
+      path: '/docs',
+      meta: { icon: 'i', display: true, href: 'https://example.com', rel: 'noopener noreferrer' },
+    });
+    expect(bind.rel).toBe('noopener noreferrer');
+  });
+
+  it('falls back to { to } when meta is missing entirely', () => {
+    const wrapper = mountNav();
+    const bind = wrapper.vm.navItemBind({ path: '/nometa' });
+    expect(bind).toEqual({ to: '/nometa' });
+  });
+});
+
+describe('core.navigation.component — template rendering', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders a regular nav item as a router-link (no href attribute)', () => {
+    const wrapper = mountNav({
+      nav: [{ path: '/tasks', name: 'Tasks', meta: { display: true, icon: 'fa-solid fa-list' } }],
+    });
+    const html = wrapper.html();
+    expect(html).toContain('Tasks');
+    // Internal link: no href="http..." attribute
+    expect(html).not.toMatch(/href="https?:\/\//);
+  });
+
+  it('renders an external nav item with href + target + rel', () => {
+    const wrapper = mountNav({
+      nav: [
+        {
+          path: '/api-docs',
+          name: 'API Docs',
+          meta: {
+            display: true,
+            icon: 'fa-solid fa-book',
+            href: 'https://api.trawl.me/api/docs',
+          },
+        },
+      ],
+    });
+    const html = wrapper.html();
+    expect(html).toContain('API Docs');
+    expect(html).toContain('href="https://api.trawl.me/api/docs"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener"');
+  });
+
+  it('renders an external nav item in the navBottom list too', () => {
+    const wrapper = mountNav({
+      navBottom: [
+        {
+          path: '/api-docs',
+          name: 'API Docs',
+          meta: {
+            display: true,
+            icon: 'fa-solid fa-book',
+            href: 'https://api.trawl.me/api/docs',
+            position: 'bottom',
+          },
+        },
+      ],
+    });
+    const html = wrapper.html();
+    expect(html).toContain('API Docs');
+    expect(html).toContain('href="https://api.trawl.me/api/docs"');
+    expect(html).toContain('target="_blank"');
+  });
+
+  it('renders regular navBottom items with router-link (no external href)', () => {
+    const wrapper = mountNav({
+      navBottom: [
+        { path: '/settings', name: 'Settings', meta: { display: true, icon: 'fa-solid fa-gear', position: 'bottom' } },
+      ],
+    });
+    const html = wrapper.html();
+    expect(html).toContain('Settings');
+    expect(html).not.toMatch(/href="https?:\/\//);
+  });
+
+  it('mixes internal and external items in the same list', () => {
+    const wrapper = mountNav({
+      nav: [
+        { path: '/tasks', name: 'Tasks', meta: { display: true, icon: 'fa-solid fa-list' } },
+        {
+          path: '/api-docs',
+          name: 'API Docs',
+          meta: { display: true, icon: 'fa-solid fa-book', href: 'https://api.trawl.me/api/docs' },
+        },
+      ],
+    });
+    const html = wrapper.html();
+    expect(html).toContain('Tasks');
+    expect(html).toContain('API Docs');
+    expect(html).toContain('href="https://api.trawl.me/api/docs"');
+  });
+});

--- a/src/modules/core/tests/core.store.unit.tests.js
+++ b/src/modules/core/tests/core.store.unit.tests.js
@@ -245,6 +245,94 @@ describe('Core Store', () => {
     expect(coreStore.nav.find((r) => r.name === 'admin')).toBeUndefined();
   });
 
+  it('should include external-link routes (meta.href without component) in the nav', () => {
+    const coreStore = useCoreStore();
+    const mockRoutes = [
+      { path: '/', name: 'home', meta: { display: true, icon: 'fa-solid fa-house' } },
+      {
+        path: '/api-docs',
+        name: 'API Docs',
+        meta: { display: true, icon: 'fa-solid fa-book', href: 'https://api.trawl.me/api/docs', target: '_blank' },
+      },
+    ];
+
+    coreStore.init(mockRoutes);
+    coreStore.refreshNav(false);
+
+    const external = coreStore.nav.find((r) => r.name === 'API Docs');
+    expect(external).toBeDefined();
+    expect(external.meta.href).toBe('https://api.trawl.me/api/docs');
+  });
+
+  it('should place external-link routes in navBottom when meta.position is "bottom"', () => {
+    const coreStore = useCoreStore();
+    const mockRoutes = [
+      {
+        path: '/api-docs',
+        name: 'API Docs',
+        meta: {
+          display: true,
+          icon: 'fa-solid fa-book',
+          href: 'https://api.trawl.me/api/docs',
+          position: 'bottom',
+        },
+      },
+    ];
+
+    coreStore.init(mockRoutes);
+    coreStore.refreshNav(false);
+
+    expect(coreStore.nav.find((r) => r.name === 'API Docs')).toBeUndefined();
+    expect(coreStore.navBottom.find((r) => r.name === 'API Docs')).toBeDefined();
+  });
+
+  it('should hide external-link routes when meta.display is false', () => {
+    const coreStore = useCoreStore();
+    const mockRoutes = [
+      {
+        path: '/api-docs',
+        name: 'API Docs',
+        meta: { display: false, icon: 'fa-solid fa-book', href: 'https://api.trawl.me/api/docs' },
+      },
+    ];
+
+    coreStore.init(mockRoutes);
+    coreStore.refreshNav(false);
+
+    expect(coreStore.nav.find((r) => r.name === 'API Docs')).toBeUndefined();
+    expect(coreStore.navBottom.find((r) => r.name === 'API Docs')).toBeUndefined();
+  });
+
+  it('should respect CASL permissions on external-link routes', () => {
+    const coreStore = useCoreStore();
+    const mockRoutes = [
+      {
+        path: '/admin-docs',
+        name: 'Admin Docs',
+        meta: {
+          display: true,
+          icon: 'fa-solid fa-book',
+          href: 'https://admin.example.com/docs',
+          action: 'manage',
+          subject: 'User',
+        },
+      },
+    ];
+
+    coreStore.init(mockRoutes);
+    // User without matching ability
+    mockAbility.rules = [];
+    mockAbility.can.mockReturnValue(false);
+    coreStore.refreshNav(true);
+    expect(coreStore.nav.find((r) => r.name === 'Admin Docs')).toBeUndefined();
+
+    // User with matching ability
+    mockAbility.rules = [{ action: 'manage', subject: 'User' }];
+    mockAbility.can.mockReturnValue(true);
+    coreStore.refreshNav(true);
+    expect(coreStore.nav.find((r) => r.name === 'Admin Docs')).toBeDefined();
+  });
+
   it('should not show guarded routes when not logged in even without ability rules', () => {
     const coreStore = useCoreStore();
     const mockRoutes = [


### PR DESCRIPTION
## Summary

Support external links in the sidenav via route `meta.href`. Routes can now declare an external URL and the nav renders an `<a href target rel>` anchor instead of a router-link, without forking the navigation component downstream.

Closes #3954.

## API

Route record shape:

```js
{
  path: '/api-docs',           // used as key, not navigated
  name: 'API Docs',
  meta: {
    icon: 'fa-solid fa-book',
    display: true,
    href: 'https://api.trawl.me/api/docs', // external URL — triggers anchor mode
    target: '_blank',                        // optional, defaults to '_blank'
    rel: 'noopener',                         // optional, defaults to 'noopener'
    position: 'bottom',                      // optional, works like any nav item
    // action / subject CASL guards also work
  },
}
```

The component adds a `navItemBind(item)` helper used via `v-bind="navItemBind(item)"`:
- item has `meta.href` -> returns `{ href, target, rel }` (Vuetify renders an `<a>`, no active state)
- otherwise -> returns `{ to: item.path }` (unchanged default)

Both `nav` and `navBottom` lists go through the same helper. CASL permissions and the `display` / `icon` filters in `core.store.refreshNav()` work unchanged for external link routes (no store changes needed).

## Why

Downstream projects (trawl_vue next) need to add external sidenav links (API docs) and today the only option is to fork the 250+ line navigation component. This lands the small upstream feature so downstream adds a one-line route record.

## Test plan

- [x] `navItemBind` returns `{ to }` for internal routes, `{ href, target, rel }` for external routes
- [x] Honors explicit `meta.target` and `meta.rel` overrides
- [x] External link renders as `<a href target rel>` in both `nav` and `navBottom` lists
- [x] Regular items still render as router-link (no `href="http..."`)
- [x] `refreshNav()` includes external-link routes when they have `icon` + `display: true`
- [x] `refreshNav()` hides external-link routes with `display: false`
- [x] `refreshNav()` respects CASL permissions on external-link routes
- [x] `refreshNav()` places external-link routes in `navBottom` when `meta.position === 'bottom'`
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 958 passed (10 new component tests + 4 new store tests)
- [x] `npm run test:coverage` — 99.07% statements / 93.93% branches / 98.72% functions / 99.49% lines (above thresholds)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Navigation now supports external links in addition to internal route links
  * External links automatically open in new browser tabs with security protections enabled
  * Navigation configuration remains fully backward-compatible with existing setups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->