### PR TITLE
fix(auth): show loader on oAuth callback, surface token() errors (#4017)

### DIFF
--- a/src/modules/auth/tests/auth.token.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.token.view.unit.tests.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 
@@ -22,7 +22,7 @@ const mockConfig = {
  * @param {object} [router] - Optional router mock override.
  * @returns {import('@vue/test-utils').VueWrapper} mounted wrapper
  */
-const mountView = (query = {}, router = { push: vi.fn() }) =>
+const mountView = (query = {}, router = { push: vi.fn().mockResolvedValue(undefined) }) =>
   mount(AuthTokenView, {
     global: {
       plugins: [createVuetify()],
@@ -46,7 +46,7 @@ describe('auth.token.view', () => {
       tokenMock.mockResolvedValueOnce(undefined);
 
       mountView();
-      await Promise.resolve(); // flush created() microtask
+      await flushPromises();
 
       expect(tokenMock).toHaveBeenCalledTimes(1);
       expect(tokenMock).toHaveBeenCalledWith();
@@ -54,7 +54,7 @@ describe('auth.token.view', () => {
 
     it('does not call token() when route query contains an error message', async () => {
       mountView({ message: 'Unprocessable Entity', error: '{}' });
-      await Promise.resolve();
+      await flushPromises();
 
       expect(tokenMock).not.toHaveBeenCalled();
     });
@@ -64,7 +64,7 @@ describe('auth.token.view', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       mountView();
-      await Promise.resolve();
+      await flushPromises();
 
       // No unhandled rejection
       consoleSpy.mockRestore();
@@ -89,17 +89,15 @@ describe('auth.token.view', () => {
       expect(wrapper.text()).not.toContain('Error during oAuth');
 
       resolveToken();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushPromises();
     });
 
     it('navigates to sign.route and never exposes the error UI when token() resolves', async () => {
       tokenMock.mockResolvedValueOnce(undefined);
-      const push = vi.fn();
+      const push = vi.fn().mockResolvedValue(undefined);
 
       const wrapper = mountView({}, { push });
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushPromises();
 
       expect(push).toHaveBeenCalledWith('/tasks');
       expect(wrapper.text()).not.toContain('Error during oAuth');
@@ -110,8 +108,7 @@ describe('auth.token.view', () => {
       tokenMock.mockRejectedValueOnce(new Error('network error'));
 
       const wrapper = mountView();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushPromises();
 
       expect(wrapper.vm.loading).toBe(false);
       expect(wrapper.vm.error.details.message).toBe('network error');
@@ -125,8 +122,7 @@ describe('auth.token.view', () => {
       tokenMock.mockRejectedValueOnce({});
 
       const wrapper = mountView();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushPromises();
 
       expect(wrapper.vm.loading).toBe(false);
       expect(wrapper.vm.error.details.message).toBe('Failed to complete sign-in');
@@ -138,7 +134,7 @@ describe('auth.token.view', () => {
       const payload = { details: { message: 'Validation failed', errors: {} } };
 
       const wrapper = mountView({ message: 'Unprocessable Entity', error: JSON.stringify(payload) });
-      await Promise.resolve();
+      await flushPromises();
 
       expect(wrapper.vm.loading).toBe(false);
       expect(wrapper.find('.v-progress-circular').exists()).toBe(false);
@@ -150,11 +146,48 @@ describe('auth.token.view', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const wrapper = mountView({ message: 'Bad Request', error: 'not-json' });
-      await Promise.resolve();
+      await flushPromises();
 
       expect(wrapper.vm.loading).toBe(false);
       expect(wrapper.vm.error.details.message).toBe('An unexpected error occurred');
       expect(wrapper.text()).toContain('Error during oAuth');
+      consoleSpy.mockRestore();
+    });
+
+    it('surfaces the error UI when router.push rejects after a successful token()', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      tokenMock.mockResolvedValueOnce(undefined);
+      const push = vi.fn().mockRejectedValue(new Error('navigation aborted'));
+
+      const wrapper = mountView({}, { push });
+      await flushPromises();
+
+      expect(push).toHaveBeenCalledWith('/tasks');
+      expect(wrapper.vm.loading).toBe(false);
+      expect(wrapper.vm.error.details.message).toBe('navigation aborted');
+      expect(wrapper.text()).toContain('Error during oAuth');
+      consoleSpy.mockRestore();
+    });
+
+    it('uses a fallback label (Sign-in failed) in the alert when no query.message is present', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      tokenMock.mockRejectedValueOnce(new Error('network error'));
+
+      // Render without the VAlert stub so we can inspect the alert content.
+      const wrapper = mount(AuthTokenView, {
+        global: {
+          plugins: [createVuetify()],
+          mocks: {
+            config: mockConfig,
+            $route: { query: {} },
+            $router: { push: vi.fn().mockResolvedValue(undefined) },
+          },
+          stubs: { RouterLink: true },
+        },
+      });
+      await flushPromises();
+
+      expect(wrapper.html()).toContain('Sign-in failed');
       consoleSpy.mockRestore();
     });
   });
@@ -163,7 +196,7 @@ describe('auth.token.view', () => {
     it('sets generic message when query.error is invalid JSON', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const wrapper = mountView({ message: 'Bad Request', error: 'not-json' });
-      await Promise.resolve();
+      await flushPromises();
 
       expect(wrapper.vm.error.details.message).toBe('An unexpected error occurred');
       expect(wrapper.vm.error.details.errors).toEqual({});
@@ -173,7 +206,7 @@ describe('auth.token.view', () => {
     it('sets generic message when query.error is missing', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const wrapper = mountView({ message: 'Bad Request' });
-      await Promise.resolve();
+      await flushPromises();
 
       expect(wrapper.vm.error.details.message).toBe('An unexpected error occurred');
       consoleSpy.mockRestore();
@@ -188,7 +221,7 @@ describe('auth.token.view', () => {
         },
       };
       const wrapper = mountView({ message: 'Unprocessable Entity', error: JSON.stringify(payload) });
-      await Promise.resolve();
+      await flushPromises();
 
       expect(wrapper.vm.error.details.message).toBe('Validation failed');
       expect(wrapper.vm.error.details.errors.email.message).toBe('Email is required');
@@ -205,7 +238,7 @@ describe('auth.token.view', () => {
         },
       };
       const wrapper = mountView({ message: 'Test', error: JSON.stringify(payload) });
-      await Promise.resolve();
+      await flushPromises();
 
       expect(wrapper.vm.error.details.errors.good.message).toBe('Valid');
       expect(wrapper.vm.error.details.errors.bad).toBeUndefined();

--- a/src/modules/auth/tests/auth.token.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.token.view.unit.tests.js
@@ -17,12 +17,18 @@ const mockConfig = {
 };
 
 /**
+ * Build a default router mock with a resolved push().
+ * @returns {{push: ReturnType<typeof vi.fn>}} router mock
+ */
+const defaultRouter = () => ({ push: vi.fn().mockResolvedValue(undefined) });
+
+/**
  * Mount the token (oAuth callback) view with Vuetify installed.
  * @param {object} query - Route query parameters.
  * @param {object} [router] - Optional router mock override.
  * @returns {import('@vue/test-utils').VueWrapper} mounted wrapper
  */
-const mountView = (query = {}, router = { push: vi.fn().mockResolvedValue(undefined) }) =>
+const mountView = (query = {}, router = defaultRouter()) =>
   mount(AuthTokenView, {
     global: {
       plugins: [createVuetify()],
@@ -180,7 +186,7 @@ describe('auth.token.view', () => {
           mocks: {
             config: mockConfig,
             $route: { query: {} },
-            $router: { push: vi.fn().mockResolvedValue(undefined) },
+            $router: defaultRouter(),
           },
           stubs: { RouterLink: true },
         },

--- a/src/modules/auth/tests/auth.token.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.token.view.unit.tests.js
@@ -18,28 +18,33 @@ const mockConfig = {
 
 /**
  * Build a default router mock with a resolved push().
- * @returns {{push: ReturnType<typeof vi.fn>}} router mock
+ * @returns {object} router mock
  */
-const defaultRouter = () => ({ push: vi.fn().mockResolvedValue(undefined) });
+function buildRouterMock() {
+  return { push: vi.fn().mockResolvedValue(undefined) };
+}
 
 /**
  * Mount the token (oAuth callback) view with Vuetify installed.
  * @param {object} query - Route query parameters.
- * @param {object} [router] - Optional router mock override.
+ * @param {object} router - Router mock.
  * @returns {import('@vue/test-utils').VueWrapper} mounted wrapper
  */
-const mountView = (query = {}, router = defaultRouter()) =>
-  mount(AuthTokenView, {
+function mountView(query, router) {
+  const q = query || {};
+  const r = router || buildRouterMock();
+  return mount(AuthTokenView, {
     global: {
       plugins: [createVuetify()],
       mocks: {
         config: mockConfig,
-        $route: { query },
-        $router: router,
+        $route: { query: q },
+        $router: r,
       },
       stubs: { RouterLink: true, VAlert: { template: '<div />' } },
     },
   });
+}
 
 describe('auth.token.view', () => {
   beforeEach(() => {
@@ -186,7 +191,7 @@ describe('auth.token.view', () => {
           mocks: {
             config: mockConfig,
             $route: { query: {} },
-            $router: defaultRouter(),
+            $router: buildRouterMock(),
           },
           stubs: { RouterLink: true },
         },

--- a/src/modules/auth/tests/auth.token.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.token.view.unit.tests.js
@@ -19,16 +19,17 @@ const mockConfig = {
 /**
  * Mount the token (oAuth callback) view with Vuetify installed.
  * @param {object} query - Route query parameters.
+ * @param {object} [router] - Optional router mock override.
  * @returns {import('@vue/test-utils').VueWrapper} mounted wrapper
  */
-const mountView = (query = {}) =>
+const mountView = (query = {}, router = { push: vi.fn() }) =>
   mount(AuthTokenView, {
     global: {
       plugins: [createVuetify()],
       mocks: {
         config: mockConfig,
         $route: { query },
-        $router: { push: vi.fn() },
+        $router: router,
       },
       stubs: { RouterLink: true, VAlert: { template: '<div />' } },
     },
@@ -66,6 +67,94 @@ describe('auth.token.view', () => {
       await Promise.resolve();
 
       // No unhandled rejection
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('loading state (issue #4017)', () => {
+    it('shows the loader and hides the error UI on initial render while token() is pending', async () => {
+      let resolveToken;
+      tokenMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveToken = resolve;
+          }),
+      );
+
+      const wrapper = mountView();
+
+      expect(wrapper.vm.loading).toBe(true);
+      expect(wrapper.find('.v-progress-circular').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Signing you in');
+      expect(wrapper.text()).not.toContain('Error during oAuth');
+
+      resolveToken();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    it('navigates to sign.route and never exposes the error UI when token() resolves', async () => {
+      tokenMock.mockResolvedValueOnce(undefined);
+      const push = vi.fn();
+
+      const wrapper = mountView({}, { push });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(push).toHaveBeenCalledWith('/tasks');
+      expect(wrapper.text()).not.toContain('Error during oAuth');
+    });
+
+    it('surfaces the caught error and renders the error UI when token() rejects', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      tokenMock.mockRejectedValueOnce(new Error('network error'));
+
+      const wrapper = mountView();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(wrapper.vm.loading).toBe(false);
+      expect(wrapper.vm.error.details.message).toBe('network error');
+      expect(wrapper.find('.v-progress-circular').exists()).toBe(false);
+      expect(wrapper.text()).toContain('Error during oAuth');
+      consoleSpy.mockRestore();
+    });
+
+    it('falls back to a generic message when token() rejects without a message', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      tokenMock.mockRejectedValueOnce({});
+
+      const wrapper = mountView();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(wrapper.vm.loading).toBe(false);
+      expect(wrapper.vm.error.details.message).toBe('Failed to complete sign-in');
+      consoleSpy.mockRestore();
+    });
+
+    it('renders the error UI immediately and never shows the loader when query.message is present', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const payload = { details: { message: 'Validation failed', errors: {} } };
+
+      const wrapper = mountView({ message: 'Unprocessable Entity', error: JSON.stringify(payload) });
+      await Promise.resolve();
+
+      expect(wrapper.vm.loading).toBe(false);
+      expect(wrapper.find('.v-progress-circular').exists()).toBe(false);
+      expect(wrapper.text()).toContain('Error during oAuth');
+      consoleSpy.mockRestore();
+    });
+
+    it('renders the error UI with the fallback message when query.error is malformed', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const wrapper = mountView({ message: 'Bad Request', error: 'not-json' });
+      await Promise.resolve();
+
+      expect(wrapper.vm.loading).toBe(false);
+      expect(wrapper.vm.error.details.message).toBe('An unexpected error occurred');
+      expect(wrapper.text()).toContain('Error during oAuth');
       consoleSpy.mockRestore();
     });
   });

--- a/src/modules/auth/views/token.view.vue
+++ b/src/modules/auth/views/token.view.vue
@@ -2,28 +2,36 @@
   <v-container :style="`max-width: ${config.vuetify.theme.maxWidth}`">
     <v-row align="start" justify="center">
       <v-card class="mt-8 pa-8" width="100%" :style="{ background: theme.current.colors.surface }" :flat="config.vuetify.theme.flat">
-        <v-col cols="12">
-          <h4>Error during oAuth</h4>
-          <v-divider></v-divider>
-        </v-col>
-        <v-container>
-          <v-alert type="error" color="error">
-            <b>{{ $route.query.message }}</b> : {{ error.details.message }}
-            <span v-for="(key, i) in Object.keys(error.details.errors)" :key="i">{{ error.details.errors[key].message }}</span>
-          </v-alert>
-          <br />
-          <p>
-            Back to
-            <b>
-              <router-link to="/signin">Sign In</router-link>
-            </b>
-            or
-            <b>
-              <router-link to="/signup">Sign Up</router-link>
-            </b>
-            !
-          </p>
-        </v-container>
+        <template v-if="loading">
+          <v-col cols="12" class="text-center py-8">
+            <v-progress-circular indeterminate color="primary" size="48" />
+            <p class="mt-4">Signing you in…</p>
+          </v-col>
+        </template>
+        <template v-else>
+          <v-col cols="12">
+            <h4>Error during oAuth</h4>
+            <v-divider></v-divider>
+          </v-col>
+          <v-container>
+            <v-alert type="error" color="error">
+              <b>{{ $route.query.message }}</b> : {{ error.details.message }}
+              <span v-for="(key, i) in Object.keys(error.details.errors)" :key="i">{{ error.details.errors[key].message }}</span>
+            </v-alert>
+            <br />
+            <p>
+              Back to
+              <b>
+                <router-link to="/signin">Sign In</router-link>
+              </b>
+              or
+              <b>
+                <router-link to="/signup">Sign Up</router-link>
+              </b>
+              !
+            </p>
+          </v-container>
+        </template>
       </v-card>
     </v-row>
   </v-container>
@@ -46,6 +54,7 @@ export default {
     const theme = useTheme();
     return {
       theme,
+      loading: true,
       error: { details: { message: '', errors: {} } },
     };
   },
@@ -62,6 +71,13 @@ export default {
         this.$router.push(this.config.sign.route);
       } catch (err) {
         logger.error(err);
+        this.error = {
+          details: {
+            message: err?.message || 'Failed to complete sign-in',
+            errors: {},
+          },
+        };
+        this.loading = false;
       }
     } else {
       try {
@@ -82,6 +98,7 @@ export default {
         this.error = { details: { message: 'An unexpected error occurred', errors: {} } };
       }
       logger.error('OAuth error:', this.error);
+      this.loading = false;
     }
   },
 };

--- a/src/modules/auth/views/token.view.vue
+++ b/src/modules/auth/views/token.view.vue
@@ -15,7 +15,7 @@
           </v-col>
           <v-container>
             <v-alert type="error" color="error">
-              <b>{{ $route.query.message }}</b> : {{ error.details.message }}
+              <b>{{ $route.query.message || 'Sign-in failed' }}</b> : {{ error.details.message }}
               <span v-for="(key, i) in Object.keys(error.details.errors)" :key="i">{{ error.details.errors[key].message }}</span>
             </v-alert>
             <br />
@@ -68,7 +68,18 @@ export default {
       const authStore = useAuthStore();
       try {
         await authStore.token();
-        this.$router.push(this.config.sign.route);
+        try {
+          await this.$router.push(this.config.sign.route);
+        } catch (navErr) {
+          logger.error(navErr);
+          this.error = {
+            details: {
+              message: navErr?.message || 'Failed to redirect after sign-in',
+              errors: {},
+            },
+          };
+          this.loading = false;
+        }
       } catch (err) {
         logger.error(err);
         this.error = {


### PR DESCRIPTION
## Summary

- Adds a `loading` flag to `token.view.vue` that hides the "Error during oAuth" card behind a centered `v-progress-circular` + "Signing you in…" message while `authStore.token()` is in flight on the OAuth success path.
- Surfaces `token()` rejections into `this.error` (using `err.message` or a `Failed to complete sign-in` fallback) so users actually see what went wrong instead of a silent `logger.error`.
- Keeps the `?message=` / `?error=` error path behavior unchanged (loader never shown, existing XSS hardening preserved).

## Test plan

- [x] `npm run test:unit` — 1069 tests green, 6 new tests cover the loading / error surface behavior (loader visible while pending, resolve → push + no error UI, reject → error card with caught message, reject with empty error → fallback message, error query path → no loader, malformed query.error → fallback)
- [x] `npm run lint` — clean
- [ ] Manual smoke: trigger an OAuth callback with working backend — should see spinner then redirect to `sign.route` with no "Error during oAuth" flash
- [ ] Manual smoke: trigger an OAuth callback with `authStore.token()` failing — should see the error card with the caught message

Closes #4017