### PR TITLE
fix(admin): prevent toggleUserRole from erasing user fields

### DIFF
--- a/src/modules/admin/stores/admin.store.js
+++ b/src/modules/admin/stores/admin.store.js
@@ -88,7 +88,7 @@ export const useAdminStore = defineStore('admin', {
     async updateUser(params, formData) {
       this.error = null;
       try {
-        const obj = model.clean({ ...this.user, ...formData }, whitelists);
+        const obj = model.clean(formData || {}, whitelists);
         const res = await axios.put(`${apiBase()}/admin/users/${params.id}`, obj);
         assign(this.user, res.data.data);
       } catch (err) {

--- a/src/modules/admin/stores/admin.store.js
+++ b/src/modules/admin/stores/admin.store.js
@@ -85,6 +85,16 @@ export const useAdminStore = defineStore('admin', {
       }
     },
 
+    /**
+     * @desc Update a user via the admin API using a partial patch.
+     * Only the fields present in `formData` (after whitelist sanitization) are sent,
+     * so callers must provide every field they want persisted. Merging with the
+     * local `this.user` placeholder is intentionally avoided to prevent empty
+     * defaults from wiping persisted fields (e.g. role-toggle from the list view).
+     * @param {{ id: string }} params - Route params, must contain the target user id.
+     * @param {Object} [formData] - Partial user payload (whitelisted fields only).
+     * @returns {Promise<void>}
+     */
     async updateUser(params, formData) {
       this.error = null;
       try {

--- a/src/modules/admin/tests/admin.store.unit.tests.js
+++ b/src/modules/admin/tests/admin.store.unit.tests.js
@@ -257,9 +257,22 @@ describe('Admin Store', () => {
 
       axios.put.mockResolvedValueOnce({ data: { data: updatedUser } });
 
-      await store.updateUser({ id: '123' });
+      await store.updateUser({ id: '123' }, { firstName: 'New', email: 'new@example.com' });
 
       expect(store.user).toMatchObject(updatedUser);
+    });
+
+    // Regression: toggleUserRole from the admin users list passes only { roles }
+    // as formData while store.user is the untouched defaultUser() placeholder.
+    // Merging the two would send empty firstName/lastName/email and _.assignIn
+    // on the server wipes those fields in DB. Payload must be the patch alone.
+    it('sends only the provided patch, never the stale store.user placeholder', async () => {
+      const store = useAdminStore();
+      axios.put.mockResolvedValueOnce({ data: { data: { id: '123', roles: ['user', 'admin'] } } });
+
+      await store.updateUser({ id: '123' }, { roles: ['user', 'admin'] });
+
+      expect(axios.put).toHaveBeenCalledWith(expect.stringContaining('/admin/users/123'), { roles: ['user', 'admin'] });
     });
 
     it('should handle error and set error state', async () => {

--- a/src/modules/users/tests/users.store.unit.tests.js
+++ b/src/modules/users/tests/users.store.unit.tests.js
@@ -214,7 +214,7 @@ describe('Users Store', () => {
 
     it('should send only whitelisted fields to the API (not _id, updated, created)', async () => {
       const usersStore = useAdminStore();
-      usersStore.user = {
+      const formData = {
         _id: 'should-not-be-sent',
         firstName: 'John',
         lastName: 'Doe',
@@ -228,9 +228,9 @@ describe('Users Store', () => {
       };
 
       axios.put.mockClear();
-      axios.put.mockResolvedValueOnce({ data: { data: usersStore.user } });
+      axios.put.mockResolvedValueOnce({ data: { data: formData } });
 
-      await usersStore.updateUser({ id: 'should-not-be-sent' });
+      await usersStore.updateUser({ id: 'should-not-be-sent' }, formData);
 
       const sentPayload = axios.put.mock.calls[0][1];
       expect(sentPayload).not.toHaveProperty('_id');

--- a/src/modules/users/tests/users.store.unit.tests.js
+++ b/src/modules/users/tests/users.store.unit.tests.js
@@ -195,7 +195,7 @@ describe('Users Store', () => {
 
       axios.put.mockResolvedValueOnce({ data: { data: updatedUser } });
 
-      await usersStore.updateUser({ id: '789' });
+      await usersStore.updateUser({ id: '789' }, updatedUser);
 
       expect(usersStore.user).toMatchObject(updatedUser);
     });


### PR DESCRIPTION
## Summary

- Fixes #3993 — from `/admin/users`, toggling a role wipes `firstName`/`lastName`/`email` on the target user (destructively, in DB).
- Root cause: `adminStore.updateUser` built the PUT body as `{ ...this.user, ...formData }`. `this.user` is the detail-page state — empty `defaultUser()` placeholder when the admin hasn't visited `/admin/users/:id`. The request sent `firstName: ''`, `email: ''`, etc., and `_.assignIn` on the server dutifully overwrote the real values.
- Fix: `updateUser` now sends only the provided `formData`. The backend already accepts partial updates; the detail-view form emits the full set of editable fields, so nothing breaks there.

## Test plan

- [x] `src/modules/admin/tests/admin.store.unit.tests.js` — new regression test asserts `axios.put` is called with `{ roles: [...] }` only (no stale placeholder leaked).
- [x] `src/modules/users/tests/users.store.unit.tests.js` — existing whitelist-scrubbing test updated to pass `formData` explicitly (it previously encoded the buggy merge behavior).
- [x] `npm run test:unit` → 1028/1028 green.
- [x] `npm run lint` → clean.
- [ ] Manual: from `/admin/users`, toggle a role on a row without opening the detail page first — row retains `firstName`/`lastName`/`email`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined user update handling to send only modified fields rather than merging with existing data, ensuring accurate partial updates.

* **Tests**
  * Enhanced test coverage for user update payloads to verify correct request data handling and field whitelisting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->