### PR TITLE
fix(auth): call backend signout to clear httpOnly TOKEN cookie

### DIFF
--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -201,8 +201,12 @@ export const useAuthStore = defineStore('auth', {
       // Call backend first so the server can clear the httpOnly TOKEN cookie.
       // Swallow any error (older backends may not expose this endpoint, or the
       // server may be unreachable) — the local reset below must still run.
+      // `__isRetryRequest: true` flags this request so the 401 interceptor does
+      // not re-enter signout() and recurse (see src/lib/services/axios.js).
       try {
-        await axios.post(`${api}/${config.api.endPoints.auth}/signout`);
+        await axios.post(`${api}/${config.api.endPoints.auth}/signout`, null, {
+          __isRetryRequest: true,
+        });
       } catch {
         // Never trap the user logged-in on backend failure.
       }

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -189,11 +189,24 @@ export const useAuthStore = defineStore('auth', {
     },
 
     /**
-     * @desc Sign out the current user: clear auth state, abilities, and localStorage.
+     * @desc Sign out the current user: call backend to clear the httpOnly TOKEN cookie,
+     * then reset auth state, abilities, and localStorage. Backend failures never trap the
+     * user as logged-in on the client — local reset always runs.
      * @returns {Promise<void>}
      */
     async signout() {
+      const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
       const coreStore = useCoreStore();
+
+      // Call backend first so the server can clear the httpOnly TOKEN cookie.
+      // Swallow any error (older backends may not expose this endpoint, or the
+      // server may be unreachable) — the local reset below must still run.
+      try {
+        await axios.post(`${api}/${config.api.endPoints.auth}/signout`);
+      } catch {
+        // Never trap the user logged-in on backend failure.
+      }
+
       this.auth = false;
       this.cookieExpire = 0;
       this.user = null;

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -47,7 +47,10 @@ describe('Auth Store', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     localStorage.clear();
-    // Reset mocks
+    // Reset mocks — clear axios call history so per-test `toHaveBeenCalledWith`
+    // assertions don't see calls from previous tests.
+    axios.post.mockReset();
+    axios.get.mockReset();
     mockUpdateAbilities.mockClear();
     // Reset posthog mocks
     posthog.__loaded = false;
@@ -121,7 +124,11 @@ describe('Auth Store', () => {
       axios.post.mockResolvedValueOnce({ data: {} });
       await authStore.signout();
 
-      expect(axios.post).toHaveBeenCalledWith('http://localhost:3000/api/auth/signout');
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:3000/api/auth/signout',
+        null,
+        { __isRetryRequest: true },
+      );
     });
 
     it('should clear local state even when backend signout rejects', async () => {
@@ -141,7 +148,11 @@ describe('Auth Store', () => {
       // Must not throw — signout always resolves so the user is never trapped as logged-in.
       await expect(authStore.signout()).resolves.toBeUndefined();
 
-      expect(axios.post).toHaveBeenCalledWith('http://localhost:3000/api/auth/signout');
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:3000/api/auth/signout',
+        null,
+        { __isRetryRequest: true },
+      );
       expect(authStore.auth).toBe(false);
       expect(authStore.cookieExpire).toBe(0);
       expect(authStore.user).toBe(null);

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -101,6 +101,7 @@ describe('Auth Store', () => {
     localStorage.setItem(`${config.cookie.prefix}CookieExpire`, '12345');
     localStorage.setItem(`${config.cookie.prefix}LastLoginAt`, '2026-01-01T00:00:00Z');
 
+    axios.post.mockResolvedValueOnce({ data: {} });
     await authStore.signout();
 
     expect(authStore.auth).toBe(false);
@@ -109,6 +110,62 @@ describe('Auth Store', () => {
     expect(localStorage.getItem(`${config.cookie.prefix}UserRoles`)).toBe(null);
     expect(localStorage.getItem(`${config.cookie.prefix}CookieExpire`)).toBe(null);
     expect(localStorage.getItem(`${config.cookie.prefix}LastLoginAt`)).toBe(null);
+  });
+
+  describe('signout backend call', () => {
+    it('should call backend signout endpoint with the correct URL', async () => {
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.user = { id: 'u1' };
+
+      axios.post.mockResolvedValueOnce({ data: {} });
+      await authStore.signout();
+
+      expect(axios.post).toHaveBeenCalledWith('http://localhost:3000/api/auth/signout');
+    });
+
+    it('should clear local state even when backend signout rejects', async () => {
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.cookieExpire = Date.now() + 1000;
+      authStore.user = { id: 'u1' };
+      authStore.pendingRequests = [{ id: 'r1' }];
+      localStorage.setItem(`${config.cookie.prefix}UserRoles`, 'user');
+      localStorage.setItem(`${config.cookie.prefix}CookieExpire`, '12345');
+      localStorage.setItem(`${config.cookie.prefix}LastLoginAt`, '2026-01-01T00:00:00Z');
+
+      const backendError = new Error('Backend unreachable');
+      backendError.response = { status: 500 };
+      axios.post.mockRejectedValueOnce(backendError);
+
+      // Must not throw — signout always resolves so the user is never trapped as logged-in.
+      await expect(authStore.signout()).resolves.toBeUndefined();
+
+      expect(axios.post).toHaveBeenCalledWith('http://localhost:3000/api/auth/signout');
+      expect(authStore.auth).toBe(false);
+      expect(authStore.cookieExpire).toBe(0);
+      expect(authStore.user).toBe(null);
+      expect(authStore.pendingRequests).toEqual([]);
+      expect(localStorage.getItem(`${config.cookie.prefix}UserRoles`)).toBe(null);
+      expect(localStorage.getItem(`${config.cookie.prefix}CookieExpire`)).toBe(null);
+      expect(localStorage.getItem(`${config.cookie.prefix}LastLoginAt`)).toBe(null);
+      expect(mockUpdateAbilities).toHaveBeenCalledWith([]);
+    });
+
+    it('should clear local state when backend signout returns 404 (older backend)', async () => {
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.user = { id: 'u1' };
+
+      const notFoundError = new Error('Not found');
+      notFoundError.response = { status: 404 };
+      axios.post.mockRejectedValueOnce(notFoundError);
+
+      await authStore.signout();
+
+      expect(authStore.auth).toBe(false);
+      expect(authStore.user).toBe(null);
+    });
   });
 
   it('should have mail state initialized', () => {


### PR DESCRIPTION
## Summary

- `authStore.signout()` now calls `POST /auth/signout` before resetting local state so the server clears the httpOnly `TOKEN` cookie (JS cannot delete it from the browser).
- Backend errors are swallowed: older backends without the endpoint or transient network failures never trap the user as logged-in on the client — the local Pinia/localStorage/posthog reset always runs.
- Companion to `pierreb-devkit/Node#3502` which adds the endpoint.

## Test plan

- [x] `npm run test:unit` — 1066/1066 pass
- [x] `npm run lint` — clean
- [x] New tests:
  - verifies `axios.post` is called with the correct signout URL
  - verifies local state + localStorage are cleared even when the backend rejects (500)
  - verifies local state is cleared when the backend returns 404 (older backend)

Closes #3502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sign-out reliability: session will now properly clear even if backend communication encounters issues.

* **Tests**
  * Expanded test coverage for sign-out functionality across various failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->