### PR TITLE
chore(skills): /ui is stack enforcer, drop dead frontend-design link

### DIFF
--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -15,9 +15,7 @@ Design system reference and visual quality guidelines for the Devkit Vue stack.
 
 Invoke `/ui` directly only for pure design tasks (restyle, theme change, layout fix) that don't need the full `/feature` workflow.
 
-## Design thinking
-
-Before any visual work, read the [Anthropic frontend-design guidelines](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) for design thinking, typography, color, motion, spatial composition, and anti-patterns. Apply those principles, then constrain with the stack's design system below.
+This skill is an **enforcer**, not a creative brief. Its job is to keep visual work within the stack's design system (Vuetify 4 + MD3 + theme helpers). Creative direction for net-new identity work (landings, brand, bold aesthetic stances) belongs outside this skill.
 
 ## References
 


### PR DESCRIPTION
## Summary

- `/ui` SKILL.md: drop the "Design thinking" section that pointed at an Anthropic URL (`frontend-design`). The URL was almost never WebFetched in practice and blurred the skill's intent.
- Replace with a one-line clarification: `/ui` is an **enforcer** (Vuetify 4 + MD3 + theme helpers). Creative direction for net-new identity work belongs elsewhere.

Related context: creative direction for landings now lives in the infra-side `/landing-page` skill, which exposes concrete inspiration sources (21st.dev + Anthropic frontend-design) — but that's an infra concern, invisible to this stack.

## Test plan

- [ ] Skill is markdown-only; no runtime impact. `/verify` not strictly required, but harmless.
- [ ] CodeRabbit review
- [ ] CI green