### PR TITLE
feat(billing): useMeter composable + extras store actions (PR-V1)

### DIFF
--- a/src/modules/billing/composables/billing.useMeter.js
+++ b/src/modules/billing/composables/billing.useMeter.js
@@ -47,7 +47,7 @@ export function useMeter({ pollIntervalMs = 30000 } = {}) {
    */
   const progress = computed(() => {
     if (quota.value === 0) return 0;
-    return Math.min(100, Math.round((used.value / quota.value) * 100));
+    return Math.max(0, Math.min(100, Math.round((used.value / quota.value) * 100)));
   });
 
   /**
@@ -81,10 +81,15 @@ export function useMeter({ pollIntervalMs = 30000 } = {}) {
   const refresh = () =>
     Promise.all([billingStore.fetchUsageMeter(), billingStore.fetchExtrasBalance()]);
 
+  /** @desc Safe wrapper: catches refresh errors to avoid unhandled Promise rejections. */
+  const safeRefresh = () => refresh().catch(() => {});
+
   onMounted(() => {
-    refresh();
+    void safeRefresh();
     if (pollIntervalMs > 0) {
-      timer = setInterval(refresh, pollIntervalMs);
+      timer = setInterval(() => {
+        void safeRefresh();
+      }, pollIntervalMs);
     }
   });
 

--- a/src/modules/billing/composables/billing.useMeter.js
+++ b/src/modules/billing/composables/billing.useMeter.js
@@ -1,0 +1,121 @@
+/**
+ * Module dependencies.
+ */
+import { computed, onMounted, onUnmounted } from 'vue';
+import { useBillingStore } from '../stores/billing.store';
+
+/**
+ * @desc Composable exposing meter-based usage helpers for compute billing.
+ * Polls the API at a configurable interval and exposes reactive derived state.
+ * @param {Object} [opts] - Options
+ * @param {number} [opts.pollIntervalMs=30000] - Polling interval in ms; set to 0 to disable
+ * @returns {{
+ *   used: import('vue').ComputedRef<number>,
+ *   quota: import('vue').ComputedRef<number>,
+ *   extras: import('vue').ComputedRef<number>,
+ *   breakdown: import('vue').ComputedRef<Object>,
+ *   progress: import('vue').ComputedRef<number>,
+ *   breakdownPercent: import('vue').ComputedRef<Object>,
+ *   totalRemaining: import('vue').ComputedRef<number>,
+ *   refresh: () => Promise<[Object, Object]>,
+ *   purchasePack: (packId: string) => Promise<void>
+ * }}
+ */
+export function useMeter({ pollIntervalMs = 30000 } = {}) {
+  const billingStore = useBillingStore();
+
+  /** @type {import('vue').ComputedRef<number>} Meter credits consumed this week */
+  const used = computed(() => billingStore.usageMeter?.meterUsed ?? 0);
+
+  /** @type {import('vue').ComputedRef<number>} Included weekly quota */
+  const quota = computed(() => billingStore.usageMeter?.meterQuota ?? 0);
+
+  /**
+   * @type {import('vue').ComputedRef<number>}
+   * Extras balance: prefer usageMeter.extrasRemaining, fallback to extrasBalance.balance
+   */
+  const extras = computed(
+    () => billingStore.usageMeter?.extrasRemaining ?? billingStore.extrasBalance?.balance ?? 0,
+  );
+
+  /** @type {import('vue').ComputedRef<Object>} Per-bucket breakdown of meter usage */
+  const breakdown = computed(() => billingStore.usageMeter?.meterBreakdown ?? {});
+
+  /**
+   * @type {import('vue').ComputedRef<number>}
+   * Percentage of weekly quota consumed, clamped to [0, 100].
+   */
+  const progress = computed(() => {
+    if (quota.value === 0) return 0;
+    return Math.min(100, Math.round((used.value / quota.value) * 100));
+  });
+
+  /**
+   * @type {import('vue').ComputedRef<Object>}
+   * Per-bucket share of total used (%). Values sum to ~100 when used > 0.
+   * Returns empty object when used === 0.
+   */
+  const breakdownPercent = computed(() => {
+    const total = used.value;
+    if (total === 0) return {};
+    const bd = breakdown.value;
+    const result = {};
+    for (const [key, val] of Object.entries(bd)) {
+      result[key] = Math.round((val / total) * 100);
+    }
+    return result;
+  });
+
+  /**
+   * @type {import('vue').ComputedRef<number>}
+   * Sum of remaining included quota and extras credits (floor 0).
+   */
+  const totalRemaining = computed(() => Math.max(0, quota.value - used.value) + extras.value);
+
+  let timer = null;
+
+  /**
+   * @desc Trigger parallel refresh of meter usage and extras balance.
+   * @returns {Promise<[Object, Object]>} Both resolved values
+   */
+  const refresh = () =>
+    Promise.all([billingStore.fetchUsageMeter(), billingStore.fetchExtrasBalance()]);
+
+  onMounted(() => {
+    refresh();
+    if (pollIntervalMs > 0) {
+      timer = setInterval(refresh, pollIntervalMs);
+    }
+  });
+
+  onUnmounted(() => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  });
+
+  /**
+   * @desc Initiate purchase of an extras credit pack.
+   * @param {string} packId - Pack identifier to purchase
+   * @returns {Promise<void>}
+   */
+  const purchasePack = (packId) => billingStore.createExtrasCheckout(packId);
+
+  return {
+    used,
+    quota,
+    extras,
+    breakdown,
+    progress,
+    breakdownPercent,
+    totalRemaining,
+    refresh,
+    purchasePack,
+  };
+}
+
+/**
+ * Exports.
+ */
+export default useMeter;

