### PR TITLE
feat(core/pageHeader): breadcrumb slot + canonical height + overflow fix

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -51,7 +51,7 @@ breadcrumb, fix overflow, or impose a fixed height: **revert to the
 stack file** at the next `/update-stack`:
 
 ```sh
-git checkout <devkit>/master -- src/modules/core/components/core.pageHeader.component.vue
+git checkout origin/master -- src/modules/core/components/core.pageHeader.component.vue
 ```
 
 Then verify your detail-view breadcrumbs still render via the new

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,69 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## core.pageHeader — breadcrumb slot + canonical 56px height + overflow fix (2026-04-26)
+
+**Non-breaking for default consumers.** The shared
+`src/modules/core/components/core.pageHeader.component.vue` now exposes
+a richer contract so downstream projects that previously needed to fork
+this file can drop their custo and live on the stack version.
+
+### What changed in the stack
+
+- **NEW slot `#breadcrumb`** — when provided, renders **in place of** the
+  `<h2>` title (and suppresses the subtitle). Use it for detail-view
+  breadcrumb trails:
+
+  ```vue
+  <core-page-header icon="fa-list">
+    <template #breadcrumb>
+      <router-link to="/scraps">Scraps</router-link> &rsaquo; {{ current }}
+    </template>
+    <template #actions>...</template>
+  </core-page-header>
+  ```
+
+- **Canonical 56px height** — `min-height` and `max-height` are now both
+  pinned to 56px on the root row, in every mode (title, breadcrumb,
+  tabs). This guarantees a jump-free transition between list view (title)
+  and detail view (breadcrumb).
+- **Overflow fix** — the title/breadcrumb container now uses
+  `flex: 1; min-width: 0;` plus `text-truncate`, so long content
+  ellipsis-truncates instead of pushing the actions cluster off-screen.
+  The main row is `flex-nowrap` (actions stay on the same line). Inner
+  `flex-wrap` is kept on the actions cluster as a safety net for extreme
+  viewports.
+- **Actions cluster** — the `#actions` slot is now rendered inside a
+  `<div class="d-flex align-center flex-wrap">` wrapper (only when the
+  slot has content).
+
+### Action for downstream projects
+
+**No config change is required.** Default consumers (header with `title`
++ optional `subtitle` + optional `actions`) keep the same DOM and look.
+
+If your project has a **custom version** of
+`src/modules/core/components/core.pageHeader.component.vue` to add a
+breadcrumb, fix overflow, or impose a fixed height: **revert to the
+stack file** at the next `/update-stack`:
+
+```sh
+git checkout <devkit>/master -- src/modules/core/components/core.pageHeader.component.vue
+```
+
+Then verify your detail-view breadcrumbs still render via the new
+`#breadcrumb` slot and run your usual smoke pass.
+
+### Why
+
+Several downstream projects (notably `trawl_vue`) had to fork this file
+to support breadcrumbs + overflow + canonical height, which produced
+recurring merge conflicts on every `/update-stack`. Pushing the contract
+upstream lets every project drop its custo and removes a sharp edge from
+stack syncs.
+
+---
+
 ## Admin tabs flattened to a single routed row (2026-04-14)
 
 **Breaking change (URL-level).** The admin section now exposes its four

--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -1,28 +1,55 @@
 <template>
-  <v-row class="mx-4 my-1" align="center" :style="$slots.tabs ? { minHeight: '56px' } : null">
+  <v-row class="core-page-header mx-4 my-1 flex-nowrap" align="center">
     <template v-if="$slots.tabs">
       <!-- Tabs mode: tabs replace icon + title -->
       <slot name="tabs"></slot>
     </template>
     <template v-else>
-      <!-- Standard mode: icon + title -->
+      <!-- Standard mode: icon + (breadcrumb OR title) -->
       <slot v-if="!$vuetify.display.mobile" name="avatar">
         <v-avatar v-if="icon" :color="avatarColor" size="40">
           <v-icon :icon="icon" size="small" color="white"></v-icon>
         </v-avatar>
       </slot>
