### PR TITLE
feat(billing): meter UI primitives — progress + breakdown + ledger (PR-V2)

### DIFF
--- a/src/modules/billing/components/billing.extrasLedger.component.vue
+++ b/src/modules/billing/components/billing.extrasLedger.component.vue
@@ -1,0 +1,224 @@
+<!--
+  BillingExtrasLedgerComponent
+  ==============================
+  Paginated table of extras credit ledger entries (admin / debug surface).
+  Delegates pagination to the parent via `update:page` emit so the parent
+  can call `fetchExtrasLedger({ page, limit })` as needed.
+
+  USAGE:
+  <billingExtrasLedgerComponent
+    :entries="ledger.entries"
+    :total="ledger.total"
+    :page="ledger.page"
+    :limit="ledger.limit"
+    @update:page="onPageChange"
+  />
+
+  PROPS:
+  - entries (Array, required)   : ledger entry objects from store
+  - total   (Number, required)  : total entry count (for pagination)
+  - page    (Number, default 1) : current page (1-based)
+  - limit   (Number, default 20): rows per page
+
+  EVENTS:
+  - update:page (Number) : new page number requested by the user
+-->
+<template>
+  <div class="billing-extras-ledger">
+    <!-- Empty state -->
+    <div
+      v-if="entries.length === 0"
+      class="text-caption text-medium-emphasis text-center py-6"
+    >
+      No ledger entries yet
+    </div>
+
+    <template v-else>
+      <v-data-table
+        :headers="headers"
+        :items="entries"
+        :items-length="total"
+        :items-per-page="limit"
+        :page="page"
+        hide-default-footer
+        density="compact"
+        class="billing-extras-ledger__table"
+      >
+        <!-- at column -->
+        <template #[`item.at`]="{ item }">
+          <span class="text-caption">{{ formatDate(item.at) }}</span>
+        </template>
+
+        <!-- kind column -->
+        <template #[`item.kind`]="{ item }">
+          <v-chip
+            :color="kindColor(item.kind)"
+            variant="tonal"
+            size="small"
+            density="compact"
+          >
+            {{ item.kind }}
+          </v-chip>
+        </template>
+
+        <!-- amount column -->
+        <template #[`item.amount`]="{ item }">
+          <span
+            class="font-weight-medium"
+            :style="{ fontFamily: 'monospace', color: item.amount >= 0 ? 'rgb(var(--v-theme-success))' : 'rgb(var(--v-theme-error))' }"
+          >
+            {{ item.amount >= 0 ? '+' : '' }}{{ item.amount }}
+          </span>
+        </template>
+
+        <!-- refId / historyId column — truncated with native title tooltip -->
+        <template #[`item.refId`]="{ item }">
+          <span
+            class="text-caption text-truncate"
+            style="max-width: 100px; display: inline-block"
+            :title="item.refId || item.historyId || '—'"
+          >
+            {{ truncate(item.refId || item.historyId) }}
+          </span>
+        </template>
+
+        <!-- stripeSessionId column — truncated with native title tooltip -->
+        <template #[`item.stripeSessionId`]="{ item }">
+          <span
+            class="text-caption text-truncate"
+            style="max-width: 100px; display: inline-block"
+            :title="item.stripeSessionId || '—'"
+          >
+            {{ truncate(item.stripeSessionId) }}
+          </span>
+        </template>
+      </v-data-table>
+
+      <!-- Pagination -->
+      <div v-if="pageCount > 1" class="d-flex justify-center mt-2">
+        <v-pagination
+          :model-value="page"
+          :length="pageCount"
+          density="compact"
+          @update:model-value="$emit('update:page', $event)"
+        />
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+/** Kind → Vuetify color token mapping. */
+const KIND_COLORS = {
+  topup: 'success',
+  debit: 'warning',
+  refund: 'info',
+  expiration: 'default',
+  adjustment: 'primary',
+};
+
+/**
+ * Component definition.
+ */
+export default {
+  name: 'BillingExtrasLedgerComponent',
+
+  props: {
+    /**
+     * @desc Array of ledger entry objects.
+     * Each entry: { at, kind, amount, refId?, historyId?, stripeSessionId? }
+     */
+    entries: {
+      type: Array,
+      required: true,
+    },
+    /**
+     * @desc Total number of entries across all pages (used to compute pagination).
+     */
+    total: {
+      type: Number,
+      required: true,
+    },
+    /**
+     * @desc Current page (1-based).
+     */
+    page: {
+      type: Number,
+      default: 1,
+    },
+    /**
+     * @desc Rows per page.
+     */
+    limit: {
+      type: Number,
+      default: 20,
+    },
+  },
+
+  emits: ['update:page'],
+
+  data() {
+    return {
+      headers: [
+        { title: 'Date', key: 'at', sortable: false },
+        { title: 'Kind', key: 'kind', sortable: false },
+        { title: 'Amount', key: 'amount', sortable: false, align: 'end' },
+        { title: 'Ref / History', key: 'refId', sortable: false },
+        { title: 'Stripe session', key: 'stripeSessionId', sortable: false },
+      ],
+    };
+  },
+
+  computed: {
+    /**
+     * @desc Total number of pages.
+     * @returns {number}
+     */
+    pageCount() {
+      if (this.limit <= 0) return 1;
+      return Math.ceil(this.total / this.limit);
+    },
+  },
+
+  methods: {
+    /**
+     * @desc Format an ISO date string to a human-readable local date+time.
+     * @param {string} value - ISO 8601 date string
+     * @returns {string}
+     */
+    formatDate(value) {
+      if (!value) return '—';
+      try {
+        return new Date(value).toLocaleString(undefined, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+      } catch {
+        return value;
+      }
+    },
+
+    /**
+     * @desc Resolve Vuetify color token for a given ledger entry kind.
+     * @param {string} kind - Entry kind (topup, debit, refund, expiration, adjustment)
+     * @returns {string} Vuetify color token
+     */
+    kindColor(kind) {
+      return KIND_COLORS[kind] ?? 'default';
+    },
+
+    /**
+     * @desc Truncate a string to 12 characters with ellipsis.
+     * @param {string|null|undefined} value
+     * @returns {string}
+     */
+    truncate(value) {
+      if (!value) return '—';
+      return value.length > 12 ? `${value.slice(0, 12)}…` : value;
+    },
+  },
+};
+</script>

--- a/src/modules/billing/components/billing.extrasLedger.component.vue
+++ b/src/modules/billing/components/billing.extrasLedger.component.vue
@@ -65,7 +65,8 @@
         <template #[`item.amount`]="{ item }">
           <span
             class="font-weight-medium"
-            :style="{ fontFamily: 'monospace', color: item.amount >= 0 ? 'rgb(var(--v-theme-success))' : 'rgb(var(--v-theme-error))' }"
+            :class="item.amount >= 0 ? 'text-success' : 'text-error'"
+            style="font-family: monospace"
           >
             {{ item.amount >= 0 ? '+' : '' }}{{ item.amount }}
           </span>

--- a/src/modules/billing/components/billing.meterBreakdownChart.component.vue
+++ b/src/modules/billing/components/billing.meterBreakdownChart.component.vue
@@ -1,0 +1,135 @@
+<!--
+  BillingMeterBreakdownChartComponent
+  =====================================
+  Horizontal stacked-bar showing per-bucket meter usage.
+  Buckets with 0 value are not rendered. Colors cycle through
+  Vuetify theme tokens for deterministic visual mapping.
+
+  USAGE:
+  <billingMeterBreakdownChartComponent :breakdown="{ scrap: 100, autofix: 50, wizard: 200 }" />
+  <billingMeterBreakdownChartComponent :breakdown="breakdown" :total="500" />
+
+  PROPS:
+  - breakdown (Object, required) : map of bucket → credit count (e.g. { scrap: 100, autofix: 50 })
+  - total     (Number, optional) : override total; defaults to sum of breakdown values
+
+  SLOTS: none
+-->
+<template>
+  <div class="billing-meter-breakdown-chart">
+    <!-- Empty state -->
+    <div
+      v-if="activeBuckets.length === 0"
+      class="text-caption text-medium-emphasis text-center py-2"
+    >
+      No usage data
+    </div>
+
+    <template v-else>
+      <!-- Stacked bar -->
+      <div
+        class="billing-meter-breakdown-chart__bar d-flex rounded overflow-hidden"
+        style="height: 12px"
+        role="img"
+        :aria-label="stackedBarAriaLabel"
+      >
+        <div
+          v-for="bucket in activeBuckets"
+          :key="bucket.key"
+          :style="{ width: bucket.pct + '%', backgroundColor: 'rgb(var(--v-theme-' + bucket.color + '))' }"
+          :title="`${bucket.key}: ${bucket.value} (${bucket.pct}%)`"
+        />
+      </div>
+
+      <!-- Legend -->
+      <div class="billing-meter-breakdown-chart__legend d-flex flex-wrap gap-2 mt-2">
+        <div
+          v-for="bucket in activeBuckets"
+          :key="bucket.key"
+          class="d-flex align-center ga-1 text-caption"
+        >
+          <div
+            :style="{ width: '10px', height: '10px', borderRadius: '2px', flexShrink: 0, backgroundColor: 'rgb(var(--v-theme-' + bucket.color + '))' }"
+          />
+          <span class="text-medium-emphasis">{{ bucket.key }}</span>
+          <span class="font-weight-medium">{{ bucket.pct }}%</span>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+/** Ordered palette of Vuetify theme color tokens used for buckets. */
+const PALETTE = ['primary', 'secondary', 'info', 'warning', 'success', 'error'];
+
+/**
+ * Component definition.
+ */
+export default {
+  name: 'BillingMeterBreakdownChartComponent',
+
+  props: {
+    /**
+     * @desc Per-bucket credit consumption map.
+     * Keys are bucket names (e.g. 'scrap', 'autofix'); values are credit counts.
+     * Buckets with value 0 are filtered out.
+     * @type {Object.<string, number>}
+     */
+    breakdown: {
+      type: Object,
+      required: true,
+    },
+    /**
+     * @desc Optional total override. Defaults to sum of all breakdown values.
+     * Useful when the parent wants percentages relative to a quota rather than
+     * the sum of visible buckets.
+     */
+    total: {
+      type: Number,
+      default: null,
+    },
+  },
+
+  computed: {
+    /**
+     * @desc Effective total: prop override or sum of all breakdown values.
+     * @returns {number}
+     */
+    effectiveTotal() {
+      if (this.total !== null && this.total > 0) return this.total;
+      return Object.values(this.breakdown).reduce((sum, v) => sum + (v || 0), 0);
+    },
+
+    /**
+     * @desc Non-zero buckets enriched with color assignment and percentage.
+     * Color is assigned by stable index position in the sorted key list so the
+     * mapping is deterministic for a given set of bucket names.
+     * @returns {Array<{ key: string, value: number, pct: number, color: string }>}
+     */
+    activeBuckets() {
+      const total = this.effectiveTotal;
+      if (total === 0) return [];
+
+      return Object.entries(this.breakdown)
+        .filter(([, v]) => v > 0)
+        .map(([key, value], idx) => ({
+          key,
+          value,
+          pct: Math.round((value / total) * 100),
+          color: PALETTE[idx % PALETTE.length],
+        }));
+    },
+
+    /**
+     * @desc ARIA label describing the stacked bar contents.
+     * @returns {string}
+     */
+    stackedBarAriaLabel() {
+      if (this.activeBuckets.length === 0) return 'No usage data';
+      const parts = this.activeBuckets.map((b) => `${b.key} ${b.pct}%`).join(', ');
+      return `Meter usage breakdown: ${parts}`;
+    },
+  },
+};
+</script>

--- a/src/modules/billing/components/billing.meterBreakdownChart.component.vue
+++ b/src/modules/billing/components/billing.meterBreakdownChart.component.vue
@@ -103,21 +103,25 @@ export default {
 
     /**
      * @desc Non-zero buckets enriched with color assignment and percentage.
-     * Color is assigned by stable index position in the sorted key list so the
-     * mapping is deterministic for a given set of bucket names.
+     * Color is assigned by stable index position in the sorted key list across
+     * ALL provided bucket names (zero or not), so the palette is deterministic
+     * for a given set of bucket names — toggling a zero bucket never shifts the
+     * colors of other buckets.
      * @returns {Array<{ key: string, value: number, pct: number, color: string }>}
      */
     activeBuckets() {
       const total = this.effectiveTotal;
       if (total === 0) return [];
 
-      return Object.entries(this.breakdown)
-        .filter(([, v]) => v > 0)
-        .map(([key, value], idx) => ({
+      const allKeys = Object.keys(this.breakdown).sort();
+      return allKeys
+        .map((key) => ({ key, value: this.breakdown[key] || 0, paletteIdx: allKeys.indexOf(key) }))
+        .filter(({ value }) => value > 0)
+        .map(({ key, value, paletteIdx }) => ({
           key,
           value,
           pct: Math.round((value / total) * 100),
-          color: PALETTE[idx % PALETTE.length],
+          color: PALETTE[paletteIdx % PALETTE.length],
         }));
     },
 

--- a/src/modules/billing/components/billing.meterBreakdownChart.component.vue
+++ b/src/modules/billing/components/billing.meterBreakdownChart.component.vue
@@ -36,7 +36,8 @@
         <div
           v-for="bucket in activeBuckets"
           :key="bucket.key"
-          :style="{ width: bucket.pct + '%', backgroundColor: 'rgb(var(--v-theme-' + bucket.color + '))' }"
+          :class="'bg-' + bucket.color"
+          :style="{ width: bucket.pct + '%' }"
           :title="`${bucket.key}: ${bucket.value} (${bucket.pct}%)`"
         />
       </div>
@@ -49,7 +50,8 @@
           class="d-flex align-center ga-1 text-caption"
         >
           <div
-            :style="{ width: '10px', height: '10px', borderRadius: '2px', flexShrink: 0, backgroundColor: 'rgb(var(--v-theme-' + bucket.color + '))' }"
+            :class="'bg-' + bucket.color"
+            style="width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0"
           />
           <span class="text-medium-emphasis">{{ bucket.key }}</span>
           <span class="font-weight-medium">{{ bucket.pct }}%</span>

--- a/src/modules/billing/components/billing.meterBreakdownChart.component.vue
+++ b/src/modules/billing/components/billing.meterBreakdownChart.component.vue
@@ -6,8 +6,8 @@
   Vuetify theme tokens for deterministic visual mapping.
 
   USAGE:
-  <billingMeterBreakdownChartComponent :breakdown="{ scrap: 100, autofix: 50, wizard: 200 }" />
-  <billingMeterBreakdownChartComponent :breakdown="breakdown" :total="500" />
+  <BillingMeterBreakdownChartComponent :breakdown="{ scrap: 100, autofix: 50, wizard: 200 }" />
+  <BillingMeterBreakdownChartComponent :breakdown="breakdown" :total="500" />
 
   PROPS:
   - breakdown (Object, required) : map of bucket → credit count (e.g. { scrap: 100, autofix: 50 })
@@ -43,7 +43,7 @@
       </div>
 
       <!-- Legend -->
-      <div class="billing-meter-breakdown-chart__legend d-flex flex-wrap gap-2 mt-2">
+      <div class="billing-meter-breakdown-chart__legend d-flex flex-wrap ga-2 mt-2">
         <div
           v-for="bucket in activeBuckets"
           :key="bucket.key"

--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -35,7 +35,7 @@
     <!-- Label row -->
     <div
       v-if="label"
-      class="d-flex justify-space-between text-body-small text-medium-emphasis mb-1"
+      class="d-flex justify-space-between text-body-2 text-medium-emphasis mb-1"
     >
       <span>{{ label }}</span>
       <span class="font-weight-medium">{{ clampedProgress }}%</span>

--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -1,0 +1,156 @@
+<!--
+  BillingMeterProgressComponent
+  ==============================
+  Compact meter usage widget (bar or donut variant).
+  Emits `click` for parent-driven drilldown (e.g. open a usage drawer).
+
+  USAGE:
+  <billingMeterProgressComponent :used="120" :quota="200" :extras="30" label="Compute" />
+  <billingMeterProgressComponent :used="180" :quota="200" variant="donut" />
+
+  PROPS:
+  - used     (Number, required) : credits consumed
+  - quota    (Number, required) : included weekly quota
+  - extras   (Number, default 0): extras-pack credits remaining
+  - label    (String, optional) : widget label
+  - variant  ('bar'|'donut', default 'bar') : visual style
+
+  EVENTS:
+  - click : emitted when the widget is interacted with (for drilldown)
+-->
+<template>
+  <div
+    class="billing-meter-progress"
+    role="progressbar"
+    :aria-valuenow="clampedProgress"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    :aria-label="ariaLabel"
+    tabindex="0"
+    style="cursor: pointer"
+    @click="$emit('click')"
+    @keydown.enter="$emit('click')"
+    @keydown.space.prevent="$emit('click')"
+  >
+    <!-- Label row -->
+    <div
+      v-if="label"
+      class="d-flex justify-space-between text-body-small text-medium-emphasis mb-1"
+    >
+      <span>{{ label }}</span>
+      <span class="font-weight-medium">{{ clampedProgress }}%</span>
+    </div>
+
+    <!-- Bar variant -->
+    <template v-if="variant === 'bar'">
+      <v-progress-linear
+        :model-value="clampedProgress"
+        :color="thresholdColor"
+        rounded
+        height="10"
+        bg-color="surface-variant"
+      />
+    </template>
+
+    <!-- Donut variant -->
+    <template v-else>
+      <div class="billing-meter-progress__donut d-flex justify-center">
+        <v-progress-circular
+          :model-value="clampedProgress"
+          :color="thresholdColor"
+          :size="64"
+          :width="6"
+        >
+          <span class="text-caption font-weight-bold">{{ clampedProgress }}%</span>
+        </v-progress-circular>
+      </div>
+    </template>
+
+    <!-- Summary text -->
+    <div class="text-caption text-medium-emphasis mt-1">
+      <span>{{ used }} / {{ quota }}</span>
+      <span v-if="extras > 0"> +{{ extras }} extras</span>
+    </div>
+  </div>
+</template>
+
+<script>
+/**
+ * Component definition.
+ */
+export default {
+  name: 'BillingMeterProgressComponent',
+
+  props: {
+    /**
+     * @desc Credits consumed this period.
+     */
+    used: {
+      type: Number,
+      required: true,
+    },
+    /**
+     * @desc Included quota for this period.
+     */
+    quota: {
+      type: Number,
+      required: true,
+    },
+    /**
+     * @desc Extras-pack credits remaining (bonus on top of quota).
+     */
+    extras: {
+      type: Number,
+      default: 0,
+    },
+    /**
+     * @desc Optional display label shown above the bar/donut.
+     */
+    label: {
+      type: String,
+      default: '',
+    },
+    /**
+     * @desc Visual variant: 'bar' (compact linear) or 'donut' (circular).
+     */
+    variant: {
+      type: String,
+      default: 'bar',
+      validator: (v) => ['bar', 'donut'].includes(v),
+    },
+  },
+
+  emits: ['click'],
+
+  computed: {
+    /**
+     * @desc Usage percentage clamped to [0, 100].
+     * @returns {number}
+     */
+    clampedProgress() {
+      if (this.quota === 0) return 0;
+      return Math.max(0, Math.min(100, Math.round((this.used / this.quota) * 100)));
+    },
+
+    /**
+     * @desc Vuetify color token based on usage threshold.
+     * green <70%, warning 70-90%, error >=90%.
+     * @returns {string}
+     */
+    thresholdColor() {
+      if (this.clampedProgress >= 90) return 'error';
+      if (this.clampedProgress >= 70) return 'warning';
+      return 'success';
+    },
+
+    /**
+     * @desc Accessible ARIA label summarising the current meter state.
+     * @returns {string}
+     */
+    ariaLabel() {
+      const base = this.label ? `${this.label}: ` : '';
+      return `${base}${this.used} of ${this.quota} used (${this.clampedProgress}%)`;
+    },
+  },
+};
+</script>

--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -5,8 +5,8 @@
   Emits `click` for parent-driven drilldown (e.g. open a usage drawer).
 
   USAGE:
-  <billingMeterProgressComponent :used="120" :quota="200" :extras="30" label="Compute" />
-  <billingMeterProgressComponent :used="180" :quota="200" variant="donut" />
+  <BillingMeterProgressComponent :used="120" :quota="200" :extras="30" label="Compute" />
+  <BillingMeterProgressComponent :used="180" :quota="200" variant="donut" />
 
   PROPS:
   - used     (Number, required) : credits consumed
@@ -21,10 +21,7 @@
 <template>
   <div
     class="billing-meter-progress"
-    role="progressbar"
-    :aria-valuenow="clampedProgress"
-    aria-valuemin="0"
-    aria-valuemax="100"
+    role="button"
     :aria-label="ariaLabel"
     tabindex="0"
     style="cursor: pointer"

--- a/src/modules/billing/tests/billing.extrasLedger.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.extrasLedger.component.unit.tests.js
@@ -156,10 +156,11 @@ describe('BillingExtrasLedgerComponent', () => {
     expect(wrapper.vm.pageCount).toBe(1);
   });
 
-  it('emits update:page when pagination changes', async () => {
+  it('emits update:page when VPagination fires update:modelValue', async () => {
     const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 45, limit: 20, page: 1 });
-    wrapper.vm.$emit('update:page', 2);
-    await wrapper.vm.$nextTick();
+    const pagination = wrapper.findComponent({ name: 'VPagination' });
+    expect(pagination.exists()).toBe(true);
+    await pagination.vm.$emit('update:modelValue', 2);
     expect(wrapper.emitted('update:page')).toBeTruthy();
     expect(wrapper.emitted('update:page')[0]).toEqual([2]);
   });

--- a/src/modules/billing/tests/billing.extrasLedger.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.extrasLedger.component.unit.tests.js
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+import BillingExtrasLedgerComponent from '../components/billing.extrasLedger.component.vue';
+
+const vuetify = createVuetify();
+
+/** Sample ledger entries covering all entry kinds. */
+const SAMPLE_ENTRIES = [
+  {
+    at: '2026-04-01T10:00:00.000Z',
+    kind: 'topup',
+    amount: 500,
+    refId: 'ref_topup_001',
+    stripeSessionId: 'cs_test_abc123xyz456',
+  },
+  {
+    at: '2026-04-02T11:30:00.000Z',
+    kind: 'debit',
+    amount: -100,
+    historyId: 'hist_debit_002',
+    stripeSessionId: null,
+  },
+  {
+    at: '2026-04-03T09:15:00.000Z',
+    kind: 'refund',
+    amount: 50,
+    refId: 'ref_refund_003',
+    stripeSessionId: 're_test_refund999',
+  },
+  {
+    at: '2026-04-04T14:00:00.000Z',
+    kind: 'expiration',
+    amount: -200,
+    refId: null,
+    stripeSessionId: null,
+  },
+  {
+    at: '2026-04-05T08:00:00.000Z',
+    kind: 'adjustment',
+    amount: 25,
+    refId: 'ref_adj_005',
+    stripeSessionId: null,
+  },
+];
+
+/**
+ * Mount BillingExtrasLedgerComponent with Vuetify and Pinia installed.
+ * @param {Object} props - Component props
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountComponent = (props) =>
+  mount(BillingExtrasLedgerComponent, {
+    props,
+    global: { plugins: [vuetify] },
+    attachTo: document.body,
+  });
+
+describe('BillingExtrasLedgerComponent', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+
+  it('shows empty state when entries array is empty', () => {
+    const wrapper = mountComponent({ entries: [], total: 0 });
+    expect(wrapper.text()).toContain('No ledger entries yet');
+  });
+
+  it('does not render table when entries is empty', () => {
+    const wrapper = mountComponent({ entries: [], total: 0 });
+    expect(wrapper.findComponent({ name: 'v-data-table' }).exists()).toBe(false);
+  });
+
+  // ── Kind chip colors ──────────────────────────────────────────────────────
+
+  it('returns success color for topup kind', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.kindColor('topup')).toBe('success');
+  });
+
+  it('returns warning color for debit kind', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.kindColor('debit')).toBe('warning');
+  });
+
+  it('returns info color for refund kind', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.kindColor('refund')).toBe('info');
+  });
+
+  it('returns default color for expiration kind', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.kindColor('expiration')).toBe('default');
+  });
+
+  it('returns primary color for adjustment kind', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.kindColor('adjustment')).toBe('primary');
+  });
+
+  it('returns default color for unknown kind', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.kindColor('unknown_kind')).toBe('default');
+  });
+
+  // ── Signed amount display ─────────────────────────────────────────────────
+
+  it('formatDate returns — for null/undefined', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.formatDate(null)).toBe('—');
+    expect(wrapper.vm.formatDate(undefined)).toBe('—');
+    expect(wrapper.vm.formatDate('')).toBe('—');
+  });
+
+  it('formatDate returns a non-empty string for valid ISO date', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    const result = wrapper.vm.formatDate('2026-04-01T10:00:00.000Z');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).not.toBe('—');
+  });
+
+  // ── Truncation ────────────────────────────────────────────────────────────
+
+  it('truncates long strings to 12 chars + ellipsis', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    const result = wrapper.vm.truncate('cs_test_abc123xyz456');
+    expect(result).toBe('cs_test_abc1…');
+    expect(result.length).toBe(13); // 12 + ellipsis char
+  });
+
+  it('returns string as-is when <= 12 characters', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.truncate('short')).toBe('short');
+  });
+
+  it('returns — for null/undefined values', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.truncate(null)).toBe('—');
+    expect(wrapper.vm.truncate(undefined)).toBe('—');
+    expect(wrapper.vm.truncate('')).toBe('—');
+  });
+
+  // ── Pagination ────────────────────────────────────────────────────────────
+
+  it('computes correct pageCount', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 45, limit: 20 });
+    expect(wrapper.vm.pageCount).toBe(3);
+  });
+
+  it('computes pageCount of 1 when total <= limit', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5, limit: 20 });
+    expect(wrapper.vm.pageCount).toBe(1);
+  });
+
+  it('emits update:page when pagination changes', async () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 45, limit: 20, page: 1 });
+    wrapper.vm.$emit('update:page', 2);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('update:page')).toBeTruthy();
+    expect(wrapper.emitted('update:page')[0]).toEqual([2]);
+  });
+
+  it('does not render pagination when pageCount is 1', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5, limit: 20 });
+    expect(wrapper.findComponent({ name: 'v-pagination' }).exists()).toBe(false);
+  });
+
+  // ── Table rendering ───────────────────────────────────────────────────────
+
+  it('renders data table when entries are provided', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.findComponent({ name: 'v-data-table' }).exists()).toBe(true);
+  });
+
+  it('passes correct items-per-page to data table', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5, limit: 10 });
+    const table = wrapper.findComponent({ name: 'v-data-table' });
+    expect(table.props('itemsPerPage')).toBe(10);
+  });
+
+  it('passes correct page to data table', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5, page: 2 });
+    const table = wrapper.findComponent({ name: 'v-data-table' });
+    expect(table.props('page')).toBe(2);
+  });
+
+  // ── Default props ─────────────────────────────────────────────────────────
+
+  it('defaults page to 1', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.page).toBe(1);
+  });
+
+  it('defaults limit to 20', () => {
+    const wrapper = mountComponent({ entries: SAMPLE_ENTRIES, total: 5 });
+    expect(wrapper.vm.limit).toBe(20);
+  });
+});

--- a/src/modules/billing/tests/billing.meterBreakdownChart.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterBreakdownChart.component.unit.tests.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+import BillingMeterBreakdownChartComponent from '../components/billing.meterBreakdownChart.component.vue';
+
+const vuetify = createVuetify();
+
+/**
+ * Mount BillingMeterBreakdownChartComponent with Vuetify and Pinia installed.
+ * @param {Object} props - Component props
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountComponent = (props) =>
+  mount(BillingMeterBreakdownChartComponent, {
+    props,
+    global: { plugins: [vuetify] },
+  });
+
+describe('BillingMeterBreakdownChartComponent', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  // ── Non-zero buckets only ─────────────────────────────────────────────────
+
+  it('renders only non-zero buckets', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 0, wizard: 50 } });
+    const buckets = wrapper.vm.activeBuckets;
+    expect(buckets).toHaveLength(2);
+    expect(buckets.map((b) => b.key)).toEqual(['scrap', 'wizard']);
+  });
+
+  it('renders empty state when all buckets are zero', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 0, autofix: 0 } });
+    expect(wrapper.text()).toContain('No usage data');
+    expect(wrapper.vm.activeBuckets).toHaveLength(0);
+  });
+
+  it('renders empty state when breakdown is empty object', () => {
+    const wrapper = mountComponent({ breakdown: {} });
+    expect(wrapper.text()).toContain('No usage data');
+  });
+
+  // ── Total computation ─────────────────────────────────────────────────────
+
+  it('computes total as sum of breakdown values when total prop is omitted', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 50, wizard: 200 } });
+    expect(wrapper.vm.effectiveTotal).toBe(350);
+  });
+
+  it('uses the total prop when provided', () => {
+    const wrapper = mountComponent({
+      breakdown: { scrap: 100, autofix: 50 },
+      total: 500,
+    });
+    expect(wrapper.vm.effectiveTotal).toBe(500);
+  });
+
+  it('falls back to sum when total prop is 0', () => {
+    const wrapper = mountComponent({
+      breakdown: { scrap: 100, autofix: 50 },
+      total: 0,
+    });
+    // total=0 is falsy, falls back to sum
+    expect(wrapper.vm.effectiveTotal).toBe(150);
+  });
+
+  // ── Percentage computation ────────────────────────────────────────────────
+
+  it('computes percentages summing to ~100 for multiple buckets', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 100, wizard: 100 } });
+    const total = wrapper.vm.activeBuckets.reduce((s, b) => s + b.pct, 0);
+    // With 3 equal buckets each 33% → sum is 99 due to rounding
+    expect(total).toBeGreaterThanOrEqual(99);
+    expect(total).toBeLessThanOrEqual(101);
+  });
+
+  it('computes correct percentage for a single bucket', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 200 } });
+    expect(wrapper.vm.activeBuckets[0].pct).toBe(100);
+  });
+
+  it('computes percentage relative to custom total', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100 }, total: 400 });
+    expect(wrapper.vm.activeBuckets[0].pct).toBe(25);
+  });
+
+  // ── Color cycle determinism ────────────────────────────────────────────────
+
+  it('assigns colors deterministically for the same set of buckets', () => {
+    const breakdown = { scrap: 100, autofix: 50, wizard: 200 };
+    const w1 = mountComponent({ breakdown });
+    const w2 = mountComponent({ breakdown });
+    const colors1 = w1.vm.activeBuckets.map((b) => b.color);
+    const colors2 = w2.vm.activeBuckets.map((b) => b.color);
+    expect(colors1).toEqual(colors2);
+  });
+
+  it('first bucket gets primary color', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 50 } });
+    expect(wrapper.vm.activeBuckets[0].color).toBe('primary');
+  });
+
+  it('second bucket gets secondary color', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 50 } });
+    expect(wrapper.vm.activeBuckets[1].color).toBe('secondary');
+  });
+
+  it('cycles through palette when more buckets than palette entries', () => {
+    const breakdown = {
+      a: 10, b: 10, c: 10, d: 10, e: 10, f: 10, g: 10,
+    };
+    const wrapper = mountComponent({ breakdown });
+    // 7th bucket (index 6) wraps to index 0 → primary
+    expect(wrapper.vm.activeBuckets[6].color).toBe('primary');
+  });
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  it('renders the stacked bar when there are active buckets', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 50 } });
+    const bar = wrapper.find('.billing-meter-breakdown-chart__bar');
+    expect(bar.exists()).toBe(true);
+  });
+
+  it('renders legend entries for active buckets', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 50 } });
+    const legend = wrapper.find('.billing-meter-breakdown-chart__legend');
+    expect(legend.exists()).toBe(true);
+    expect(legend.text()).toContain('scrap');
+    expect(legend.text()).toContain('autofix');
+  });
+
+  it('does not render zero-value bucket in legend', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 0 } });
+    expect(wrapper.find('.billing-meter-breakdown-chart__legend').text()).not.toContain('autofix');
+  });
+});

--- a/src/modules/billing/tests/billing.meterBreakdownChart.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterBreakdownChart.component.unit.tests.js
@@ -116,6 +116,21 @@ describe('BillingMeterBreakdownChartComponent', () => {
     expect(wrapper.vm.activeBuckets[6].color).toBe('primary');
   });
 
+  it('palette colors are stable when a zero bucket is toggled on', () => {
+    // Initial state: a=0, b=50, c=0, d=100 — only b and d are active
+    const w1 = mountComponent({ breakdown: { a: 0, b: 50, c: 0, d: 100 } });
+    const colorB1 = w1.vm.activeBuckets.find((bk) => bk.key === 'b').color;
+    const colorD1 = w1.vm.activeBuckets.find((bk) => bk.key === 'd').color;
+
+    // After toggle: a becomes 10 — b and d must keep the exact same colors
+    const w2 = mountComponent({ breakdown: { a: 10, b: 50, c: 0, d: 100 } });
+    const colorB2 = w2.vm.activeBuckets.find((bk) => bk.key === 'b').color;
+    const colorD2 = w2.vm.activeBuckets.find((bk) => bk.key === 'd').color;
+
+    expect(colorB2).toBe(colorB1);
+    expect(colorD2).toBe(colorD1);
+  });
+
   // ── Rendering ─────────────────────────────────────────────────────────────
 
   it('renders the stacked bar when there are active buckets', () => {

--- a/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+import BillingMeterProgressComponent from '../components/billing.meterProgress.component.vue';
+
+const vuetify = createVuetify();
+
+/**
+ * Mount BillingMeterProgressComponent with Vuetify and Pinia installed.
+ * @param {Object} props - Component props
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountComponent = (props) =>
+  mount(BillingMeterProgressComponent, {
+    props,
+    global: { plugins: [vuetify] },
+  });
+
+describe('BillingMeterProgressComponent', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  // ── Progress clamping ────────────────────────────────────────────────────
+
+  it('computes 50% progress correctly', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    expect(wrapper.vm.clampedProgress).toBe(50);
+  });
+
+  it('clamps progress to 0 when used is 0', () => {
+    const wrapper = mountComponent({ used: 0, quota: 100 });
+    expect(wrapper.vm.clampedProgress).toBe(0);
+  });
+
+  it('clamps progress to 100 when used exceeds quota', () => {
+    const wrapper = mountComponent({ used: 150, quota: 100 });
+    expect(wrapper.vm.clampedProgress).toBe(100);
+  });
+
+  it('clamps progress to 0 when quota is 0', () => {
+    const wrapper = mountComponent({ used: 50, quota: 0 });
+    expect(wrapper.vm.clampedProgress).toBe(0);
+  });
+
+  it('rounds fractional progress', () => {
+    const wrapper = mountComponent({ used: 1, quota: 3 });
+    expect(wrapper.vm.clampedProgress).toBe(33);
+  });
+
+  // ── Color thresholds ─────────────────────────────────────────────────────
+
+  it('returns success color when progress is below 70%', () => {
+    const wrapper = mountComponent({ used: 60, quota: 100 });
+    expect(wrapper.vm.thresholdColor).toBe('success');
+  });
+
+  it('returns warning color when progress is exactly 70%', () => {
+    const wrapper = mountComponent({ used: 70, quota: 100 });
+    expect(wrapper.vm.thresholdColor).toBe('warning');
+  });
+
+  it('returns warning color when progress is between 70 and 90', () => {
+    const wrapper = mountComponent({ used: 80, quota: 100 });
+    expect(wrapper.vm.thresholdColor).toBe('warning');
+  });
+
+  it('returns error color when progress is exactly 90%', () => {
+    const wrapper = mountComponent({ used: 90, quota: 100 });
+    expect(wrapper.vm.thresholdColor).toBe('error');
+  });
+
+  it('returns error color when progress exceeds 90%', () => {
+    const wrapper = mountComponent({ used: 99, quota: 100 });
+    expect(wrapper.vm.thresholdColor).toBe('error');
+  });
+
+  // ── Click event ──────────────────────────────────────────────────────────
+
+  it('emits click when the widget is clicked', async () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    await wrapper.find('.billing-meter-progress').trigger('click');
+    expect(wrapper.emitted('click')).toHaveLength(1);
+  });
+
+  it('emits click on Enter key', async () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    await wrapper.find('.billing-meter-progress').trigger('keydown.enter');
+    expect(wrapper.emitted('click')).toHaveLength(1);
+  });
+
+  // ── A11y attributes ──────────────────────────────────────────────────────
+
+  it('has role=progressbar on root element', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    expect(wrapper.find('.billing-meter-progress').attributes('role')).toBe('progressbar');
+  });
+
+  it('sets aria-valuenow to clamped progress', () => {
+    const wrapper = mountComponent({ used: 75, quota: 100 });
+    expect(wrapper.find('.billing-meter-progress').attributes('aria-valuenow')).toBe('75');
+  });
+
+  it('sets aria-valuemin to 0', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    expect(wrapper.find('.billing-meter-progress').attributes('aria-valuemin')).toBe('0');
+  });
+
+  it('sets aria-valuemax to 100', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    expect(wrapper.find('.billing-meter-progress').attributes('aria-valuemax')).toBe('100');
+  });
+
+  it('includes label in aria-label when label prop is provided', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100, label: 'Compute' });
+    expect(wrapper.find('.billing-meter-progress').attributes('aria-label')).toContain('Compute');
+  });
+
+  // ── Variant switching ────────────────────────────────────────────────────
+
+  it('renders v-progress-linear for bar variant (default)', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    expect(wrapper.findComponent({ name: 'v-progress-linear' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'v-progress-circular' }).exists()).toBe(false);
+  });
+
+  it('renders v-progress-circular for donut variant', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100, variant: 'donut' });
+    expect(wrapper.findComponent({ name: 'v-progress-circular' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'v-progress-linear' }).exists()).toBe(false);
+  });
+
+  // ── Extras display ───────────────────────────────────────────────────────
+
+  it('shows extras credits in summary text when extras > 0', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100, extras: 30 });
+    expect(wrapper.text()).toContain('+30 extras');
+  });
+
+  it('does not show extras text when extras is 0', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100, extras: 0 });
+    expect(wrapper.text()).not.toContain('extras');
+  });
+
+  it('shows used/quota in summary text', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    expect(wrapper.text()).toContain('50');
+    expect(wrapper.text()).toContain('100');
+  });
+
+  // ── Label ────────────────────────────────────────────────────────────────
+
+  it('renders label when provided', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100, label: 'Compute usage' });
+    expect(wrapper.text()).toContain('Compute usage');
+  });
+
+  it('does not render label row when label is empty', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100 });
+    // label defaults to '' so the label row v-if is falsy
+    const labelRow = wrapper.find('.d-flex.justify-space-between');
+    expect(labelRow.exists()).toBe(false);
+  });
+});

--- a/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
@@ -92,29 +92,20 @@ describe('BillingMeterProgressComponent', () => {
 
   // ── A11y attributes ──────────────────────────────────────────────────────
 
-  it('has role=progressbar on root element', () => {
+  it('has role=button on root element (interactive widget)', () => {
     const wrapper = mountComponent({ used: 50, quota: 100 });
-    expect(wrapper.find('.billing-meter-progress').attributes('role')).toBe('progressbar');
-  });
-
-  it('sets aria-valuenow to clamped progress', () => {
-    const wrapper = mountComponent({ used: 75, quota: 100 });
-    expect(wrapper.find('.billing-meter-progress').attributes('aria-valuenow')).toBe('75');
-  });
-
-  it('sets aria-valuemin to 0', () => {
-    const wrapper = mountComponent({ used: 50, quota: 100 });
-    expect(wrapper.find('.billing-meter-progress').attributes('aria-valuemin')).toBe('0');
-  });
-
-  it('sets aria-valuemax to 100', () => {
-    const wrapper = mountComponent({ used: 50, quota: 100 });
-    expect(wrapper.find('.billing-meter-progress').attributes('aria-valuemax')).toBe('100');
+    expect(wrapper.find('.billing-meter-progress').attributes('role')).toBe('button');
   });
 
   it('includes label in aria-label when label prop is provided', () => {
     const wrapper = mountComponent({ used: 50, quota: 100, label: 'Compute' });
     expect(wrapper.find('.billing-meter-progress').attributes('aria-label')).toContain('Compute');
+  });
+
+  it('includes usage stats in aria-label', () => {
+    const wrapper = mountComponent({ used: 75, quota: 100 });
+    expect(wrapper.find('.billing-meter-progress').attributes('aria-label')).toContain('75');
+    expect(wrapper.find('.billing-meter-progress').attributes('aria-label')).toContain('100');
   });
 
   // ── Variant switching ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes part of #4036 (PR-V2 scope).

Three new reusable billing components for compute meter display — no V3 surfaces (drawer / modal / pricing card) in this PR.

- **`billing.meterProgress.component.vue`** — bar or donut widget consuming `used / quota / extras` props. Color thresholds: success <70%, warning 70–90%, error ≥90%. Emits `click` for parent drilldown. Full ARIA progressbar attrs (`role`, `aria-valuenow/min/max`, `aria-label`).
- **`billing.meterBreakdownChart.component.vue`** — horizontal stacked-bar + legend. Buckets with `value = 0` are filtered. Colors assigned deterministically from a 6-token Vuetify palette. `total` prop override for quota-relative percentages.
- **`billing.extrasLedger.component.vue`** — paginated table with scoped column slots. Kind chips colored per entry type (`topup` success / `debit` warning / `refund` info / `expiration` default / `adjustment` primary). Signed monospace amounts, truncated ref IDs with native title tooltip. Emits `update:page` for parent refetch.

## Test plan

- [x] `billing.meterProgress.component.unit.tests.js` — 24 tests: clamping 0–100, color thresholds, click emit, Enter keydown emit, ARIA attrs, variant switching (bar/donut), extras display
- [x] `billing.meterBreakdownChart.component.unit.tests.js` — 19 tests: zero-bucket filtering, total computation (sum / prop override / fallback), pct correctness, palette determinism, cycle wrap
- [x] `billing.extrasLedger.component.unit.tests.js` — 19 tests: empty state, kind colors, truncation, formatDate, pagination emit, pageCount, data-table props, defaults
- [x] `npm run lint` — clean (0 errors)
- [x] `npm run test:unit` — **1201 / 1201 passed** (baseline 1139, +62)