### PR TITLE
docs(update-stack): use full npm install after lockfile conflicts

### DIFF
--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -35,12 +35,15 @@ git merge devkit-vue/master
 | `package.json` | `git checkout --ours package.json` then merge upstream version bumps |
 | Downstream-only new files (new modules, helpers, composables, lib additions) | Never delete — these do not exist in the stack, `git checkout --ours <file>` if flagged |
 
-After resolving `package.json`:
+After resolving `package.json`, regenerate the lockfile with a **full install** (not `--package-lock-only`):
 
 ```bash
-npm install --package-lock-only
+rm -rf node_modules package-lock.json
+npm install
 git add package-lock.json
 ```
+
+**Why full install, not `npm install --package-lock-only`:** `--package-lock-only` writes the lockfile without actually installing, so platform-specific optional peer deps (e.g. `@emnapi/core` on darwin) can be omitted from the top-level lockfile tree. The lockfile looks fine locally but `npm ci` on the linux CI runner fails with `Missing: @emnapi/core@X.Y.Z from lock file`. A full `npm install` resolves the cross-platform optional dep tree correctly and validates the install in one go. Do not "optimize" this back to `--package-lock-only`.
 
 Stage all resolved files and complete the merge:
 


### PR DESCRIPTION
## Summary

- What changed: Updated `/update-stack` skill to run `rm -rf node_modules package-lock.json && npm install` (full install) instead of `npm install --package-lock-only` after resolving `package-lock.json` merge conflicts. Added an inline rationale paragraph to prevent regression.
- Why: `--package-lock-only` writes the lockfile without actually installing, so platform-specific optional peer deps (e.g. `@emnapi/core` on darwin) can be omitted from the top-level lockfile tree. The lockfile looks fine locally but `npm ci` on the linux CI runner fails with `Missing: @emnapi/core@X.Y.Z from lock file`. A full install resolves the cross-platform optional dep tree correctly and validates the install in one go.
- Related issues: Closes #3957

## Scope

- Modules impacted: `.claude/skills/update-stack/SKILL.md` only (skill documentation)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint` (no code touched — markdown-only skill edit)
- [x] `npm run test:unit` (no code touched)
- [x] `npm run build` (no code touched)
- [x] Manual checks done: diff audit confirms minimal, focused edit

## Guardrails check

- [x] No secrets or credentials introduced
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed (N/A — doc-only)

## Notes for reviewers

- Security considerations: none (documentation only)
- Mergeability considerations: none (single markdown file, no code churn)
- Follow-up tasks: downstream projects running `/update-stack` will pick up the corrected command automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge-resolving workflow documentation for improved package dependency handling.

* **Bug Fixes**
  * Enhanced lockfile generation process to ensure consistent peer dependency capture across all platforms, preventing build failures in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->