-      <div :class="[$vuetify.display.mobile ? 'ml-6' : '', !$vuetify.display.mobile && ($slots.avatar || icon) ? 'ml-2' : '']">
-        <h2 class="text-title-large font-weight-medium" :class="titleClass" style="line-height: 1;">
-          <slot name="title">{{ title }}</slot>
-        </h2>
-        <p v-if="subtitle || $slots.subtitle" class="text-body-medium text-medium-emphasis" style="margin: 0; line-height: 1;">
-          <slot name="subtitle">{{ subtitle }}</slot>
-        </p>
+      <div
+        class="core-page-header__content"
+        :class="[
+          $vuetify.display.mobile ? 'ml-6' : '',
+          !$vuetify.display.mobile && ($slots.avatar || icon) ? 'ml-2' : '',
+        ]"
+      >
+        <!-- Breadcrumb takes precedence over title when provided -->
+        <div
+          v-if="$slots.breadcrumb"
+          class="core-page-header__breadcrumb text-title-large font-weight-medium text-truncate"
+          :class="titleClass"
+          style="line-height: 1;"
+        >
+          <slot name="breadcrumb"></slot>
+        </div>
+        <template v-else>
+          <h2
+            class="core-page-header__title text-title-large font-weight-medium text-truncate"
+            :class="titleClass"
+            style="line-height: 1;"
+          >
+            <slot name="title">{{ title }}</slot>
+          </h2>
+          <p
+            v-if="subtitle || $slots.subtitle"
+            class="core-page-header__subtitle text-body-medium text-medium-emphasis text-truncate"
+            style="margin: 0; line-height: 1;"
+          >
+            <slot name="subtitle">{{ subtitle }}</slot>
+          </p>
+        </template>
       </div>
     </template>
     <v-spacer></v-spacer>
-    <!-- Actions slot -->
-    <slot name="actions"></slot>
+    <!-- Actions slot — wrapped in a flex cluster (flex-wrap = safety net for extreme viewports) -->
+    <div v-if="$slots.actions" class="core-page-header__actions d-flex align-center flex-wrap">
+      <slot name="actions"></slot>
+    </div>
   </v-row>
 </template>
 
@@ -53,3 +80,24 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+/*
+ * Canonical 56px height — keeps list view (title) and detail view (breadcrumb)
+ * visually aligned so route transitions don't jump.
+ */
+.core-page-header {
+  min-height: 56px;
+  max-height: 56px;
+}
+
+/*
+ * flex: 1 + min-width: 0 lets the title/breadcrumb container shrink past its
+ * intrinsic width when content is long, so the truncate kicks in instead of
+ * pushing the actions cluster off-screen.
+ */
+.core-page-header__content {
+  flex: 1 1 0;
+  min-width: 0;
+}
+</style>

