### PR TITLE
feat(core): sidenav logo — support SVG/image file + make clickable to homepage

### DIFF
--- a/src/config/defaults/development.config.js
+++ b/src/config/defaults/development.config.js
@@ -5,7 +5,8 @@ export default {
     description: 'Vue - Boilerplate Front : Vuetify, Axios, Jest, Cypress (Alpha) ', // <meta name="description">
     keywords: 'vue, vuetify, axios, jest, cypress', // <meta name="keywords">
     author: 'pierre@devkit.me', // <meta name="author">
-    icon: 'fa-solid fa-earth-americas', // FontAwesome icon class for app icon
+    icon: 'fa-solid fa-earth-americas', // FontAwesome icon class for app icon (sidenav fallback when logoFile unset)
+    logoFile: null, // Optional: path to SVG/PNG (e.g. '/images/logo.svg' in /public) for a branded sidenav logo — takes precedence over icon
     lang: 'en', // html lang attribute — 'en' | 'fr' | 'de' | 'es' | etc.
     url: 'http://localhost:8080', // canonical base URL — override in production
     notFound: {

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -28,11 +28,21 @@
       <!-- Logo / drawer on mobile-->
       <v-list :style="listStyle" nav class="pt-4">
         <v-list-item
+          to="/"
           :style="{ color: navColor }"
         >
           <template #prepend>
+            <v-img
+              v-if="config.app.logoFile"
+              :src="config.app.logoFile"
+              :alt="config.app.title"
+              width="32"
+              height="32"
+              class="ms-n1"
+              inline
+            ></v-img>
             <v-icon
-              v-if="config.app.title && !($vuetify.display.mobile && !isGlass)"
+              v-else-if="config.app.title && !($vuetify.display.mobile && !isGlass)"
               :style="{ color: navColor, opacity: 1 }"
               :icon="config.app.icon"
               size="large"

--- a/src/modules/core/tests/core.navigation.component.unit.tests.js
+++ b/src/modules/core/tests/core.navigation.component.unit.tests.js
@@ -38,10 +38,11 @@ import CoreNavigation from '../components/core.navigation.component.vue';
 
 /**
  * @desc Minimal config mock — only the keys the component reads.
+ * @param {Object} [overrides] - partial overrides merged onto the default config
  * @returns {Object}
  */
-const makeConfig = () => ({
-  app: { title: 'Test App', icon: 'fa-solid fa-cube' },
+const makeConfig = (overrides = {}) => ({
+  app: { title: 'Test App', icon: 'fa-solid fa-cube', logoFile: null, ...(overrides.app || {}) },
   header: { socials: [] },
   vuetify: {
     theme: {
@@ -63,9 +64,10 @@ const makeConfig = () => ({
  * @param {Object} opts
  * @param {Array}  opts.nav - items for the main nav list
  * @param {Array}  opts.navBottom - items for the bottom nav list
+ * @param {Object} [opts.configOverrides] - partial config overrides (e.g. { app: { logoFile: '/logo.svg' } })
  * @returns {import('@vue/test-utils').VueWrapper}
  */
-const mountNav = ({ nav = [], navBottom = [] } = {}) => {
+const mountNav = ({ nav = [], navBottom = [], configOverrides = {} } = {}) => {
   coreStoreState.nav = nav;
   coreStoreState.navBottom = navBottom;
   const vuetify = createVuetify({ components, directives });
@@ -73,7 +75,7 @@ const mountNav = ({ nav = [], navBottom = [] } = {}) => {
     global: {
       plugins: [vuetify],
       mocks: {
-        config: makeConfig(),
+        config: makeConfig(configOverrides),
         $vuetify: { display: { mobile: false } },
       },
       stubs: {
@@ -221,5 +223,48 @@ describe('core.navigation.component — template rendering', () => {
     expect(html).toContain('Tasks');
     expect(html).toContain('API Docs');
     expect(html).toContain('href="https://api.trawl.me/api/docs"');
+  });
+});
+
+describe('core.navigation.component — sidenav logo', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders a v-img when config.app.logoFile is set', () => {
+    const wrapper = mountNav({ configOverrides: { app: { logoFile: '/images/logo.svg' } } });
+    const img = wrapper.findComponent({ name: 'VImg' });
+    expect(img.exists()).toBe(true);
+    expect(img.props('src')).toBe('/images/logo.svg');
+    // FA icon for the app logo must NOT be rendered when logoFile takes precedence
+    const icons = wrapper.findAllComponents({ name: 'VIcon' });
+    const hasAppIcon = icons.some((i) => i.props('icon') === 'fa-solid fa-cube');
+    expect(hasAppIcon).toBe(false);
+  });
+
+  it('exposes the app.title as alt text on the logo image', () => {
+    const wrapper = mountNav({ configOverrides: { app: { logoFile: '/images/logo.svg', title: 'Brand Alpha' } } });
+    const img = wrapper.findComponent({ name: 'VImg' });
+    expect(img.exists()).toBe(true);
+    expect(img.props('alt')).toBe('Brand Alpha');
+  });
+
+  it('falls back to the FA icon when logoFile is unset (back-compat)', () => {
+    const wrapper = mountNav();
+    // No v-img rendered for the logo
+    const img = wrapper.findComponent({ name: 'VImg' });
+    expect(img.exists()).toBe(false);
+  });
+
+  it('wraps the logo v-list-item with to="/" in both branches', () => {
+    // FA branch — first v-list-item is the logo item
+    const wrapperIcon = mountNav();
+    const logoItemIcon = wrapperIcon.findAllComponents({ name: 'VListItem' })[0];
+    expect(logoItemIcon.props('to')).toBe('/');
+
+    // logoFile branch
+    const wrapperImg = mountNav({ configOverrides: { app: { logoFile: '/images/logo.svg' } } });
+    const logoItemImg = wrapperImg.findAllComponents({ name: 'VListItem' })[0];
+    expect(logoItemImg.props('to')).toBe('/');
   });
 });


### PR DESCRIPTION
## Summary

- **What changed:** Sidenav logo (`core.navigation.component.vue`) now supports two rendering modes — `<v-img>` via new optional `config.app.logoFile` (SVG/PNG path), fallback to existing `<v-icon>` via `config.app.icon`. The logo `<v-list-item>` is now a router-link to `/` in both branches, matching the header pattern (`core.header.component.vue:12`).
- **Why:** Downstream projects want branded SVG logos in the sidenav and the "click logo → home" UX already exposed by the header.
- **Related issues:** Closes #3986

## Scope

- Modules impacted: `core` (navigation component + tests), `config/defaults` (doc the new optional field)
- Cross-module impact: `none` — purely additive, `app.logoFile` defaults to `null`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` (1027/1027 passing, coverage 98.99% stmts / 93.68% branches — well above thresholds)
- [x] `npm run build`
- [x] Manual checks done (if applicable) — unit tests cover both branches (logoFile present → `<v-img>` with correct `src` + `alt`; unset → FA icon) and confirm `to="/"` is applied on the logo list-item in both cases

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects — default `logoFile: null` preserves all existing downstream configs
- [x] Tests added or updated when behavior changed — 4 new unit tests + refactored `makeConfig()` helper to accept overrides

## Notes for reviewers

- **Back-compat:** existing downstream configs (pierreb_vue, comes_vue, trawl_vue, montaine_vue) rely on `app.icon` — untouched. New field is opt-in.
- **Template condition:** the existing `!($vuetify.display.mobile && !isGlass)` guard on the FA icon is preserved for the fallback branch; the `<v-img>` branch doesn't inherit that condition because a branded logo should render consistently across breakpoints.
- **Follow-up:** downstream projects wanting an SVG brand asset just drop it in `/public` and set `app.logoFile: '/logo.svg'` — no code change needed on their side.