### PR TITLE
fix(auth): tolerate canonical + legacy + plain-string OAuth error payloads

### DIFF
--- a/src/modules/auth/tests/auth.token.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.token.view.unit.tests.js
@@ -215,14 +215,35 @@ describe('auth.token.view', () => {
       consoleSpy.mockRestore();
     });
 
-    it('sets generic message when query.error is malformed JSON', async () => {
+    it('surfaces malformed JSON string as-is via plain-string fallback', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const wrapper = mountView({ message: 'Bad Request', error: '{ malformed json' });
       await flushPromises();
 
-      // Malformed JSON is a non-empty string, so fallback surfaces it as-is (older backend shape).
+      // Malformed JSON is a non-empty string, so the catch branch surfaces it as-is (older backend shape).
       expect(wrapper.vm.error.details.message).toBe('{ malformed json');
       expect(wrapper.vm.error.details.errors).toEqual({});
+      consoleSpy.mockRestore();
+    });
+
+    it('falls back to generic message when JSON parses but has no recognized message field', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const wrapper = mountView({ message: 'Bad Request', error: JSON.stringify({ foo: 'bar' }) });
+      await flushPromises();
+
+      // Never surface the raw JSON body when no string-valued key is recognized — avoids leaking noisy payloads.
+      expect(wrapper.vm.error.details.message).toBe('An unexpected error occurred');
+      expect(wrapper.vm.error.details.errors).toEqual({});
+      consoleSpy.mockRestore();
+    });
+
+    it('ignores non-string description/details.message/message values', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const payload = { description: 42, details: { message: { nested: 'x' } }, message: ['array'] };
+      const wrapper = mountView({ message: 'Bad Request', error: JSON.stringify(payload) });
+      await flushPromises();
+
+      expect(wrapper.vm.error.details.message).toBe('An unexpected error occurred');
       consoleSpy.mockRestore();
     });
 

--- a/src/modules/auth/tests/auth.token.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.token.view.unit.tests.js
@@ -153,14 +153,15 @@ describe('auth.token.view', () => {
       consoleSpy.mockRestore();
     });
 
-    it('renders the error UI with the fallback message when query.error is malformed', async () => {
+    it('renders the error UI and surfaces the plain-string payload when query.error is not JSON (issue #4021)', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const wrapper = mountView({ message: 'Bad Request', error: 'not-json' });
       await flushPromises();
 
       expect(wrapper.vm.loading).toBe(false);
-      expect(wrapper.vm.error.details.message).toBe('An unexpected error occurred');
+      // Tolerant parser (#4021) surfaces plain-string payloads as-is instead of swallowing them.
+      expect(wrapper.vm.error.details.message).toBe('not-json');
       expect(wrapper.text()).toContain('Error during oAuth');
       consoleSpy.mockRestore();
     });
@@ -204,12 +205,23 @@ describe('auth.token.view', () => {
   });
 
   describe('error parsing (XSS hardening)', () => {
-    it('sets generic message when query.error is invalid JSON', async () => {
+    it('surfaces plain-string query.error directly when not valid JSON', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const wrapper = mountView({ message: 'Bad Request', error: 'not-json' });
+      const wrapper = mountView({ message: 'Bad Request', error: 'plain string fallback' });
       await flushPromises();
 
-      expect(wrapper.vm.error.details.message).toBe('An unexpected error occurred');
+      expect(wrapper.vm.error.details.message).toBe('plain string fallback');
+      expect(wrapper.vm.error.details.errors).toEqual({});
+      consoleSpy.mockRestore();
+    });
+
+    it('sets generic message when query.error is malformed JSON', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const wrapper = mountView({ message: 'Bad Request', error: '{ malformed json' });
+      await flushPromises();
+
+      // Malformed JSON is a non-empty string, so fallback surfaces it as-is (older backend shape).
+      expect(wrapper.vm.error.details.message).toBe('{ malformed json');
       expect(wrapper.vm.error.details.errors).toEqual({});
       consoleSpy.mockRestore();
     });
@@ -265,6 +277,48 @@ describe('auth.token.view', () => {
       expect(wrapper.vm.error.details).toBeDefined();
       expect(wrapper.vm.error.details.message).toBe('');
       expect(wrapper.vm.error.details.errors).toEqual({});
+    });
+  });
+
+  describe('error parsing (tolerant multi-shape)', () => {
+    it('prefers canonical description over other keys', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const payload = { description: 'Registration is currently deactivated' };
+      const wrapper = mountView({ message: 'Signup error', error: JSON.stringify(payload) });
+      await flushPromises();
+
+      expect(wrapper.vm.error.details.message).toBe('Registration is currently deactivated');
+      expect(wrapper.vm.error.details.errors).toEqual({});
+      consoleSpy.mockRestore();
+    });
+
+    it('falls back to legacy details.message when no description', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const payload = { details: { message: 'legacy msg' } };
+      const wrapper = mountView({ message: 'Bad Request', error: JSON.stringify(payload) });
+      await flushPromises();
+
+      expect(wrapper.vm.error.details.message).toBe('legacy msg');
+      consoleSpy.mockRestore();
+    });
+
+    it('falls back to top-level message when no description or details.message', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const payload = { message: 'top-level only' };
+      const wrapper = mountView({ message: 'Bad Request', error: JSON.stringify(payload) });
+      await flushPromises();
+
+      expect(wrapper.vm.error.details.message).toBe('top-level only');
+      consoleSpy.mockRestore();
+    });
+
+    it('surfaces plain-string query.error (older backend wire shape)', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const wrapper = mountView({ message: 'Signup error', error: 'Signup error' });
+      await flushPromises();
+
+      expect(wrapper.vm.error.details.message).toBe('Signup error');
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/src/modules/auth/views/token.view.vue
+++ b/src/modules/auth/views/token.view.vue
@@ -63,6 +63,14 @@ export default {
       return this.theme.name;
     },
   },
