### PR TITLE
chore: gitignore graphify-out/ + Graphify doc note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ app/tests/coverage/
 coverage/
 .coveralls.yml
 
+# Graphify code knowledge graph (transient, regen via `graphify update .`)
+graphify-out/
+
 # waos Vue app and assets
 # ======================
 /src/config/index.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,10 @@ Vue 3 + Vuetify 4 stack from Devkit. Standalone frontend or fullstack with Node/
 - E2E only for critical product flows (auth, org onboarding, invite/join); requires Node + Vue + MongoDB running
 - Docker (mongo + node-api): `docker compose -f docker-compose.test.yml up -d`
 
+## Dev tooling
+
+- **Code knowledge graph (optional)**: install Graphify via `uv tool install graphifyy==0.5.0` (Python tool, system-wide). Run `graphify update .` to generate `graph.json` + report under `graphify-out/`. Pin v0.5.0 — Graphify ships fast (5 releases / 48h around 22-23 April 2026), expect breaking changes on minor bumps.
+
 ## Downstream config patterns
 
 - **Config layering**: Module configs (`*.development.config.js`) load first, then global overrides (`{env}.config.js`). Override in global config, not module configs, to avoid stack merge conflicts.


### PR DESCRIPTION
## Summary

Closes #4023.

- Add `graphify-out/` to `.gitignore` (transient code knowledge graph output, regen via `graphify update .`).
- Short note under a new `Dev tooling` section in `CLAUDE.md`: install command (`uv tool install graphifyy==0.5.0`), basic usage, and version-pin rationale (Graphify ships fast, expect breaking changes on minor bumps).

`AGENTS.md` left untouched — it routes to `CLAUDE.md` for tooling docs and isn't a structural mirror.

## Test plan

- [x] `npm run lint` clean
- [x] Diff is doc + gitignore only (no code surface)