--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -207,14 +207,19 @@ export const useBillingStore = defineStore('billing', {
       try {
         const api = apiBase();
         const successUrl = `${window.location.origin}/billing?packPurchased=1`;
-        const cancelUrl = `${window.location.origin}/billing/pricing`;
+        const cancelUrl = `${window.location.origin}/pricing`;
         const res = await axios.post(`${api}/${config.api.endPoints.billing}/extras/checkout`, {
           packId,
           successUrl,
           cancelUrl,
         });
-        const { url } = res.data.data;
-        if (url) window.location.assign(url);
+        const url = res?.data?.data?.url;
+        if (!url) return;
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'https:') {
+          throw new Error('Rejected non-HTTPS checkout URL');
+        }
+        window.location.assign(parsed.toString());
       } catch (err) {
         console.error(err);
         throw err;

--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -21,6 +21,10 @@ export const useBillingStore = defineStore('billing', {
     subscription: null,
     quota: null,
     loading: false,
+    // meter billing (meterMode: true)
+    usageMeter: null, // { plan, planVersion, weekKey, weekResetAt, meterUsed, meterQuota, meterBreakdown, extrasRemaining, packsAvailable }
+    extrasBalance: null, // { balance, packsAvailable }
+    extrasLedger: { entries: [], total: 0, page: 1, limit: 20 },
   }),
 
   actions: {
@@ -123,6 +127,94 @@ export const useBillingStore = defineStore('billing', {
           throw new Error('Rejected non-HTTPS portal URL');
         }
         window.location.href = parsed.toString();
+      } catch (err) {
+        console.error(err);
+        throw err;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /**
+     * @desc Fetch current meter usage and quota for the active organization.
+     * @returns {Promise<Object>} Resolved usageMeter object
+     */
+    async fetchUsageMeter() {
+      this.loading = true;
+      try {
+        const api = apiBase();
+        const res = await axios.get(`${api}/${config.api.endPoints.billing}/usage`);
+        this.usageMeter = res.data.data;
+        return this.usageMeter;
+      } catch (err) {
+        console.error(err);
+        throw err;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /**
+     * @desc Fetch the extras credit balance for the active organization.
+     * @returns {Promise<Object>} Resolved extrasBalance object
+     */
+    async fetchExtrasBalance() {
+      this.loading = true;
+      try {
+        const api = apiBase();
+        const res = await axios.get(`${api}/${config.api.endPoints.billing}/extras/balance`);
+        this.extrasBalance = res.data.data;
+        return this.extrasBalance;
+      } catch (err) {
+        console.error(err);
+        throw err;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /**
+     * @desc Fetch a paginated ledger of extras credit transactions.
+     * @param {Object} [opts] - Pagination options
+     * @param {number} [opts.page=1] - Page number (1-based)
+     * @param {number} [opts.limit=20] - Page size
+     * @returns {Promise<Object>} Resolved extrasLedger object { entries, total, page, limit }
+     */
+    async fetchExtrasLedger({ page = 1, limit = 20 } = {}) {
+      this.loading = true;
+      try {
+        const api = apiBase();
+        const res = await axios.get(`${api}/${config.api.endPoints.billing}/extras/ledger`, {
+          params: { page, limit },
+        });
+        this.extrasLedger = res.data.data;
+        return this.extrasLedger;
+      } catch (err) {
+        console.error(err);
+        throw err;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /**
+     * @desc Purchase an extras credit pack and redirect to Stripe Checkout.
+     * @param {string} packId - The pack identifier to purchase
+     * @returns {Promise<void>}
+     */
+    async createExtrasCheckout(packId) {
+      this.loading = true;
+      try {
+        const api = apiBase();
+        const successUrl = `${window.location.origin}/billing?packPurchased=1`;
+        const cancelUrl = `${window.location.origin}/billing/pricing`;
+        const res = await axios.post(`${api}/${config.api.endPoints.billing}/extras/checkout`, {
+          packId,
+          successUrl,
+          cancelUrl,
+        });
+        const { url } = res.data.data;
+        if (url) window.location.assign(url);
       } catch (err) {
         console.error(err);
         throw err;

--- a/src/modules/billing/tests/billing.store.unit.tests.js
+++ b/src/modules/billing/tests/billing.store.unit.tests.js
@@ -201,4 +201,189 @@ describe('Billing Store', () => {
       spy.mockRestore();
     });
   });
+
+  describe('fetchUsageMeter', () => {
+    it('should initialize usageMeter and extrasLedger with default state', () => {
+      const store = useBillingStore();
+      expect(store.usageMeter).toBeNull();
+      expect(store.extrasBalance).toBeNull();
+      expect(store.extrasLedger).toEqual({ entries: [], total: 0, page: 1, limit: 20 });
+    });
+
+    it('should fetch and set usageMeter from backend payload', async () => {
+      const store = useBillingStore();
+      const mockMeter = {
+        plan: 'pro',
+        planVersion: 'v1',
+        weekKey: '2026-W18',
+        weekResetAt: '2026-05-04T00:00:00Z',
+        meterUsed: 1234,
+        meterQuota: 8000,
+        meterBreakdown: { scrap: 800, autofix: 434 },
+        extrasRemaining: 12500,
+        packsAvailable: [],
+      };
+      axios.get.mockResolvedValueOnce({ data: { data: mockMeter } });
+      const result = await store.fetchUsageMeter();
+      expect(store.usageMeter).toEqual(mockMeter);
+      expect(result).toEqual(mockMeter);
+      expect(store.loading).toBe(false);
+    });
+
+    it('should call correct API endpoint for fetchUsageMeter', async () => {
+      const store = useBillingStore();
+      axios.get.mockResolvedValueOnce({ data: { data: {} } });
+      await store.fetchUsageMeter();
+      expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/billing/usage'));
+    });
+
+    it('should propagate fetchUsageMeter error to caller', async () => {
+      const store = useBillingStore();
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      axios.get.mockRejectedValueOnce(new Error('Meter fetch failed'));
+      await expect(store.fetchUsageMeter()).rejects.toThrow('Meter fetch failed');
+      expect(spy).toHaveBeenCalled();
+      expect(store.loading).toBe(false);
+      spy.mockRestore();
+    });
+  });
+
+  describe('fetchExtrasBalance', () => {
+    it('should fetch and set extrasBalance', async () => {
+      const store = useBillingStore();
+      const mockBalance = { balance: 5000, packsAvailable: [{ id: 'pack_500', credits: 500 }] };
+      axios.get.mockResolvedValueOnce({ data: { data: mockBalance } });
+      const result = await store.fetchExtrasBalance();
+      expect(store.extrasBalance).toEqual(mockBalance);
+      expect(result).toEqual(mockBalance);
+      expect(store.loading).toBe(false);
+    });
+
+    it('should call correct API endpoint for fetchExtrasBalance', async () => {
+      const store = useBillingStore();
+      axios.get.mockResolvedValueOnce({ data: { data: {} } });
+      await store.fetchExtrasBalance();
+      expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/billing/extras/balance'));
+    });
+
+    it('should propagate fetchExtrasBalance error to caller', async () => {
+      const store = useBillingStore();
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      axios.get.mockRejectedValueOnce(new Error('Balance fetch failed'));
+      await expect(store.fetchExtrasBalance()).rejects.toThrow('Balance fetch failed');
+      expect(spy).toHaveBeenCalled();
+      expect(store.loading).toBe(false);
+      spy.mockRestore();
+    });
+  });
+
+  describe('fetchExtrasLedger', () => {
+    it('should fetch and set extrasLedger with default pagination', async () => {
+      const store = useBillingStore();
+      const mockLedger = {
+        entries: [{ id: 'tx_1', credits: 500, createdAt: '2026-04-01' }],
+        total: 1,
+        page: 1,
+        limit: 20,
+      };
+      axios.get.mockResolvedValueOnce({ data: { data: mockLedger } });
+      const result = await store.fetchExtrasLedger();
+      expect(store.extrasLedger).toEqual(mockLedger);
+      expect(result).toEqual(mockLedger);
+      expect(store.loading).toBe(false);
+    });
+
+    it('should call API endpoint with correct pagination params', async () => {
+      const store = useBillingStore();
+      axios.get.mockResolvedValueOnce({
+        data: { data: { entries: [], total: 0, page: 2, limit: 10 } },
+      });
+      await store.fetchExtrasLedger({ page: 2, limit: 10 });
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/billing/extras/ledger'),
+        expect.objectContaining({ params: { page: 2, limit: 10 } }),
+      );
+    });
+
+    it('should default to page 1 and limit 20', async () => {
+      const store = useBillingStore();
+      axios.get.mockResolvedValueOnce({
+        data: { data: { entries: [], total: 0, page: 1, limit: 20 } },
+      });
+      await store.fetchExtrasLedger();
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/billing/extras/ledger'),
+        expect.objectContaining({ params: { page: 1, limit: 20 } }),
+      );
+    });
+
+    it('should propagate fetchExtrasLedger error to caller', async () => {
+      const store = useBillingStore();
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      axios.get.mockRejectedValueOnce(new Error('Ledger fetch failed'));
+      await expect(store.fetchExtrasLedger()).rejects.toThrow('Ledger fetch failed');
+      expect(spy).toHaveBeenCalled();
+      expect(store.loading).toBe(false);
+      spy.mockRestore();
+    });
+  });
+
+  describe('createExtrasCheckout', () => {
+    it('should call extras checkout API with correct packId and redirect URLs', async () => {
+      const store = useBillingStore();
+      const checkoutUrl = 'https://checkout.stripe.com/extras_session123';
+      axios.post.mockResolvedValueOnce({ data: { data: { url: checkoutUrl } } });
+
+      const originalLocation = window.location;
+      delete window.location;
+      window.location = {
+        ...originalLocation,
+        origin: 'https://app.example.com',
+        assign: vi.fn(),
+      };
+
+      await store.createExtrasCheckout('pack_500');
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining('/billing/extras/checkout'),
+        expect.objectContaining({
+          packId: 'pack_500',
+          successUrl: 'https://app.example.com/billing?packPurchased=1',
+          cancelUrl: 'https://app.example.com/billing/pricing',
+        }),
+      );
+      expect(window.location.assign).toHaveBeenCalledWith(checkoutUrl);
+      expect(store.loading).toBe(false);
+
+      window.location = originalLocation;
+    });
+
+    it('should not redirect when URL is absent in API response', async () => {
+      const store = useBillingStore();
+      axios.post.mockResolvedValueOnce({ data: { data: {} } });
+
+      const originalLocation = window.location;
+      delete window.location;
+      window.location = {
+        ...originalLocation,
+        origin: 'https://app.example.com',
+        assign: vi.fn(),
+      };
+
+      await store.createExtrasCheckout('pack_500');
+      expect(window.location.assign).not.toHaveBeenCalled();
+
+      window.location = originalLocation;
+    });
+
+    it('should propagate createExtrasCheckout error to caller', async () => {
+      const store = useBillingStore();
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      axios.post.mockRejectedValueOnce(new Error('Extras checkout failed'));
+      await expect(store.createExtrasCheckout('pack_500')).rejects.toThrow('Extras checkout failed');
+      expect(spy).toHaveBeenCalled();
+      expect(store.loading).toBe(false);
+      spy.mockRestore();
+    });
+  });
 });

--- a/src/modules/billing/tests/billing.store.unit.tests.js
+++ b/src/modules/billing/tests/billing.store.unit.tests.js
@@ -349,7 +349,7 @@ describe('Billing Store', () => {
         expect.objectContaining({
           packId: 'pack_500',
           successUrl: 'https://app.example.com/billing?packPurchased=1',
-          cancelUrl: 'https://app.example.com/billing/pricing',
+          cancelUrl: 'https://app.example.com/pricing',
         }),
       );
       expect(window.location.assign).toHaveBeenCalledWith(checkoutUrl);
@@ -374,6 +374,28 @@ describe('Billing Store', () => {
       expect(window.location.assign).not.toHaveBeenCalled();
 
       window.location = originalLocation;
+    });
+
+    it('should reject non-HTTPS checkout URLs', async () => {
+      const store = useBillingStore();
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      axios.post.mockResolvedValueOnce({ data: { data: { url: 'http://evil.example.com/checkout' } } });
+
+      const originalLocation = window.location;
+      delete window.location;
+      window.location = {
+        ...originalLocation,
+        origin: 'https://app.example.com',
+        assign: vi.fn(),
+      };
+
+      await expect(store.createExtrasCheckout('pack_500')).rejects.toThrow('Rejected non-HTTPS checkout URL');
+      expect(window.location.assign).not.toHaveBeenCalled();
+      expect(spy).toHaveBeenCalled();
+      expect(store.loading).toBe(false);
+
+      window.location = originalLocation;
+      spy.mockRestore();
     });
 
     it('should propagate createExtrasCheckout error to caller', async () => {

--- a/src/modules/billing/tests/billing.useMeter.unit.tests.js
+++ b/src/modules/billing/tests/billing.useMeter.unit.tests.js
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { useBillingStore } from '../stores/billing.store';
+import { useMeter } from '../composables/billing.useMeter';
+
+// Mock axios (used indirectly via store)
+vi.mock('../../../lib/services/axios', () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
+
+/**
+ * @desc Mount a wrapper component calling useMeter and expose its return value.
+ * @param {Object} [opts] - Options forwarded to useMeter
+ * @returns {{ result: Object, wrapper: import('@vue/test-utils').VueWrapper }}
+ */
+function mountMeter(opts = {}) {
+  let result;
+  const Wrapper = defineComponent({
+    setup() {
+      result = useMeter(opts);
+      return {};
+    },
+    template: '<div />',
+  });
+  const wrapper = mount(Wrapper);
+  return { result, wrapper };
+}
+
+describe('useMeter composable', () => {
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    store = useBillingStore();
+    vi.clearAllMocks();
+    // Stub store actions to no-ops by default
+    vi.spyOn(store, 'fetchUsageMeter').mockResolvedValue(null);
+    vi.spyOn(store, 'fetchExtrasBalance').mockResolvedValue(null);
+    vi.spyOn(store, 'createExtrasCheckout').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── Computed defaults ────────────────────────────────────────────────────
+
+  it('defaults used to 0 when usageMeter is null', () => {
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.used.value).toBe(0);
+  });
+
+  it('defaults quota to 0 when usageMeter is null', () => {
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.quota.value).toBe(0);
+  });
+
+  it('defaults extras to 0 when both usageMeter and extrasBalance are null', () => {
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.extras.value).toBe(0);
+  });
+
+  it('prefers usageMeter.extrasRemaining over extrasBalance.balance for extras', () => {
+    store.usageMeter = { meterUsed: 0, meterQuota: 100, extrasRemaining: 500 };
+    store.extrasBalance = { balance: 999 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.extras.value).toBe(500);
+  });
+
+  it('falls back to extrasBalance.balance when usageMeter.extrasRemaining is absent', () => {
+    store.usageMeter = { meterUsed: 0, meterQuota: 100 };
+    store.extrasBalance = { balance: 250 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.extras.value).toBe(250);
+  });
+
+  it('defaults breakdown to empty object when usageMeter is null', () => {
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.breakdown.value).toEqual({});
+  });
+
+  // ── progress ─────────────────────────────────────────────────────────────
+
+  it('progress is 0 when quota is 0', () => {
+    store.usageMeter = { meterUsed: 500, meterQuota: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.progress.value).toBe(0);
+  });
+
+  it('progress computes correct percentage', () => {
+    store.usageMeter = { meterUsed: 2000, meterQuota: 8000 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.progress.value).toBe(25);
+  });
+
+  it('progress is clamped to 100 when over quota', () => {
+    store.usageMeter = { meterUsed: 10000, meterQuota: 8000 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.progress.value).toBe(100);
+  });
+
+  it('progress is clamped to 0 minimum', () => {
+    store.usageMeter = { meterUsed: 0, meterQuota: 8000 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.progress.value).toBe(0);
+  });
+
+  it('progress rounds to nearest integer', () => {
+    store.usageMeter = { meterUsed: 1, meterQuota: 3 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.progress.value).toBe(33);
+  });
+
+  // ── breakdownPercent ──────────────────────────────────────────────────────
+
+  it('breakdownPercent returns empty object when used is 0', () => {
+    store.usageMeter = { meterUsed: 0, meterQuota: 8000, meterBreakdown: { scrap: 0, autofix: 0 } };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.breakdownPercent.value).toEqual({});
+  });
+
+  it('breakdownPercent sums to ~100 across buckets', () => {
+    store.usageMeter = {
+      meterUsed: 1200,
+      meterQuota: 8000,
+      meterBreakdown: { scrap: 800, autofix: 400 },
+    };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    const bp = result.breakdownPercent.value;
+    const sum = Object.values(bp).reduce((a, b) => a + b, 0);
+    // Due to Math.round rounding, allow ±1
+    expect(sum).toBeGreaterThanOrEqual(99);
+    expect(sum).toBeLessThanOrEqual(101);
+  });
+
+  it('breakdownPercent computes correct per-bucket percent', () => {
+    store.usageMeter = {
+      meterUsed: 1000,
+      meterQuota: 8000,
+      meterBreakdown: { scrap: 700, autofix: 300 },
+    };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.breakdownPercent.value.scrap).toBe(70);
+    expect(result.breakdownPercent.value.autofix).toBe(30);
+  });
+
+  // ── totalRemaining ────────────────────────────────────────────────────────
+
+  it('totalRemaining is quota - used + extras', () => {
+    store.usageMeter = { meterUsed: 2000, meterQuota: 8000, extrasRemaining: 500 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.totalRemaining.value).toBe(6500);
+  });
+
+  it('totalRemaining floors at 0 when used exceeds quota (no extras)', () => {
+    store.usageMeter = { meterUsed: 10000, meterQuota: 8000, extrasRemaining: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.totalRemaining.value).toBe(0);
+  });
+
+  it('totalRemaining uses extras when quota is exhausted', () => {
+    store.usageMeter = { meterUsed: 8000, meterQuota: 8000, extrasRemaining: 1500 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.totalRemaining.value).toBe(1500);
+  });
+
+  // ── refresh ────────────────────────────────────────────────────────────────
+
+  it('refresh calls fetchUsageMeter and fetchExtrasBalance in parallel', async () => {
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    store.fetchUsageMeter.mockClear();
+    store.fetchExtrasBalance.mockClear();
+
+    const promise = result.refresh();
+    // Both must be called before awaiting (parallel)
+    expect(store.fetchUsageMeter).toHaveBeenCalledTimes(1);
+    expect(store.fetchExtrasBalance).toHaveBeenCalledTimes(1);
+    await promise;
+  });
+
+  it('refresh is called on mount', async () => {
+    mountMeter({ pollIntervalMs: 0 });
+    // onMounted fires synchronously in test environment with @vue/test-utils
+    expect(store.fetchUsageMeter).toHaveBeenCalled();
+    expect(store.fetchExtrasBalance).toHaveBeenCalled();
+  });
+
+  // ── polling ────────────────────────────────────────────────────────────────
+
+  it('polling refreshes on every interval tick', async () => {
+    vi.useFakeTimers();
+    const { wrapper } = mountMeter({ pollIntervalMs: 5000 });
+
+    // Reset call counts from initial mount refresh
+    store.fetchUsageMeter.mockClear();
+    store.fetchExtrasBalance.mockClear();
+
+    vi.advanceTimersByTime(5000);
+    expect(store.fetchUsageMeter).toHaveBeenCalledTimes(1);
+    expect(store.fetchExtrasBalance).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5000);
+    expect(store.fetchUsageMeter).toHaveBeenCalledTimes(2);
+    expect(store.fetchExtrasBalance).toHaveBeenCalledTimes(2);
+
+    wrapper.unmount();
+  });
+
+  it('polling is disabled when pollIntervalMs is 0', async () => {
+    vi.useFakeTimers();
+    mountMeter({ pollIntervalMs: 0 });
+
+    store.fetchUsageMeter.mockClear();
+    store.fetchExtrasBalance.mockClear();
+
+    vi.advanceTimersByTime(60000);
+    expect(store.fetchUsageMeter).not.toHaveBeenCalled();
+    expect(store.fetchExtrasBalance).not.toHaveBeenCalled();
+  });
+
+  it('clears polling interval on unmount', () => {
+    vi.useFakeTimers();
+    const { wrapper } = mountMeter({ pollIntervalMs: 5000 });
+
+    store.fetchUsageMeter.mockClear();
+    store.fetchExtrasBalance.mockClear();
+
+    wrapper.unmount();
+    vi.advanceTimersByTime(10000);
+
+    // No further calls after unmount
+    expect(store.fetchUsageMeter).not.toHaveBeenCalled();
+    expect(store.fetchExtrasBalance).not.toHaveBeenCalled();
+  });
+
+  // ── purchasePack ───────────────────────────────────────────────────────────
+
+  it('purchasePack delegates to store.createExtrasCheckout', async () => {
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    await result.purchasePack('pack_500');
+    expect(store.createExtrasCheckout).toHaveBeenCalledWith('pack_500');
+  });
+
+  it('purchasePack propagates store errors to caller', async () => {
+    store.createExtrasCheckout.mockRejectedValueOnce(new Error('Checkout failed'));
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    await expect(result.purchasePack('pack_500')).rejects.toThrow('Checkout failed');
+  });
+});

--- a/src/modules/billing/tests/billing.useMeter.unit.tests.js
+++ b/src/modules/billing/tests/billing.useMeter.unit.tests.js
@@ -102,7 +102,7 @@ describe('useMeter composable', () => {
   });
 
   it('progress is clamped to 0 minimum', () => {
-    store.usageMeter = { meterUsed: 0, meterQuota: 8000 };
+    store.usageMeter = { meterUsed: -100, meterQuota: 8000 };
     const { result } = mountMeter({ pollIntervalMs: 0 });
     expect(result.progress.value).toBe(0);
   });


### PR DESCRIPTION
Closes part of #4036 — PR-V1: useMeter store foundation

## Changes

- **`stores/billing.store.js`** — new state fields (`usageMeter`, `extrasBalance`, `extrasLedger`) + 4 new actions:
  - `fetchUsageMeter()` — GET `/api/billing/usage` → `usageMeter`
  - `fetchExtrasBalance()` — GET `/api/billing/extras/balance` → `extrasBalance`
  - `fetchExtrasLedger({page, limit})` — GET `/api/billing/extras/ledger` → `extrasLedger`
  - `createExtrasCheckout(packId)` — POST `/api/billing/extras/checkout` → redirect
- **`composables/billing.useMeter.js`** (new) — computed `used`, `quota`, `extras`, `breakdown`, `progress` (0-100 clamped), `breakdownPercent` (~100% sum), `totalRemaining`, auto-poll via `onMounted`/`onUnmounted`, `purchasePack`
- **`tests/billing.useMeter.unit.tests.js`** (new) — 25 tests
- **`tests/billing.store.unit.tests.js`** (extended) — 15 new tests for the 4 new actions

## Backward compat

`useQuota`, `fetchUsage`, and legacy store state are **untouched**. All 77 pre-existing tests still pass.

## Test results

- 108 tests passing (8 files), 0 failures
- Lint clean

## Checklist

- [x] A. billing.store.js — new state + 4 actions
- [x] B. billing.useMeter.js composable (new)
- [x] C. useQuota legacy untouched
- [x] D. Tests: billing.useMeter.unit.tests.js (new), billing.store.unit.tests.js (extended), billing.useQuota.unit.tests.js (regression green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Meter-based compute billing now available with real-time usage tracking, quota monitoring, progress visualization, and per-bucket usage breakdown.
  * Purchase additional compute quota with automated checkout process and balance tracking.

* **Tests**
  * Comprehensive unit test coverage added for billing meter tracking, quota management, and purchase functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->