+  /**
+   * OAuth callback handler. When no route query.message is present, exchange the
+   * authorization code for a session token and redirect to the post-sign route.
+   * When an error message is present, parse the tolerant `error` query payload —
+   * canonical `description`, legacy `details.message`, top-level `message`, or
+   * plain string (older backend wire shape, issue #4021) — for display.
+   * @returns {Promise<void>}
+   */
   async created() {
     if (!this.$route.query.message) {
       const authStore = useAuthStore();
@@ -92,13 +100,22 @@ export default {
       }
     } else {
       const raw = this.$route.query.error;
-      let details = { message: 'An unexpected error occurred', errors: {} };
+      const FALLBACK = 'An unexpected error occurred';
+      /**
+       * Return `value` if it is a non-empty string, otherwise `undefined`.
+       * @param {*} value - Candidate value to type-check.
+       * @returns {string|undefined} The string, or undefined when not usable.
+       */
+      const asNonEmptyString = (value) => (typeof value === 'string' && value.length > 0 ? value : undefined);
+      let details = { message: FALLBACK, errors: {} };
       try {
         const parsed = JSON.parse(raw);
-        const msg = parsed?.description
-          || parsed?.details?.message
-          || parsed?.message
-          || (typeof raw === 'string' ? raw : 'An unexpected error occurred');
+        // Prefer canonical `description`, then legacy `details.message`, then top-level `message`.
+        // Each candidate must itself be a non-empty string — never surface the raw JSON body.
+        const msg = asNonEmptyString(parsed?.description)
+          || asNonEmptyString(parsed?.details?.message)
+          || asNonEmptyString(parsed?.message)
+          || FALLBACK;
         const rawErrors = parsed?.details?.errors;
         const errors = {};
         if (rawErrors && typeof rawErrors === 'object' && !Array.isArray(rawErrors)) {
@@ -110,8 +127,10 @@ export default {
         }
         details = { message: msg, errors };
       } catch {
-        // Fallback: error query was a plain string (older backend) — surface it directly
-        if (typeof raw === 'string' && raw.length > 0) details = { message: raw, errors: {} };
+        // Older backend shape: `error` query param is a plain (non-JSON) string.
+        // Vue's `{{ }}` interpolation auto-escapes HTML, so this is safe to render.
+        const plain = asNonEmptyString(raw);
+        if (plain) details = { message: plain, errors: {} };
       }
       this.error = { details };
       logger.error('OAuth error:', this.error);

--- a/src/modules/auth/views/token.view.vue
+++ b/src/modules/auth/views/token.view.vue
@@ -46,6 +46,16 @@ import { useAuthStore } from '../stores/auth.store';
 import { createLogger } from '../../../lib/helpers/logger';
 
 const logger = createLogger('auth');
+
+/**
+ * Return `value` if it is a non-empty string, otherwise `undefined`.
+ * @param {*} value - Candidate value to type-check.
+ * @returns {string|undefined} The string, or undefined when not usable.
+ */
+function asNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
 /**
  * Component definition.
  */
@@ -101,12 +111,6 @@ export default {
     } else {
       const raw = this.$route.query.error;
       const FALLBACK = 'An unexpected error occurred';
-      /**
-       * Return `value` if it is a non-empty string, otherwise `undefined`.
-       * @param {*} value - Candidate value to type-check.
-       * @returns {string|undefined} The string, or undefined when not usable.
-       */
-      const asNonEmptyString = (value) => (typeof value === 'string' && value.length > 0 ? value : undefined);
       let details = { message: FALLBACK, errors: {} };
       try {
         const parsed = JSON.parse(raw);

--- a/src/modules/auth/views/token.view.vue
+++ b/src/modules/auth/views/token.view.vue
@@ -91,9 +91,14 @@ export default {
         this.loading = false;
       }
     } else {
+      const raw = this.$route.query.error;
+      let details = { message: 'An unexpected error occurred', errors: {} };
       try {
-        const parsed = JSON.parse(this.$route.query.error);
-        const message = typeof parsed?.details?.message === 'string' ? parsed.details.message : 'An unexpected error occurred';
+        const parsed = JSON.parse(raw);
+        const msg = parsed?.description
+          || parsed?.details?.message
+          || parsed?.message
+          || (typeof raw === 'string' ? raw : 'An unexpected error occurred');
         const rawErrors = parsed?.details?.errors;
         const errors = {};
         if (rawErrors && typeof rawErrors === 'object' && !Array.isArray(rawErrors)) {
@@ -103,11 +108,12 @@ export default {
             }
           });
         }
-        this.error = { details: { message, errors } };
-      } catch (parseErr) {
-        logger.error('Failed to parse OAuth error query param:', parseErr);
-        this.error = { details: { message: 'An unexpected error occurred', errors: {} } };
+        details = { message: msg, errors };
+      } catch {
+        // Fallback: error query was a plain string (older backend) — surface it directly
+        if (typeof raw === 'string' && raw.length > 0) details = { message: raw, errors: {} };
       }
+      this.error = { details };
       logger.error('OAuth error:', this.error);
       this.loading = false;
     }


### PR DESCRIPTION
## Summary

- Rewrites `token.view.vue` `created()` error branch to tolerate all three OAuth error wire shapes (canonical `description`, legacy `details.message`, plain-string) with graceful fallback.
- Fixes the observed trawl prod regression where `Unprocessable Entity : An unexpected error occurred` replaced the real backend message after Node #3495 changed the wire shape.
- Additive and backward compatible with the pre-#3513 Node payload, so Node/Vue rollout order does not matter.

## Changes

- `src/modules/auth/views/token.view.vue`: parser now prefers `description` (canonical `responses.error` envelope) then `details.message` (legacy) then `message` (top-level), with a catch branch that surfaces plain-string `query.error` directly.
- `src/modules/auth/tests/auth.token.view.unit.tests.js`: adds four new cases for the tolerant multi-shape parser plus updates the invalid-JSON case to match the new plain-string fallback behavior. Legacy + XSS hardening assertions remain.

## Test plan

- [x] `npm run test:unit` (1071 tests pass, 13 in `auth.token.view`)
- [x] `npm run lint`
- [ ] Post-merge: smoke on trawl prod — signup with backend gate enabled should show the real backend message instead of the generic fallback

Closes #4021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error parsing test coverage for OAuth authentication responses to verify multiple error message formats.

* **Bug Fixes**
  * Improved OAuth error handling to gracefully manage multiple error response formats from backends, with intelligent fallback mechanisms for displaying error messages to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->