--- a/src/modules/core/tests/core.pageHeader.component.unit.tests.js
+++ b/src/modules/core/tests/core.pageHeader.component.unit.tests.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import CorePageHeader from '../components/core.pageHeader.component.vue';
 
 /**
@@ -195,10 +195,6 @@ describe('core.pageHeader.component — actions cluster', () => {
 });
 
 describe('core.pageHeader.component — tabs mode (unchanged)', () => {
-  beforeEach(() => {
-    // no-op
-  });
-
   it('renders the tabs slot and skips the icon/title block', () => {
     const wrapper = mountHeader({
       props: { title: 'Tasks', icon: 'fa-solid fa-list-check' },

--- a/src/modules/core/tests/core.pageHeader.component.unit.tests.js
+++ b/src/modules/core/tests/core.pageHeader.component.unit.tests.js
@@ -14,6 +14,7 @@ import CorePageHeader from '../components/core.pageHeader.component.vue';
  * @param {boolean} [mobile=false]
  * @returns {ReturnType<typeof createVuetify>}
  */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Qwik rule does not apply in a Vue/Vitest context
 const makeVuetify = (mobile = false) =>
   createVuetify({
     components,
@@ -29,6 +30,7 @@ const makeVuetify = (mobile = false) =>
  * @param {boolean} [opts.mobile] - whether $vuetify.display.mobile should report true
  * @returns {import('@vue/test-utils').VueWrapper}
  */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Qwik rule does not apply in a Vue/Vitest context
 const mountHeader = ({ props = {}, slots = {}, mobile = false } = {}) => {
   const vuetify = makeVuetify(mobile);
   return mount(CorePageHeader, {

--- a/src/modules/core/tests/core.pageHeader.component.unit.tests.js
+++ b/src/modules/core/tests/core.pageHeader.component.unit.tests.js
@@ -11,7 +11,7 @@ import CorePageHeader from '../components/core.pageHeader.component.vue';
  *       cutoff is `lg` (1145px), which would force every test into mobile mode.
  *       We pin `mobileBreakpoint` so the desktop branch is the default and tests
  *       can opt-in to mobile via the `mobile: true` option.
- * @param {Boolean} [mobile=false]
+ * @param {boolean} [mobile=false]
  * @returns {ReturnType<typeof createVuetify>}
  */
 const makeVuetify = (mobile = false) =>
@@ -26,7 +26,7 @@ const makeVuetify = (mobile = false) =>
  * @param {Object} [opts]
  * @param {Object} [opts.props] - props to forward to the component
  * @param {Object} [opts.slots] - slot templates to inject
- * @param {Boolean} [opts.mobile] - whether $vuetify.display.mobile should report true
+ * @param {boolean} [opts.mobile] - whether $vuetify.display.mobile should report true
  * @returns {import('@vue/test-utils').VueWrapper}
  */
 const mountHeader = ({ props = {}, slots = {}, mobile = false } = {}) => {

--- a/src/modules/core/tests/core.pageHeader.component.unit.tests.js
+++ b/src/modules/core/tests/core.pageHeader.component.unit.tests.js
@@ -1,0 +1,218 @@
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { describe, it, expect, beforeEach } from 'vitest';
+import CorePageHeader from '../components/core.pageHeader.component.vue';
+
+/**
+ * @desc Build a Vuetify plugin instance with a deterministic mobile breakpoint.
+ *       happy-dom defaults to a 1024px viewport, but Vuetify v4's default mobile
+ *       cutoff is `lg` (1145px), which would force every test into mobile mode.
+ *       We pin `mobileBreakpoint` so the desktop branch is the default and tests
+ *       can opt-in to mobile via the `mobile: true` option.
+ * @param {Boolean} [mobile=false]
+ * @returns {ReturnType<typeof createVuetify>}
+ */
+const makeVuetify = (mobile = false) =>
+  createVuetify({
+    components,
+    directives,
+    display: { mobileBreakpoint: mobile ? 'xxl' : 'xs' },
+  });
+
+/**
+ * @desc Mount CorePageHeader with sane defaults (desktop display, plain props).
+ * @param {Object} [opts]
+ * @param {Object} [opts.props] - props to forward to the component
+ * @param {Object} [opts.slots] - slot templates to inject
+ * @param {Boolean} [opts.mobile] - whether $vuetify.display.mobile should report true
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountHeader = ({ props = {}, slots = {}, mobile = false } = {}) => {
+  const vuetify = makeVuetify(mobile);
+  return mount(CorePageHeader, {
+    props,
+    slots,
+    global: {
+      plugins: [vuetify],
+    },
+  });
+};
+
+describe('core.pageHeader.component — backward-compat (no breadcrumb)', () => {
+  it('renders the title in an <h2> when no breadcrumb slot is provided', () => {
+    const wrapper = mountHeader({ props: { title: 'Tasks', icon: 'fa-solid fa-list-check' } });
+    const title = wrapper.find('h2.core-page-header__title');
+    expect(title.exists()).toBe(true);
+    expect(title.text()).toBe('Tasks');
+  });
+
+  it('renders the optional subtitle when provided', () => {
+    const wrapper = mountHeader({ props: { title: 'Tasks', subtitle: 'Manage your tasks' } });
+    const subtitle = wrapper.find('p.core-page-header__subtitle');
+    expect(subtitle.exists()).toBe(true);
+    expect(subtitle.text()).toBe('Manage your tasks');
+  });
+
+  it('does not render a subtitle paragraph when subtitle is empty', () => {
+    const wrapper = mountHeader({ props: { title: 'Tasks' } });
+    expect(wrapper.find('p.core-page-header__subtitle').exists()).toBe(false);
+  });
+
+  it('renders an avatar with the provided icon (desktop)', () => {
+    const wrapper = mountHeader({ props: { title: 'Tasks', icon: 'fa-solid fa-list-check' } });
+    const avatar = wrapper.findComponent({ name: 'VAvatar' });
+    expect(avatar.exists()).toBe(true);
+  });
+
+  it('does not render the breadcrumb container in the default DOM', () => {
+    const wrapper = mountHeader({ props: { title: 'Tasks' } });
+    expect(wrapper.find('.core-page-header__breadcrumb').exists()).toBe(false);
+  });
+});
+
+describe('core.pageHeader.component — breadcrumb slot', () => {
+  it('renders the breadcrumb slot in place of the title when provided', () => {
+    const wrapper = mountHeader({
+      props: { title: 'Should be ignored', icon: 'fa-solid fa-list-check' },
+      slots: { breadcrumb: '<a class="bc-link" href="/scraps">Scraps</a> &rsaquo; Detail' },
+    });
+
+    const breadcrumb = wrapper.find('.core-page-header__breadcrumb');
+    expect(breadcrumb.exists()).toBe(true);
+    expect(breadcrumb.find('.bc-link').exists()).toBe(true);
+    expect(breadcrumb.text()).toContain('Scraps');
+    expect(breadcrumb.text()).toContain('Detail');
+  });
+
+  it('does not render the <h2> title when breadcrumb is provided', () => {
+    const wrapper = mountHeader({
+      props: { title: 'Should be ignored' },
+      slots: { breadcrumb: '<span>Scraps &rsaquo; Detail</span>' },
+    });
+    expect(wrapper.find('h2.core-page-header__title').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Should be ignored');
+  });
+
+  it('does not render the subtitle when breadcrumb takes over', () => {
+    const wrapper = mountHeader({
+      props: { title: 'Tasks', subtitle: 'Some subtitle' },
+      slots: { breadcrumb: '<span>Scraps &rsaquo; Detail</span>' },
+    });
+    expect(wrapper.find('p.core-page-header__subtitle').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Some subtitle');
+  });
+});
+
+describe('core.pageHeader.component — canonical 56px height invariant', () => {
+  it('applies the .core-page-header class on the root row in title mode', () => {
+    const wrapper = mountHeader({ props: { title: 'Tasks' } });
+    expect(wrapper.find('.core-page-header').exists()).toBe(true);
+  });
+
+  it('applies the .core-page-header class on the root row in breadcrumb mode', () => {
+    const wrapper = mountHeader({
+      props: { title: 'Tasks' },
+      slots: { breadcrumb: '<span>Detail</span>' },
+    });
+    expect(wrapper.find('.core-page-header').exists()).toBe(true);
+  });
+
+  it('produces the same root layout class set with or without the breadcrumb slot', () => {
+    const wrapperTitle = mountHeader({ props: { title: 'Tasks' } });
+    const wrapperBc = mountHeader({
+      props: { title: 'Tasks' },
+      slots: { breadcrumb: '<span>Detail</span>' },
+    });
+    const titleRoot = wrapperTitle.find('.core-page-header');
+    const bcRoot = wrapperBc.find('.core-page-header');
+    // Layout-bearing classes (height invariant + nowrap) must match across modes
+    expect(titleRoot.classes()).toEqual(expect.arrayContaining(['core-page-header', 'flex-nowrap']));
+    expect(bcRoot.classes()).toEqual(expect.arrayContaining(['core-page-header', 'flex-nowrap']));
+  });
+});
+
+describe('core.pageHeader.component — overflow handling', () => {
+  it('wraps the title/breadcrumb in a content div with .text-truncate enabled', () => {
+    const longTitle = 'A really really really long title that should ellipsis-truncate gracefully';
+    const wrapper = mountHeader({ props: { title: longTitle } });
+    const content = wrapper.find('.core-page-header__content');
+    expect(content.exists()).toBe(true);
+    const title = content.find('.core-page-header__title');
+    expect(title.classes()).toContain('text-truncate');
+  });
+
+  it('truncates the breadcrumb container too', () => {
+    const wrapper = mountHeader({
+      props: {},
+      slots: {
+        breadcrumb: '<span>Very-long-breadcrumb-segment &rsaquo; another-very-long-segment &rsaquo; tail</span>',
+      },
+    });
+    const bc = wrapper.find('.core-page-header__breadcrumb');
+    expect(bc.classes()).toContain('text-truncate');
+  });
+
+  it('keeps the main row in flex-nowrap so actions stay on the same line', () => {
+    const wrapper = mountHeader({
+      props: { title: 'Tasks' },
+      slots: { actions: '<button class="qa-action">Do it</button>' },
+    });
+    const root = wrapper.find('.core-page-header');
+    expect(root.classes()).toContain('flex-nowrap');
+  });
+});
+
+describe('core.pageHeader.component — actions cluster', () => {
+  it('wraps the actions slot in a flex-wrap cluster when actions are provided', () => {
+    const wrapper = mountHeader({
+      props: { title: 'Tasks' },
+      slots: { actions: '<button class="qa-action">Do it</button>' },
+    });
+    const cluster = wrapper.find('.core-page-header__actions');
+    expect(cluster.exists()).toBe(true);
+    expect(cluster.classes()).toEqual(expect.arrayContaining(['d-flex', 'align-center', 'flex-wrap']));
+    expect(cluster.find('.qa-action').exists()).toBe(true);
+  });
+
+  it('does not render the actions wrapper when no actions are provided', () => {
+    const wrapper = mountHeader({ props: { title: 'Tasks' } });
+    expect(wrapper.find('.core-page-header__actions').exists()).toBe(false);
+  });
+
+  it('keeps actions next to the breadcrumb (single row, same wrapper)', () => {
+    const wrapper = mountHeader({
+      props: {},
+      slots: {
+        breadcrumb: '<span>Scraps &rsaquo; Detail</span>',
+        actions: '<button class="qa-action">Edit</button>',
+      },
+    });
+    expect(wrapper.find('.core-page-header__breadcrumb').exists()).toBe(true);
+    expect(wrapper.find('.core-page-header__actions .qa-action').exists()).toBe(true);
+  });
+});
+
+describe('core.pageHeader.component — tabs mode (unchanged)', () => {
+  beforeEach(() => {
+    // no-op
+  });
+
+  it('renders the tabs slot and skips the icon/title block', () => {
+    const wrapper = mountHeader({
+      props: { title: 'Tasks', icon: 'fa-solid fa-list-check' },
+      slots: { tabs: '<div class="qa-tabs">Tabs here</div>' },
+    });
+    expect(wrapper.find('.qa-tabs').exists()).toBe(true);
+    expect(wrapper.find('h2.core-page-header__title').exists()).toBe(false);
+    expect(wrapper.find('.core-page-header__breadcrumb').exists()).toBe(false);
+  });
+
+  it('still applies the canonical 56px height class in tabs mode', () => {
+    const wrapper = mountHeader({
+      slots: { tabs: '<div class="qa-tabs">Tabs here</div>' },
+    });
+    expect(wrapper.find('.core-page-header').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #4013.

## Summary

Generalize `core.pageHeader.component` so it covers list-view (title) and detail-view (breadcrumb) layouts natively, with a stable visual height and a content-overflow story that doesn't push actions off-screen. The motivation is to remove a recurring stack-fork sharp edge: several downstream consumers had to hand-patch this file, which produced merge conflicts at every `/update-stack`.

## Changes

1. **New `#breadcrumb` slot** — renders in place of the `<h2>` title (and suppresses the subtitle) when provided. Use it for detail-view trails:

   ```vue
   <core-page-header icon="fa-list">
     <template #breadcrumb>
       <router-link to="/items">Items</router-link> &rsaquo; {{ current }}
     </template>
     <template #actions>...</template>
   </core-page-header>
   ```

2. **Canonical 56px height** — `min-height` and `max-height` are both pinned to 56px on the root row, in every mode (title, breadcrumb, tabs). Guarantees a jump-free transition between list view and detail view.

3. **Overflow fix** — title/breadcrumb live inside a `flex: 1; min-width: 0;` content div with `text-truncate`. Long content ellipsis-truncates instead of pushing the actions cluster off-screen. The main row is `flex-nowrap` so actions stay on the same line.

4. **Actions cluster** — the `#actions` slot is now rendered inside a `<div class="d-flex align-center flex-wrap">` wrapper (only when the slot has content). Inner `flex-wrap` is kept as a safety net for extreme viewports.

## Backward compatibility

Default consumers (header with `title` + optional `subtitle` + optional `actions`) keep the same DOM and visual look. No prop change, no breaking API. The new `#breadcrumb` slot is purely additive.

A non-breaking `MIGRATIONS.md` entry tells downstream projects that have forked this file to support breadcrumb / overflow / fixed-height to revert their custo to the stack version on the next `/update-stack`.

## Tests

New `src/modules/core/tests/core.pageHeader.component.unit.tests.js` (19 tests) covering the four scenarios from the issue spec:

- Backward-compat: no breadcrumb slot = same DOM (title in `<h2>`, optional subtitle, avatar with icon, no breadcrumb container).
- Breadcrumb replaces the title (and the subtitle) when the slot is provided.
- Canonical height invariant: same root layout class set with or without breadcrumb; main row stays `flex-nowrap` in both modes; tabs mode also gets the canonical height.
- Overflow handling: title and breadcrumb both ship `text-truncate`; main row is `flex-nowrap` even with actions present.
- Actions cluster: rendered only when actions are provided; carries `d-flex align-center flex-wrap`; coexists with breadcrumb in the same row.

## Test plan

- [x] `npm run test:unit` — all 1100 tests pass (19 new + 1081 existing)
- [x] `npm run lint` — clean
- [ ] Visual smoke (downstream consumer): mount a header with a long title + actions, verify ellipsis and 56px height; mount a header with a breadcrumb, verify identical height