### PR TITLE
fix(images): omit port when api.port is empty or undefined

### DIFF
--- a/src/lib/plugins/images.js
+++ b/src/lib/plugins/images.js
@@ -14,7 +14,8 @@ export default {
       if (size) name = `${name}-${size}`;
       if (operation) name = `${name}-${operation}`;
       name = `${name}.${base[1]}`;
-      return `${api.protocol}://${api.host}:${api.port}/api/uploads/images/${name}`;
+      const port = api.port ? `:${api.port}` : '';
+      return `${api.protocol}://${api.host}${port}/api/uploads/images/${name}`;
     };
   },
 };

--- a/src/lib/plugins/images.js
+++ b/src/lib/plugins/images.js
@@ -6,7 +6,21 @@
  * Plugin setup.
  */
 export default {
+  /**
+   * Install the images plugin — registers `setImages` as a global Vue property.
+   * @param {import('vue').App} app - The Vue application instance.
+   * @returns {void}
+   */
   install: (app) => {
+    /**
+     * Build a URL to an uploaded image, optionally appending a size and/or operation
+     * suffix to the filename. Omits the port segment when `api.port` is empty or undefined.
+     * @param {{protocol: string, host: string, port?: string}} api - API config (protocol, host, optional port).
+     * @param {string} file - Filename with a single extension (e.g. `photo.jpg`).
+     * @param {string|null} size - Size suffix to append before the extension (e.g. `200x200`), or null.
+     * @param {string|null} operation - Operation suffix to append before the extension (e.g. `crop`), or null.
+     * @returns {string} The resolved image URL, or the original `file` if it does not have exactly one extension.
+     */
     app.config.globalProperties.setImages = (api, file, size, operation) => {
       const base = file.split('.');
       if (base.length !== 2) return file;

--- a/src/lib/plugins/tests/images.unit.tests.js
+++ b/src/lib/plugins/tests/images.unit.tests.js
@@ -47,4 +47,14 @@ describe('images plugin', () => {
   it('preserves extension correctly', () => {
     expect(setImages(api, 'avatar.png', '100', null)).toBe('http://localhost:3000/api/uploads/images/avatar-100.png');
   });
+
+  it('omits port when api.port is empty', () => {
+    const apiNoPort = { protocol: 'https', host: 'trawl.me', port: '' };
+    expect(setImages(apiNoPort, 'photo.jpg', null, null)).toBe('https://trawl.me/api/uploads/images/photo.jpg');
+  });
+
+  it('omits port when api.port is undefined', () => {
+    const apiNoPort = { protocol: 'https', host: 'trawl.me' };
+    expect(setImages(apiNoPort, 'photo.jpg', null, null)).toBe('https://trawl.me/api/uploads/images/photo.jpg');
+  });
 });


### PR DESCRIPTION
## Summary

- `setImages` was unconditionally concatenating `:${api.port}`, producing malformed URLs like `https://host:/api/...` on HTTPS deployments where port is empty (standard prod on port 443).
- Broke user avatars everywhere `UserAvatarComponent` is used after the Gravatar refactor (commit a5f4e9ab, #3927), since avatars now route through `setImages`.
- Adds conditional port handling matching the pattern already used in downstream `screenshotUrl.js`. Purely additive/defensive — URLs with a port render identically.

## Test plan

- [x] Lint clean
- [x] Unit tests: 996 passed (73 files), including 2 new cases (empty port string + undefined port)
- [x] Coverage stable (98.99% stmts, 99.51% lines) — no thresholds touched
- [x] Existing tests with `port: '3000'` unchanged and still passing

Fixes #3963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed image URL formation to correctly handle cases where the API port is not specified or empty.

* **Tests**
  * Added tests to verify proper URL construction when API port is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->