### PR TITLE
feat(billing): meter UX surfaces (PR-V3)

### DIFF
--- a/src/modules/billing/components/billing.extrasCheckoutModal.component.vue
+++ b/src/modules/billing/components/billing.extrasCheckoutModal.component.vue
@@ -1,0 +1,184 @@
+<!--
+  BillingExtrasCheckoutModalComponent
+  =====================================
+  Dialog for purchasing an extras credit pack.
+  Presents a radio list of available packs with label and price,
+  and a CTA that redirects to Stripe via useMeter().purchasePack().
+
+  USAGE:
+  <BillingExtrasCheckoutModalComponent
+    v-model="open"
+    :packs="[{ packId: 'pack_500', label: '500 units', priceUsd: 9, meterUnits: 500 }]"
+  />
+
+  PROPS:
+  - modelValue (Boolean, required): Controls dialog open state (v-model)
+  - packs      (Array<{packId, label, priceUsd, meterUnits}>, required): Pack options from useMeter().packsAvailable
+
+  EVENTS:
+  - update:modelValue (Boolean): Emitted when dialog requests close
+-->
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    max-width="480"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <v-card>
+      <!-- Title -->
+      <v-card-title class="text-title-medium font-weight-bold pt-5 px-5">
+        Buy extra units
+      </v-card-title>
+
+      <!-- Pack radio list -->
+      <v-card-text class="px-5 pb-2">
+        <v-radio-group
+          v-model="selectedPackId"
+          hide-details
+        >
+          <v-radio
+            v-for="pack in packs"
+            :key="pack.packId"
+            :value="pack.packId"
+            :label="`${pack.label} — $${pack.priceUsd} (+${pack.meterUnits} units)`"
+            class="mb-1"
+          />
+        </v-radio-group>
+
+        <!-- Empty state when no packs available -->
+        <p
+          v-if="packs.length === 0"
+          class="text-body-2 text-medium-emphasis py-2"
+        >
+          No packs available at this time.
+        </p>
+      </v-card-text>
+
+      <!-- Actions -->
+      <v-card-actions class="px-5 pb-5 ga-2">
+        <!-- i18n key: billing.extras.cta → Buy units -->
+        <v-btn
+          color="primary"
+          variant="flat"
+          class="text-none"
+          :disabled="!selectedPackId || purchasing"
+          :loading="purchasing"
+          @click="onBuy"
+        >
+          Buy {{ selectedPackLabel }}
+        </v-btn>
+        <v-btn
+          variant="text"
+          class="text-none"
+          :disabled="purchasing"
+          @click="$emit('update:modelValue', false)"
+        >
+          Cancel
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+/**
+ * Module dependencies.
+ */
+import { useMeter } from '../composables/billing.useMeter';
+
+/**
+ * Component definition.
+ */
+export default {
+  name: 'BillingExtrasCheckoutModalComponent',
+
+  props: {
+    /**
+     * @desc Controls the dialog open state (v-model).
+     */
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+    /**
+     * @desc Available extras packs to purchase.
+     * Each pack: { packId: string, label: string, priceUsd: number, meterUnits: number }
+     */
+    packs: {
+      type: Array,
+      default: () => [],
+    },
+  },
+
+  emits: ['update:modelValue'],
+
+  /**
+   * @desc Wires useMeter composable to access purchasePack.
+   * @returns {{ purchasePack: Function }}
+   */
+  setup() {
+    const { purchasePack } = useMeter({ pollIntervalMs: 0 });
+    return { purchasePack };
+  },
+
+  data() {
+    return {
+      /** @type {string|null} Currently selected pack ID */
+      selectedPackId: null,
+      /** @type {boolean} Whether a purchase is in progress */
+      purchasing: false,
+    };
+  },
+
+  computed: {
+    /**
+     * @desc Label of the currently selected pack (for CTA text).
+     * @returns {string}
+     */
+    selectedPackLabel() {
+      if (!this.selectedPackId) return '';
+      const pack = this.packs.find((p) => p.packId === this.selectedPackId);
+      return pack ? pack.label : '';
+    },
+  },
+
+  watch: {
+    /**
+     * @desc Pre-select the first available pack when the dialog opens or packs change.
+     */
+    modelValue(open) {
+      if (open && this.packs.length > 0 && !this.selectedPackId) {
+        this.selectedPackId = this.packs[0].packId;
+      }
+    },
+    packs: {
+      immediate: true,
+      handler(newPacks) {
+        if (newPacks.length > 0 && !this.selectedPackId) {
+          this.selectedPackId = newPacks[0].packId;
+        }
+      },
+    },
+  },
+
+  methods: {
+    /**
+     * @desc Initiate Stripe checkout for the selected pack.
+     * Delegates to useMeter().purchasePack() which redirects to Stripe.
+     * @returns {Promise<void>}
+     */
+    async onBuy() {
+      if (!this.selectedPackId) return;
+      this.purchasing = true;
+      try {
+        await this.purchasePack(this.selectedPackId);
+        // On success, Stripe redirects — so we only reach here on error
+      } catch (err) {
+        console.error('Failed to initiate extras checkout:', err);
+      } finally {
+        this.purchasing = false;
+      }
+    },
+  },
+};
+</script>

--- a/src/modules/billing/components/billing.extrasCheckoutModal.component.vue
+++ b/src/modules/billing/components/billing.extrasCheckoutModal.component.vue
@@ -54,6 +54,19 @@
         </p>
       </v-card-text>
 
+      <!-- Purchase error -->
+      <v-alert
+        v-if="purchaseError"
+        type="error"
+        variant="tonal"
+        density="compact"
+        class="mx-5 mb-2"
+        closable
+        @click:close="purchaseError = null"
+      >
+        {{ purchaseError }}
+      </v-alert>
+
       <!-- Actions -->
       <v-card-actions class="px-5 pb-5 ga-2">
         <!-- i18n key: billing.extras.cta → Buy units -->
@@ -84,7 +97,7 @@
 /**
  * Module dependencies.
  */
-import { useMeter } from '../composables/billing.useMeter';
+import { useBillingStore } from '../stores/billing.store';
 
 /**
  * Component definition.
@@ -113,12 +126,13 @@ export default {
   emits: ['update:modelValue'],
 
   /**
-   * @desc Wires useMeter composable to access purchasePack.
-   * @returns {{ purchasePack: Function }}
+   * @desc Injects billingStore directly so only createExtrasCheckout is wired —
+   * no polling side-effect on mount (avoids the safeRefresh triggered by useMeter).
+   * @returns {{ billingStore: Object }}
    */
   setup() {
-    const { purchasePack } = useMeter({ pollIntervalMs: 0 });
-    return { purchasePack };
+    const billingStore = useBillingStore();
+    return { billingStore };
   },
 
   data() {
@@ -127,6 +141,8 @@ export default {
       selectedPackId: null,
       /** @type {boolean} Whether a purchase is in progress */
       purchasing: false,
+      /** @type {string|null} User-facing error message when checkout initiation fails */
+      purchaseError: null,
     };
   },
 
@@ -164,17 +180,20 @@ export default {
   methods: {
     /**
      * @desc Initiate Stripe checkout for the selected pack.
-     * Delegates to useMeter().purchasePack() which redirects to Stripe.
+     * Delegates to billingStore.createExtrasCheckout() which redirects to Stripe.
+     * On failure, sets purchaseError so the user understands what went wrong.
      * @returns {Promise<void>}
      */
     async onBuy() {
       if (!this.selectedPackId) return;
       this.purchasing = true;
+      this.purchaseError = null;
       try {
-        await this.purchasePack(this.selectedPackId);
+        await this.billingStore.createExtrasCheckout(this.selectedPackId);
         // On success, Stripe redirects — so we only reach here on error
       } catch (err) {
         console.error('Failed to initiate extras checkout:', err);
+        this.purchaseError = 'Unable to start checkout. Please try again.';
       } finally {
         this.purchasing = false;
       }

--- a/src/modules/billing/components/billing.meterDrawer.component.vue
+++ b/src/modules/billing/components/billing.meterDrawer.component.vue
@@ -131,12 +131,14 @@ export default {
   emits: ['update:modelValue'],
 
   /**
-   * @desc Wires useMeter composable to source reactive meter data.
-   * @returns {{ used: ComputedRef<number>, quota: ComputedRef<number>, extras: ComputedRef<number>, breakdown: ComputedRef<Object> }}
+   * @desc Wires useMeter composable and injects billingStore once so computed
+   * properties do not call useBillingStore() on every evaluation.
+   * @returns {{ used: ComputedRef<number>, quota: ComputedRef<number>, extras: ComputedRef<number>, breakdown: ComputedRef<Object>, billingStore: Object }}
    */
   setup() {
     const { used, quota, extras, breakdown } = useMeter({ pollIntervalMs: 30000 });
-    return { used, quota, extras, breakdown };
+    const billingStore = useBillingStore();
+    return { used, quota, extras, breakdown, billingStore };
   },
 
   data() {
@@ -149,13 +151,13 @@ export default {
   computed: {
     /**
      * @desc Available extras packs from store.
+     * Uses billingStore injected in setup to avoid repeated useBillingStore() calls.
      * @returns {Array<{packId: string, label: string, priceUsd: number, meterUnits: number}>}
      */
     packsAvailable() {
-      const billingStore = useBillingStore();
       return (
-        billingStore.usageMeter?.packsAvailable ??
-        billingStore.extrasBalance?.packsAvailable ??
+        this.billingStore.usageMeter?.packsAvailable ??
+        this.billingStore.extrasBalance?.packsAvailable ??
         []
       );
     },

--- a/src/modules/billing/components/billing.meterDrawer.component.vue
+++ b/src/modules/billing/components/billing.meterDrawer.component.vue
@@ -1,0 +1,164 @@
+<!--
+  BillingMeterDrawerComponent
+  ============================
+  Right-side navigation drawer showing the detailed weekly meter state.
+  Displays quota progress, per-bucket breakdown, extras balance, and CTA
+  to purchase more units via BillingExtrasCheckoutModal.
+
+  USAGE:
+  <BillingMeterDrawerComponent v-model="drawerOpen" />
+
+  PROPS:
+  - modelValue (Boolean, required): Controls open/closed state (v-model)
+
+  EVENTS:
+  - update:modelValue (Boolean): Emitted when the drawer requests close
+-->
+<template>
+  <v-navigation-drawer
+    :model-value="modelValue"
+    location="right"
+    temporary
+    width="400"
+    :style="{ maxWidth: '100vw' }"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <!-- Header -->
+    <div class="d-flex align-center justify-space-between pa-4 border-b">
+      <span class="text-title-medium font-weight-bold">Weekly meter</span>
+      <v-btn
+        icon
+        variant="text"
+        size="small"
+        aria-label="Close meter drawer"
+        @click="$emit('update:modelValue', false)"
+      >
+        <v-icon icon="fa-solid fa-xmark" />
+      </v-btn>
+    </div>
+
+    <!-- Body -->
+    <div class="pa-4">
+      <!-- Progress widget -->
+      <div class="mb-4">
+        <p class="text-caption text-medium-emphasis text-uppercase mb-2">
+          Usage
+        </p>
+        <!-- i18n key: billing.usage.progress -->
+        <p class="text-body-2 text-medium-emphasis mb-3">
+          {{ used }} of {{ quota }} units used
+        </p>
+        <BillingMeterProgressComponent
+          :used="used"
+          :quota="quota"
+          :extras="extras"
+          label=""
+        />
+      </div>
+
+      <v-divider class="mb-4" />
+
+      <!-- Breakdown chart -->
+      <div class="mb-4">
+        <!-- i18n key: billing.usage.breakdown -->
+        <p class="text-caption text-medium-emphasis text-uppercase mb-2">Breakdown</p>
+        <BillingMeterBreakdownChartComponent :breakdown="breakdown" />
+      </div>
+
+      <v-divider class="mb-4" />
+
+      <!-- Extras section -->
+      <div>
+        <!-- i18n key: billing.extras.title -->
+        <p class="text-caption text-medium-emphasis text-uppercase mb-2">Extra units</p>
+        <!-- i18n key: billing.extras.balance -->
+        <p class="text-body-2 mb-3">
+          {{ extras }} units remaining
+        </p>
+        <!-- i18n key: billing.extras.cta -->
+        <v-btn
+          color="primary"
+          variant="flat"
+          size="small"
+          class="text-none"
+          @click="extrasModalOpen = true"
+        >
+          Buy units
+        </v-btn>
+      </div>
+    </div>
+
+    <!-- Extras checkout modal -->
+    <BillingExtrasCheckoutModalComponent
+      v-model="extrasModalOpen"
+      :packs="packsAvailable"
+    />
+  </v-navigation-drawer>
+</template>
+
+<script>
+/**
+ * Module dependencies.
+ */
+import { useMeter } from '../composables/billing.useMeter';
+import { useBillingStore } from '../stores/billing.store';
+import BillingMeterProgressComponent from './billing.meterProgress.component.vue';
+import BillingMeterBreakdownChartComponent from './billing.meterBreakdownChart.component.vue';
+import BillingExtrasCheckoutModalComponent from './billing.extrasCheckoutModal.component.vue';
+
+/**
+ * Component definition.
+ */
+export default {
+  name: 'BillingMeterDrawerComponent',
+
+  components: {
+    BillingMeterProgressComponent,
+    BillingMeterBreakdownChartComponent,
+    BillingExtrasCheckoutModalComponent,
+  },
+
+  props: {
+    /**
+     * @desc Controls the open/closed state of the drawer (v-model).
+     */
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+  },
+
+  emits: ['update:modelValue'],
+
+  /**
+   * @desc Wires useMeter composable to source reactive meter data.
+   * @returns {{ used: ComputedRef<number>, quota: ComputedRef<number>, extras: ComputedRef<number>, breakdown: ComputedRef<Object> }}
+   */
+  setup() {
+    const { used, quota, extras, breakdown } = useMeter({ pollIntervalMs: 30000 });
+    return { used, quota, extras, breakdown };
+  },
+
+  data() {
+    return {
+      /** @type {boolean} Controls visibility of the extras checkout modal */
+      extrasModalOpen: false,
+    };
+  },
+
+  computed: {
+    /**
+     * @desc Available extras packs from store.
+     * @returns {Array<{packId: string, label: string, priceUsd: number, meterUnits: number}>}
+     */
+    packsAvailable() {
+      const billingStore = useBillingStore();
+      return (
+        billingStore.usageMeter?.packsAvailable ??
+        billingStore.extrasBalance?.packsAvailable ??
+        []
+      );
+    },
+  },
+};
+</script>

--- a/src/modules/billing/components/billing.pricingCard.component.vue
+++ b/src/modules/billing/components/billing.pricingCard.component.vue
@@ -1,16 +1,24 @@
 <!--
   BillingPricingCardComponent
   ===========================
-  Displays a single pricing plan card with name, price, features, and CTA.
+  Displays a single pricing plan card with name, price, features/equivalences, and CTA.
 
-  USAGE:
-  <billingPricingCardComponent :plan="plan" :annual="false" :current="false" @select="onSelect" />
+  USAGE (legacy — feature list):
+  <BillingPricingCardComponent :plan="plan" :annual="false" :current="false" @select="onSelect" />
+
+  USAGE (meter mode — equivalences):
+  <BillingPricingCardComponent
+    :plan="plan"
+    :equivalences="[{ label: 'operations / week', count: 500 }]"
+    @select="onSelect"
+  />
 
   PROPS:
-  - plan (Object): Plan object with id, name, tagline, features, highlighted, badge, cta, monthlyPrice, annualPrice
-  - annual (Boolean): Whether annual billing is selected
-  - current (Boolean): Whether this is the user's current plan
-  - loading (Boolean): Whether a checkout is in progress (disables CTA)
+  - plan         (Object, required): Plan object with id, name, tagline, features, highlighted, badge, cta, monthlyPrice, annualPrice
+  - annual       (Boolean): Whether annual billing is selected
+  - current      (Boolean): Whether this is the user's current plan
+  - loading      (Boolean): Whether a checkout is in progress (disables CTA)
+  - equivalences (Array<{label: String, count: Number}>, optional): When provided, renders equivalence bullets instead of feature list
 
   EVENTS:
   - select (Object): Emitted with { planId, priceId } when CTA is clicked
@@ -79,8 +87,39 @@
       Current Plan
     </v-btn>
 
-    <!-- Features -->
-    <v-list density="compact" bg-color="transparent" class="pa-0">
+    <!-- Equivalences (meter mode) — rendered when equivalences prop is present -->
+    <v-list
+      v-if="equivalences && equivalences.length > 0"
+      density="compact"
+      bg-color="transparent"
+      class="pa-0"
+    >
+      <v-list-item
+        v-for="equiv in equivalences"
+        :key="equiv.label"
+        class="px-0"
+      >
+        <template #prepend>
+          <v-icon
+            icon="fa-solid fa-tilde"
+            color="primary"
+            size="small"
+            class="mr-3"
+          ></v-icon>
+        </template>
+        <v-list-item-title>
+          ~{{ equiv.count }} {{ equiv.label }}
+        </v-list-item-title>
+      </v-list-item>
+    </v-list>
+
+    <!-- Features (legacy mode) — rendered when equivalences is absent or empty -->
+    <v-list
+      v-else
+      density="compact"
+      bg-color="transparent"
+      class="pa-0"
+    >
       <v-list-item
         v-for="feature in plan.features"
         :key="feature.text"
@@ -124,6 +163,15 @@ export default {
     loading: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * @desc Optional meter-mode equivalences. When provided, renders a bullet list of
+     * "~{count} {label}" items instead of the legacy feature list.
+     * @type {Array<{label: string, count: number}>}
+     */
+    equivalences: {
+      type: Array,
+      default: null,
     },
   },
   emits: ['select'],

--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -119,14 +119,18 @@ export default {
   emits: ['open-drawer'],
 
   /**
-   * @desc Wires both useQuota (legacy) and useMeter (meter) composables.
-   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed: ComputedRef, meterQuota: ComputedRef, meterExtras: ComputedRef }}
+   * @desc Wires useQuota (always) and useMeter only in meter mode to avoid
+   * unnecessary reactive subscriptions and polling in legacy mode.
+   * @param {Object} props - Component props
+   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed?: ComputedRef, meterQuota?: ComputedRef, meterExtras?: ComputedRef }}
    */
-  setup() {
+  setup(props) {
     const { usage, limits, usagePercent } = useQuota();
-    const { used: meterUsed, quota: meterQuota, extras: meterExtras } = useMeter({ pollIntervalMs: 0 });
-
-    return { usage, limits, usagePercent, meterUsed, meterQuota, meterExtras };
+    if (props.mode === 'meter') {
+      const { used: meterUsed, quota: meterQuota, extras: meterExtras } = useMeter({ pollIntervalMs: 0 });
+      return { usage, limits, usagePercent, meterUsed, meterQuota, meterExtras };
+    }
+    return { usage, limits, usagePercent };
   },
 
   computed: {

--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -2,17 +2,54 @@
   BillingUsageBarComponent
   ========================
   Displays a progress bar showing usage quota for a given resource action.
+  Supports two modes:
+    - 'legacy' (default): reads quota data via useQuota composable (resource/action props required).
+    - 'meter': reads weekly meter data via useMeter composable. Emits 'open-drawer' on click.
 
-  USAGE:
-  <billingUsageBarComponent resource="documents" action="create" />
+  USAGE (legacy):
+  <BillingUsageBarComponent resource="documents" action="create" />
+
+  USAGE (meter):
+  <BillingUsageBarComponent mode="meter" @open-drawer="drawerOpen = true" />
 
   PROPS:
-  - resource (String, required): Resource name (e.g. "documents")
-  - action (String, required): Action name (e.g. "create")
-  - label (String, optional): Display label, defaults to "${resource} ${action}"
+  - mode     ('legacy'|'meter', default 'legacy'): rendering mode
+  - resource (String): Resource name — required in legacy mode
+  - action   (String): Action name — required in legacy mode
+  - label    (String, optional): Display label
+
+  EVENTS:
+  - open-drawer: emitted on click in meter mode (parent should open BillingMeterDrawerComponent)
 -->
 <template>
-  <div>
+  <!-- Meter mode -->
+  <div
+    v-if="mode === 'meter'"
+    class="billing-usage-bar billing-usage-bar--meter"
+    role="button"
+    tabindex="0"
+    style="cursor: pointer"
+    aria-label="Open meter drawer"
+    @click="$emit('open-drawer')"
+    @keydown.enter="$emit('open-drawer')"
+    @keydown.space.prevent="$emit('open-drawer')"
+  >
+    <div class="d-flex justify-space-between text-body-2 text-medium-emphasis mb-1">
+      <span>{{ displayLabel || 'Weekly usage' }}</span>
+      <span class="font-weight-medium">{{ meterDisplay }}</span>
+    </div>
+    <BillingMeterProgressComponent
+      :used="meterUsed"
+      :quota="meterQuota"
+      :extras="meterExtras"
+    />
+  </div>
+
+  <!-- Legacy mode -->
+  <div
+    v-else
+    class="billing-usage-bar"
+  >
     <div class="d-flex justify-space-between text-body-small text-medium-emphasis mb-1">
       <span>{{ displayLabel }}</span>
       <span>{{ currentDisplay }}</span>
@@ -32,104 +69,146 @@
  * Module dependencies.
  */
 import { useQuota } from '../composables/billing.useQuota';
+import { useMeter } from '../composables/billing.useMeter';
+import BillingMeterProgressComponent from './billing.meterProgress.component.vue';
 
 /**
  * Component definition.
  */
 export default {
   name: 'BillingUsageBarComponent',
+
+  components: {
+    BillingMeterProgressComponent,
+  },
+
   props: {
     /**
-     * @desc Resource name (e.g. "documents").
+     * @desc Rendering mode.
+     * - 'legacy': reads quota via useQuota (resource + action required).
+     * - 'meter': reads weekly meter data via useMeter; emits 'open-drawer' on click.
+     */
+    mode: {
+      type: String,
+      default: 'legacy',
+      validator: (v) => ['legacy', 'meter'].includes(v),
+    },
+    /**
+     * @desc Resource name (e.g. "documents") — legacy mode only.
      */
     resource: {
       type: String,
-      required: true,
+      default: '',
     },
     /**
-     * @desc Action name (e.g. "create").
+     * @desc Action name (e.g. "create") — legacy mode only.
      */
     action: {
       type: String,
-      required: true,
+      default: '',
     },
     /**
-     * @desc Display label, defaults to "${resource} ${action}".
+     * @desc Display label. Defaults to "${resource} ${action}" in legacy or "Weekly usage" in meter.
      */
     label: {
       type: String,
       default: '',
     },
   },
+
+  emits: ['open-drawer'],
+
   /**
-   * @desc Wires useQuota composable and exposes reactive usage, limits, and usagePercent.
-   * @returns {{ usage: Object, limits: Object, usagePercent: Function }}
+   * @desc Wires both useQuota (legacy) and useMeter (meter) composables.
+   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed: ComputedRef, meterQuota: ComputedRef, meterExtras: ComputedRef }}
    */
   setup() {
     const { usage, limits, usagePercent } = useQuota();
+    const { used: meterUsed, quota: meterQuota, extras: meterExtras } = useMeter({ pollIntervalMs: 0 });
 
-    return { usage, limits, usagePercent };
+    return { usage, limits, usagePercent, meterUsed, meterQuota, meterExtras };
   },
+
   computed: {
     /**
-     * @desc Quota key derived from resource and action.
+     * @desc Quota key derived from resource and action (legacy mode).
      * @returns {string}
      */
     key() {
       return `${this.resource}.${this.action}`;
     },
+
     /**
      * @desc Display label for the bar.
      * @returns {string}
      */
     displayLabel() {
-      return this.label || `${this.resource} ${this.action}`;
+      return this.label || (this.mode === 'legacy' ? `${this.resource} ${this.action}` : '');
     },
+
+    // ── Legacy mode computeds ──────────────────────────────────────────────
+
     /**
-     * @desc Whether this resource action has a finite limit.
+     * @desc Whether this resource action has a finite limit (legacy).
      * @returns {boolean}
      */
     hasLimit() {
       const limit = this.limits[this.key];
       return limit !== undefined && limit !== null && limit !== Infinity;
     },
+
     /**
-     * @desc Current usage count.
+     * @desc Current usage count (legacy).
      * @returns {number}
      */
     current() {
       return this.usage[this.key] || 0;
     },
+
     /**
-     * @desc Limit value.
+     * @desc Limit value (legacy).
      * @returns {number}
      */
     limit() {
       return this.limits[this.key];
     },
+
     /**
-     * @desc Usage percentage.
+     * @desc Usage percentage (legacy).
      * @returns {number}
      */
     percent() {
       return this.usagePercent(this.resource, this.action);
     },
+
     /**
-     * @desc Display string for current/limit count.
+     * @desc Display string for current/limit count (legacy).
      * @returns {string}
      */
     currentDisplay() {
       if (!this.hasLimit) return 'Unlimited';
       return `${this.current}/${this.limit}`;
     },
+
     /**
-     * @desc Bar color based on usage percentage thresholds.
+     * @desc Bar color based on usage percentage thresholds (legacy).
      * @returns {string}
      */
     barColor() {
       if (this.percent >= 90) return 'error';
       if (this.percent >= 70) return 'warning';
       return 'success';
+    },
+
+    // ── Meter mode computeds ───────────────────────────────────────────────
+
+    /**
+     * @desc Usage summary text shown in meter mode header: "{used} / {quota} +{extras}".
+     * @returns {string}
+     */
+    meterDisplay() {
+      const base = `${this.meterUsed} / ${this.meterQuota}`;
+      return this.meterExtras > 0 ? `${base} +${this.meterExtras}` : base;
     },
   },
 };

--- a/src/modules/billing/config/billing.development.config.js
+++ b/src/modules/billing/config/billing.development.config.js
@@ -1,5 +1,10 @@
 /**
  * Billing plans static marketing content.
+ *
+ * Each plan may optionally include an `equivalences` array for meter mode display.
+ * Equivalences are illustrative devkit defaults — downstream projects override with
+ * their own branding and counts.
+ * @type {Array<{label: string, count: number}>}
  */
 export const plans = [
   {
@@ -15,6 +20,10 @@ export const plans = [
       { text: 'Community support', included: true },
       { text: 'Advanced analytics', included: false },
     ],
+    // i18n key: billing.equivalences.scrapRun → "operations / week"
+    equivalences: [
+      { label: 'operations / week', count: 100 },
+    ],
   },
   {
     id: 'starter',
@@ -28,6 +37,9 @@ export const plans = [
       { text: '10 team members', included: true },
       { text: 'Email support', included: true },
       { text: 'Advanced analytics', included: false },
+    ],
+    equivalences: [
+      { label: 'operations / week', count: 500 },
     ],
   },
   {
@@ -43,8 +55,18 @@ export const plans = [
       { text: 'Priority support', included: true },
       { text: 'Advanced analytics', included: true },
     ],
+    equivalences: [
+      { label: 'operations / week', count: 2000 },
+    ],
   },
 ];
+
+/**
+ * Extra credit packs available for purchase.
+ * Devkit default is empty — downstream projects populate with marketing copy and Stripe pack IDs.
+ * @type {Array<{packId: string, label: string, priceUsd: number, meterUnits: number}>}
+ */
+export const packs = [];
 
 /**
  * Exports.
@@ -52,5 +74,6 @@ export const plans = [
 export default {
   billing: {
     plans,
+    packs,
   },
 };

--- a/src/modules/billing/config/billing.development.config.js
+++ b/src/modules/billing/config/billing.development.config.js
@@ -4,7 +4,7 @@
  * Each plan may optionally include an `equivalences` array for meter mode display.
  * Equivalences are illustrative devkit defaults — downstream projects override with
  * their own branding and counts.
- * @type {Array<{label: string, count: number}>}
+ * @type {Array<{id: string, name: string, tagline: string, highlighted: boolean, badge: string|null, cta: string, features: Array<{text: string, included: boolean}>, equivalences?: Array<{label: string, count: number}>}>}
  */
 export const plans = [
   {

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -1,0 +1,60 @@
+/**
+ * Billing module — English i18n strings.
+ * These keys are referenced in billing components via comments for future vue-i18n adoption.
+ * Downstream projects may override these strings by merging into their i18n configuration.
+ */
+export const billingEn = {
+  billing: {
+    usage: {
+      /** i18n key: billing.usage.weekly */
+      weekly: 'Weekly meter',
+      /** i18n key: billing.usage.breakdown */
+      breakdown: 'Breakdown',
+      /** i18n key: billing.usage.progress — interpolate {used} and {quota} */
+      progress: '{used} of {quota} units used',
+      /** i18n key: billing.usage.exhausted */
+      exhausted: 'Quota exhausted',
+      bucket: {
+        /** i18n key: billing.usage.bucket.scrap */
+        scrap: 'Scrape',
+        /** i18n key: billing.usage.bucket.autofix */
+        autofix: 'Autofix',
+        /** i18n key: billing.usage.bucket.wizard */
+        wizard: 'Wizard',
+        /** i18n key: billing.usage.bucket.digest */
+        digest: 'Digest',
+        /** i18n key: billing.usage.bucket.generate */
+        generate: 'Generate',
+        /** i18n key: billing.usage.bucket.chat */
+        chat: 'Chat',
+      },
+    },
+    extras: {
+      /** i18n key: billing.extras.title */
+      title: 'Extra units',
+      /** i18n key: billing.extras.balance — interpolate {units} */
+      balance: '{units} units remaining',
+      /** i18n key: billing.extras.cta */
+      cta: 'Buy units',
+      /** i18n key: billing.extras.purchaseSuccess */
+      purchaseSuccess: 'Pack credited to your balance',
+    },
+    alerts: {
+      /** i18n key: billing.alerts.threshold80 */
+      threshold80: "You've used 80% of your weekly quota",
+      /** i18n key: billing.alerts.threshold100 */
+      threshold100: 'Quota reached — extras consumed',
+      /** i18n key: billing.alerts.extrasConsumed */
+      extrasConsumed: 'Extras balance is empty',
+    },
+    equivalences: {
+      /** i18n key: billing.equivalences.scrapRun */
+      scrapRun: 'operations / week',
+    },
+  },
+};
+
+/**
+ * Exports.
+ */
+export default billingEn;

--- a/src/modules/billing/lang/fr.js
+++ b/src/modules/billing/lang/fr.js
@@ -1,0 +1,60 @@
+/**
+ * Billing module — French i18n strings.
+ * These keys are referenced in billing components via comments for future vue-i18n adoption.
+ * Downstream projects may override these strings by merging into their i18n configuration.
+ */
+export const billingFr = {
+  billing: {
+    usage: {
+      /** i18n key: billing.usage.weekly */
+      weekly: 'Compteur hebdo',
+      /** i18n key: billing.usage.breakdown */
+      breakdown: 'Répartition',
+      /** i18n key: billing.usage.progress — interpolate {used} and {quota} */
+      progress: '{used} sur {quota} unités utilisées',
+      /** i18n key: billing.usage.exhausted */
+      exhausted: 'Quota épuisé',
+      bucket: {
+        /** i18n key: billing.usage.bucket.scrap */
+        scrap: 'Scrape',
+        /** i18n key: billing.usage.bucket.autofix */
+        autofix: 'Autofix',
+        /** i18n key: billing.usage.bucket.wizard */
+        wizard: 'Assistant',
+        /** i18n key: billing.usage.bucket.digest */
+        digest: 'Résumé',
+        /** i18n key: billing.usage.bucket.generate */
+        generate: 'Génération',
+        /** i18n key: billing.usage.bucket.chat */
+        chat: 'Chat',
+      },
+    },
+    extras: {
+      /** i18n key: billing.extras.title */
+      title: 'Unités supplémentaires',
+      /** i18n key: billing.extras.balance — interpolate {units} */
+      balance: '{units} unités restantes',
+      /** i18n key: billing.extras.cta */
+      cta: 'Acheter des unités',
+      /** i18n key: billing.extras.purchaseSuccess */
+      purchaseSuccess: 'Pack crédité sur votre solde',
+    },
+    alerts: {
+      /** i18n key: billing.alerts.threshold80 */
+      threshold80: 'Vous avez utilisé 80 % de votre quota hebdomadaire',
+      /** i18n key: billing.alerts.threshold100 */
+      threshold100: 'Quota atteint — extras consommés',
+      /** i18n key: billing.alerts.extrasConsumed */
+      extrasConsumed: 'Le solde des extras est épuisé',
+    },
+    equivalences: {
+      /** i18n key: billing.equivalences.scrapRun */
+      scrapRun: 'opérations / semaine',
+    },
+  },
+};
+
+/**
+ * Exports.
+ */
+export default billingFr;

--- a/src/modules/billing/tests/billing.extrasCheckoutModal.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.extrasCheckoutModal.component.unit.tests.js
@@ -1,9 +1,10 @@
+import { ref } from 'vue';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
-import { useBillingStore } from '../stores/billing.store';
 import BillingExtrasCheckoutModalComponent from '../components/billing.extrasCheckoutModal.component.vue';
+import * as useMeterModule from '../composables/billing.useMeter.js';
 
 const vuetify = createVuetify();
 
@@ -12,18 +13,18 @@ const mockPacks = [
   { packId: 'pack_1000', label: '1000 units', priceUsd: 16, meterUnits: 1000 },
 ];
 
+/** Shared purchasePack spy, reset in beforeEach. */
+let purchasePackSpy;
+
 /**
  * Mount BillingExtrasCheckoutModalComponent with Vuetify and Pinia.
- * Stubs v-dialog (requires visualViewport, unavailable in jsdom) and
- * spies on store actions to prevent HTTP calls from useMeter polling.
+ * Mocks useMeter composable entirely so purchasePack is directly observable
+ * without relying on the internal store delegation chain.
  * @param {Object} props - Component props
  * @returns {import('@vue/test-utils').VueWrapper}
  */
-const mountComponent = (props = {}) => {
-  const store = useBillingStore();
-  vi.spyOn(store, 'fetchUsageMeter').mockResolvedValue(null);
-  vi.spyOn(store, 'fetchExtrasBalance').mockResolvedValue(null);
-  return mount(BillingExtrasCheckoutModalComponent, {
+const mountComponent = (props = {}) =>
+  mount(BillingExtrasCheckoutModalComponent, {
     props: { modelValue: false, packs: mockPacks, ...props },
     global: {
       plugins: [vuetify],
@@ -39,12 +40,23 @@ const mountComponent = (props = {}) => {
     },
     attachTo: document.body,
   });
-};
 
 describe('BillingExtrasCheckoutModalComponent', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    purchasePackSpy = vi.fn();
+    vi.spyOn(useMeterModule, 'useMeter').mockReturnValue({
+      used: ref(0),
+      quota: ref(0),
+      extras: ref(0),
+      breakdown: ref({}),
+      progress: ref(0),
+      breakdownPercent: ref({}),
+      totalRemaining: ref(0),
+      refresh: vi.fn(),
+      purchasePack: purchasePackSpy,
+    });
   });
 
   // ── Rendering ────────────────────────────────────────────────────────────
@@ -126,8 +138,7 @@ describe('BillingExtrasCheckoutModalComponent', () => {
   // ── Buy flow ─────────────────────────────────────────────────────────────
 
   it('calls purchasePack with selected packId when Buy is clicked', async () => {
-    const store = useBillingStore();
-    vi.spyOn(store, 'createExtrasCheckout').mockResolvedValue(undefined);
+    purchasePackSpy.mockResolvedValue(undefined);
 
     const wrapper = mountComponent({ modelValue: true });
     // selectedPackId defaults to first pack
@@ -135,13 +146,12 @@ describe('BillingExtrasCheckoutModalComponent', () => {
     expect(buyBtn).toBeDefined();
     await buyBtn.trigger('click');
     await wrapper.vm.$nextTick();
-    expect(store.createExtrasCheckout).toHaveBeenCalledWith('pack_500');
+    expect(purchasePackSpy).toHaveBeenCalledWith('pack_500');
   });
 
   it('sets purchasing=true while buy is in progress', async () => {
-    const store = useBillingStore();
     let resolve;
-    vi.spyOn(store, 'createExtrasCheckout').mockReturnValue(
+    purchasePackSpy.mockReturnValue(
       new Promise((res) => {
         resolve = res;
       }),
@@ -149,7 +159,8 @@ describe('BillingExtrasCheckoutModalComponent', () => {
 
     const wrapper = mountComponent({ modelValue: true });
     const buyBtn = wrapper.findAll('.v-btn').find((b) => b.text().includes('Buy'));
-    buyBtn.trigger('click');
+    // Await trigger so the click handler starts executing (purchasing flips synchronously)
+    await buyBtn.trigger('click');
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.purchasing).toBe(true);
 
@@ -159,8 +170,7 @@ describe('BillingExtrasCheckoutModalComponent', () => {
   });
 
   it('resets purchasing=false after error in purchasePack', async () => {
-    const store = useBillingStore();
-    vi.spyOn(store, 'createExtrasCheckout').mockRejectedValue(new Error('Network error'));
+    purchasePackSpy.mockRejectedValue(new Error('Network error'));
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const wrapper = mountComponent({ modelValue: true });

--- a/src/modules/billing/tests/billing.extrasCheckoutModal.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.extrasCheckoutModal.component.unit.tests.js
@@ -1,10 +1,9 @@
-import { ref } from 'vue';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
+import { useBillingStore } from '../stores/billing.store';
 import BillingExtrasCheckoutModalComponent from '../components/billing.extrasCheckoutModal.component.vue';
-import * as useMeterModule from '../composables/billing.useMeter.js';
 
 const vuetify = createVuetify();
 
@@ -13,13 +12,13 @@ const mockPacks = [
   { packId: 'pack_1000', label: '1000 units', priceUsd: 16, meterUnits: 1000 },
 ];
 
-/** Shared purchasePack spy, reset in beforeEach. */
+/** Shared createExtrasCheckout spy, reset in beforeEach. */
 let purchasePackSpy;
 
 /**
  * Mount BillingExtrasCheckoutModalComponent with Vuetify and Pinia.
- * Mocks useMeter composable entirely so purchasePack is directly observable
- * without relying on the internal store delegation chain.
+ * Spies on billingStore.createExtrasCheckout so purchasePack is directly
+ * observable without triggering HTTP calls.
  * @param {Object} props - Component props
  * @returns {import('@vue/test-utils').VueWrapper}
  */
@@ -36,6 +35,13 @@ const mountComponent = (props = {}) =>
           emits: ['update:modelValue'],
           template: '<div class="v-dialog-stub" v-bind="$attrs"><slot /></div>',
         },
+        // v-alert: stub to avoid Vuetify overlay/transition complexity in unit tests
+        'v-alert': {
+          name: 'v-alert',
+          props: ['type', 'variant', 'density', 'closable'],
+          emits: ['click:close'],
+          template: '<div class="v-alert-stub" v-bind="$attrs"><slot /></div>',
+        },
       },
     },
     attachTo: document.body,
@@ -46,17 +52,8 @@ describe('BillingExtrasCheckoutModalComponent', () => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
     purchasePackSpy = vi.fn();
-    vi.spyOn(useMeterModule, 'useMeter').mockReturnValue({
-      used: ref(0),
-      quota: ref(0),
-      extras: ref(0),
-      breakdown: ref({}),
-      progress: ref(0),
-      breakdownPercent: ref({}),
-      totalRemaining: ref(0),
-      refresh: vi.fn(),
-      purchasePack: purchasePackSpy,
-    });
+    const store = useBillingStore();
+    vi.spyOn(store, 'createExtrasCheckout').mockImplementation(purchasePackSpy);
   });
 
   // ── Rendering ────────────────────────────────────────────────────────────
@@ -137,7 +134,7 @@ describe('BillingExtrasCheckoutModalComponent', () => {
 
   // ── Buy flow ─────────────────────────────────────────────────────────────
 
-  it('calls purchasePack with selected packId when Buy is clicked', async () => {
+  it('calls createExtrasCheckout with selected packId when Buy is clicked', async () => {
     purchasePackSpy.mockResolvedValue(undefined);
 
     const wrapper = mountComponent({ modelValue: true });
@@ -169,7 +166,7 @@ describe('BillingExtrasCheckoutModalComponent', () => {
     expect(wrapper.vm.purchasing).toBe(false);
   });
 
-  it('resets purchasing=false after error in purchasePack', async () => {
+  it('resets purchasing=false and sets purchaseError after error in createExtrasCheckout', async () => {
     purchasePackSpy.mockRejectedValue(new Error('Network error'));
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -180,6 +177,29 @@ describe('BillingExtrasCheckoutModalComponent', () => {
     await wrapper.vm.$nextTick(); // let the promise settle
 
     expect(wrapper.vm.purchasing).toBe(false);
+    expect(wrapper.vm.purchaseError).toBe('Unable to start checkout. Please try again.');
+    consoleSpy.mockRestore();
+  });
+
+  it('clears purchaseError on retry (new buy attempt)', async () => {
+    purchasePackSpy
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValue(undefined);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const wrapper = mountComponent({ modelValue: true });
+    const buyBtn = wrapper.findAll('.v-btn').find((b) => b.text().includes('Buy'));
+
+    // First click → error
+    await buyBtn.trigger('click');
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.purchaseError).toBeTruthy();
+
+    // Second click → clears error before attempt
+    await buyBtn.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.purchaseError).toBeNull();
     consoleSpy.mockRestore();
   });
 

--- a/src/modules/billing/tests/billing.extrasCheckoutModal.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.extrasCheckoutModal.component.unit.tests.js
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+import { useBillingStore } from '../stores/billing.store';
+import BillingExtrasCheckoutModalComponent from '../components/billing.extrasCheckoutModal.component.vue';
+
+const vuetify = createVuetify();
+
+const mockPacks = [
+  { packId: 'pack_500', label: '500 units', priceUsd: 9, meterUnits: 500 },
+  { packId: 'pack_1000', label: '1000 units', priceUsd: 16, meterUnits: 1000 },
+];
+
+/**
+ * Mount BillingExtrasCheckoutModalComponent with Vuetify and Pinia.
+ * Stubs v-dialog (requires visualViewport, unavailable in jsdom) and
+ * spies on store actions to prevent HTTP calls from useMeter polling.
+ * @param {Object} props - Component props
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountComponent = (props = {}) => {
+  const store = useBillingStore();
+  vi.spyOn(store, 'fetchUsageMeter').mockResolvedValue(null);
+  vi.spyOn(store, 'fetchExtrasBalance').mockResolvedValue(null);
+  return mount(BillingExtrasCheckoutModalComponent, {
+    props: { modelValue: false, packs: mockPacks, ...props },
+    global: {
+      plugins: [vuetify],
+      stubs: {
+        // v-dialog uses VOverlay which needs visualViewport (not in jsdom)
+        'v-dialog': {
+          name: 'v-dialog',
+          props: ['modelValue', 'maxWidth'],
+          emits: ['update:modelValue'],
+          template: '<div class="v-dialog-stub" v-bind="$attrs"><slot /></div>',
+        },
+      },
+    },
+    attachTo: document.body,
+  });
+};
+
+describe('BillingExtrasCheckoutModalComponent', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  // ── Rendering ────────────────────────────────────────────────────────────
+
+  it('renders a v-dialog', () => {
+    const wrapper = mountComponent();
+    expect(wrapper.findComponent({ name: 'v-dialog' }).exists()).toBe(true);
+  });
+
+  it('passes modelValue to the dialog', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.findComponent({ name: 'v-dialog' }).props('modelValue')).toBe(true);
+  });
+
+  it('renders pack radio options', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.text()).toContain('500 units');
+    expect(wrapper.text()).toContain('1000 units');
+  });
+
+  it('renders pack price in label', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.text()).toContain('$9');
+    expect(wrapper.text()).toContain('$16');
+  });
+
+  it('renders unit count in label', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.text()).toContain('+500 units');
+    expect(wrapper.text()).toContain('+1000 units');
+  });
+
+  it('shows "No packs available" when packs is empty', () => {
+    const wrapper = mountComponent({ modelValue: true, packs: [] });
+    expect(wrapper.text()).toContain('No packs available');
+  });
+
+  // ── Default selection ────────────────────────────────────────────────────
+
+  it('pre-selects the first pack when packs are provided', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.vm.selectedPackId).toBe('pack_500');
+  });
+
+  it('does not pre-select when packs is empty', () => {
+    const wrapper = mountComponent({ modelValue: true, packs: [] });
+    expect(wrapper.vm.selectedPackId).toBeNull();
+  });
+
+  it('pre-selects on open when dialog opens with packs', async () => {
+    const wrapper = mountComponent({ modelValue: false });
+    expect(wrapper.vm.selectedPackId).toBe('pack_500'); // packs watcher fires immediately
+  });
+
+  // ── CTA label ────────────────────────────────────────────────────────────
+
+  it('CTA button shows selected pack label', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    // First pack selected by default
+    expect(wrapper.vm.selectedPackLabel).toBe('500 units');
+  });
+
+  it('selectedPackLabel is empty string when no selection', () => {
+    const wrapper = mountComponent({ modelValue: true, packs: [] });
+    expect(wrapper.vm.selectedPackLabel).toBe('');
+  });
+
+  // ── Emits ────────────────────────────────────────────────────────────────
+
+  it('emits update:modelValue false when Cancel is clicked', async () => {
+    const wrapper = mountComponent({ modelValue: true });
+    const cancelBtn = wrapper.findAll('.v-btn').find((b) => b.text() === 'Cancel');
+    expect(cancelBtn).toBeDefined();
+    await cancelBtn.trigger('click');
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    expect(wrapper.emitted('update:modelValue')[0][0]).toBe(false);
+  });
+
+  // ── Buy flow ─────────────────────────────────────────────────────────────
+
+  it('calls purchasePack with selected packId when Buy is clicked', async () => {
+    const store = useBillingStore();
+    vi.spyOn(store, 'createExtrasCheckout').mockResolvedValue(undefined);
+
+    const wrapper = mountComponent({ modelValue: true });
+    // selectedPackId defaults to first pack
+    const buyBtn = wrapper.findAll('.v-btn').find((b) => b.text().includes('Buy'));
+    expect(buyBtn).toBeDefined();
+    await buyBtn.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(store.createExtrasCheckout).toHaveBeenCalledWith('pack_500');
+  });
+
+  it('sets purchasing=true while buy is in progress', async () => {
+    const store = useBillingStore();
+    let resolve;
+    vi.spyOn(store, 'createExtrasCheckout').mockReturnValue(
+      new Promise((res) => {
+        resolve = res;
+      }),
+    );
+
+    const wrapper = mountComponent({ modelValue: true });
+    const buyBtn = wrapper.findAll('.v-btn').find((b) => b.text().includes('Buy'));
+    buyBtn.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.purchasing).toBe(true);
+
+    resolve();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.purchasing).toBe(false);
+  });
+
+  it('resets purchasing=false after error in purchasePack', async () => {
+    const store = useBillingStore();
+    vi.spyOn(store, 'createExtrasCheckout').mockRejectedValue(new Error('Network error'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const wrapper = mountComponent({ modelValue: true });
+    const buyBtn = wrapper.findAll('.v-btn').find((b) => b.text().includes('Buy'));
+    await buyBtn.trigger('click');
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick(); // let the promise settle
+
+    expect(wrapper.vm.purchasing).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it('Buy button is disabled when selectedPackId is null', () => {
+    // When packs is empty, selectedPackId remains null → buy CTA should be disabled
+    const wrapper = mountComponent({ modelValue: true, packs: [] });
+    expect(wrapper.vm.selectedPackId).toBeNull();
+    // Component logic: :disabled="!selectedPackId || purchasing"
+    // When selectedPackId is null, the computed disabled condition is true
+    expect(!wrapper.vm.selectedPackId || wrapper.vm.purchasing).toBe(true);
+  });
+
+  // ── Prop validation ──────────────────────────────────────────────────────
+
+  it('renders with empty packs array without errors', () => {
+    expect(() => mountComponent({ modelValue: false, packs: [] })).not.toThrow();
+  });
+
+  it('renders correctly with modelValue=false (closed state)', () => {
+    const wrapper = mountComponent({ modelValue: false });
+    const dialog = wrapper.findComponent({ name: 'v-dialog' });
+    expect(dialog.props('modelValue')).toBe(false);
+  });
+});

--- a/src/modules/billing/tests/billing.meterDrawer.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterDrawer.component.unit.tests.js
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+import { useBillingStore } from '../stores/billing.store';
+import BillingMeterDrawerComponent from '../components/billing.meterDrawer.component.vue';
+
+const vuetify = createVuetify();
+
+/**
+ * Mount BillingMeterDrawerComponent with Vuetify and Pinia.
+ * Stubs v-navigation-drawer (requires Vuetify layout context unavailable in unit tests)
+ * and spies on store actions to prevent HTTP calls from useMeter polling.
+ * @param {Object} props - Component props
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountComponent = (props = {}) => {
+  const store = useBillingStore();
+  vi.spyOn(store, 'fetchUsageMeter').mockResolvedValue(null);
+  vi.spyOn(store, 'fetchExtrasBalance').mockResolvedValue(null);
+  return mount(BillingMeterDrawerComponent, {
+    props: { modelValue: false, ...props },
+    global: {
+      plugins: [vuetify],
+      stubs: {
+        // v-navigation-drawer requires a Vuetify layout context; stub with a passthrough
+        'v-navigation-drawer': {
+          name: 'v-navigation-drawer',
+          props: ['modelValue', 'location', 'temporary', 'width'],
+          emits: ['update:modelValue'],
+          template: '<div class="v-navigation-drawer-stub" v-bind="$attrs"><slot /></div>',
+        },
+        // Stub checkout modal to avoid Vuetify dialog/overlay visualViewport errors in unit tests
+        BillingExtrasCheckoutModalComponent: {
+          name: 'BillingExtrasCheckoutModalComponent',
+          props: ['modelValue', 'packs'],
+          emits: ['update:modelValue'],
+          template: '<div class="billing-extras-checkout-modal-stub" />',
+        },
+      },
+    },
+    attachTo: document.body,
+  });
+};
+
+describe('BillingMeterDrawerComponent', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  // ── Props ────────────────────────────────────────────────────────────────
+
+  it('renders a v-navigation-drawer', () => {
+    const wrapper = mountComponent();
+    expect(wrapper.findComponent({ name: 'v-navigation-drawer' }).exists()).toBe(true);
+  });
+
+  it('passes modelValue to the drawer', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    const drawer = wrapper.findComponent({ name: 'v-navigation-drawer' });
+    expect(drawer.props('modelValue')).toBe(true);
+  });
+
+  it('drawer has location=right', () => {
+    const wrapper = mountComponent();
+    const drawer = wrapper.findComponent({ name: 'v-navigation-drawer' });
+    expect(drawer.props('location')).toBe('right');
+  });
+
+  it('drawer is temporary', () => {
+    const wrapper = mountComponent();
+    const drawer = wrapper.findComponent({ name: 'v-navigation-drawer' });
+    // Boolean prop may be passed as '' or true depending on the stub
+    const temporaryVal = drawer.props('temporary');
+    expect(temporaryVal === true || temporaryVal === '' || temporaryVal === 'true').toBe(true);
+  });
+
+  // ── Emits ────────────────────────────────────────────────────────────────
+
+  it('emits update:modelValue false when close button is clicked', async () => {
+    const wrapper = mountComponent({ modelValue: true });
+    // Find close button by aria-label
+    const closeBtn = wrapper.find('[aria-label="Close meter drawer"]');
+    await closeBtn.trigger('click');
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    expect(wrapper.emitted('update:modelValue')[0][0]).toBe(false);
+  });
+
+  // ── Content ──────────────────────────────────────────────────────────────
+
+  it('renders "Weekly meter" header text', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.text()).toContain('Weekly meter');
+  });
+
+  it('renders "Breakdown" section label', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.text()).toContain('Breakdown');
+  });
+
+  it('renders "Extra units" section label', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.text()).toContain('Extra units');
+  });
+
+  it('renders "Buy units" CTA button', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.text()).toContain('Buy units');
+  });
+
+  it('renders BillingMeterProgressComponent', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.findComponent({ name: 'BillingMeterProgressComponent' }).exists()).toBe(true);
+  });
+
+  it('renders BillingMeterBreakdownChartComponent', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.findComponent({ name: 'BillingMeterBreakdownChartComponent' }).exists()).toBe(true);
+  });
+
+  it('renders BillingExtrasCheckoutModalComponent', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.findComponent({ name: 'BillingExtrasCheckoutModalComponent' }).exists()).toBe(true);
+  });
+
+  // ── Meter data ───────────────────────────────────────────────────────────
+
+  it('reflects store meter values in the progress component', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 400, meterQuota: 1000, extrasRemaining: 50 };
+    const wrapper = mountComponent({ modelValue: true });
+    const progress = wrapper.findComponent({ name: 'BillingMeterProgressComponent' });
+    expect(progress.props('used')).toBe(400);
+    expect(progress.props('quota')).toBe(1000);
+    expect(progress.props('extras')).toBe(50);
+  });
+
+  it('reflects breakdown from store in chart component', () => {
+    const store = useBillingStore();
+    store.usageMeter = {
+      meterUsed: 300,
+      meterQuota: 1000,
+      meterBreakdown: { scrap: 200, autofix: 100 },
+    };
+    const wrapper = mountComponent({ modelValue: true });
+    const chart = wrapper.findComponent({ name: 'BillingMeterBreakdownChartComponent' });
+    expect(chart.props('breakdown')).toEqual({ scrap: 200, autofix: 100 });
+  });
+
+  // ── Extras checkout modal open ────────────────────────────────────────────
+
+  it('extras modal is closed by default', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.vm.extrasModalOpen).toBe(false);
+  });
+
+  it('opens extras modal when "Buy units" is clicked', async () => {
+    const wrapper = mountComponent({ modelValue: true });
+    const buyBtn = wrapper.findAll('.v-btn').find((b) => b.text().includes('Buy units'));
+    expect(buyBtn).toBeDefined();
+    await buyBtn.trigger('click');
+    expect(wrapper.vm.extrasModalOpen).toBe(true);
+  });
+
+  // ── packsAvailable ───────────────────────────────────────────────────────
+
+  it('sources packsAvailable from usageMeter when available', () => {
+    const store = useBillingStore();
+    const packs = [{ packId: 'pack_500', label: '500 units', priceUsd: 9, meterUnits: 500 }];
+    store.usageMeter = { meterUsed: 0, meterQuota: 1000, packsAvailable: packs };
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.vm.packsAvailable).toEqual(packs);
+  });
+
+  it('falls back to extrasBalance.packsAvailable when usageMeter has none', () => {
+    const store = useBillingStore();
+    const packs = [{ packId: 'pack_200', label: '200 units', priceUsd: 4, meterUnits: 200 }];
+    store.usageMeter = { meterUsed: 0, meterQuota: 1000 };
+    store.extrasBalance = { balance: 0, packsAvailable: packs };
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.vm.packsAvailable).toEqual(packs);
+  });
+
+  it('returns empty array when neither store has packs', () => {
+    const wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.vm.packsAvailable).toEqual([]);
+  });
+});

--- a/src/modules/billing/tests/billing.pricingCard.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingCard.component.unit.tests.js
@@ -125,4 +125,53 @@ describe('BillingPricingCardComponent', () => {
     expect(wrapper.text()).toContain('Unlimited projects');
     expect(wrapper.text()).toContain('Priority support');
   });
+
+  // ── Equivalences prop (meter mode) ───────────────────────────────────────
+
+  it('renders equivalence bullets when equivalences prop is provided', () => {
+    const wrapper = mountComponent({
+      plan: proPlan,
+      equivalences: [{ label: 'operations / week', count: 2000 }],
+    });
+    expect(wrapper.text()).toContain('~2000 operations / week');
+  });
+
+  it('renders multiple equivalences', () => {
+    const wrapper = mountComponent({
+      plan: proPlan,
+      equivalences: [
+        { label: 'scrapes / week', count: 1500 },
+        { label: 'autofixes / week', count: 500 },
+      ],
+    });
+    expect(wrapper.text()).toContain('~1500 scrapes / week');
+    expect(wrapper.text()).toContain('~500 autofixes / week');
+  });
+
+  it('hides feature list when equivalences are provided', () => {
+    const wrapper = mountComponent({
+      plan: proPlan,
+      equivalences: [{ label: 'operations / week', count: 2000 }],
+    });
+    expect(wrapper.text()).not.toContain('Unlimited projects');
+    expect(wrapper.text()).not.toContain('Priority support');
+  });
+
+  it('shows feature list when equivalences prop is null (backward compat)', () => {
+    const wrapper = mountComponent({ plan: proPlan, equivalences: null });
+    expect(wrapper.text()).toContain('Unlimited projects');
+    expect(wrapper.text()).not.toContain('~');
+  });
+
+  it('shows feature list when equivalences prop is omitted (backward compat)', () => {
+    const wrapper = mountComponent({ plan: proPlan });
+    expect(wrapper.text()).toContain('Unlimited projects');
+    expect(wrapper.text()).not.toContain('~');
+  });
+
+  it('shows feature list when equivalences is empty array', () => {
+    const wrapper = mountComponent({ plan: proPlan, equivalences: [] });
+    expect(wrapper.text()).toContain('Unlimited projects');
+    expect(wrapper.text()).not.toContain('~');
+  });
 });

--- a/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
@@ -1,9 +1,14 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 import { useBillingStore } from '../stores/billing.store';
 import BillingUsageBarComponent from '../components/billing.usageBar.component.vue';
+
+// Prevent axios calls from useMeter polling
+vi.mock('../../../lib/services/axios', () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
 
 const vuetify = createVuetify();
 
@@ -29,7 +34,10 @@ const mountComponent = (props, quotaData = null) => {
 describe('BillingUsageBarComponent', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    vi.clearAllMocks();
   });
+
+  // ── Legacy mode (default) ────────────────────────────────────────────────
 
   it('renders progress bar with correct percentage', () => {
     const wrapper = mountComponent(
@@ -139,5 +147,96 @@ describe('BillingUsageBarComponent', () => {
       },
     );
     expect(wrapper.text()).toContain('Documents');
+  });
+
+  // ── Meter mode ───────────────────────────────────────────────────────────
+
+  it('renders meter mode when mode="meter" is passed', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 200, meterQuota: 1000, extrasRemaining: 50 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    expect(wrapper.find('.billing-usage-bar--meter').exists()).toBe(true);
+  });
+
+  it('does not render v-progress-linear directly in meter mode (delegates to BillingMeterProgressComponent)', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 200, meterQuota: 1000 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    // The outer linear bar is only in legacy mode; meter uses BillingMeterProgressComponent
+    const meterRoot = wrapper.find('.billing-usage-bar--meter');
+    expect(meterRoot.exists()).toBe(true);
+  });
+
+  it('displays used / quota text in meter mode', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 300, meterQuota: 1000 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    expect(wrapper.text()).toContain('300');
+    expect(wrapper.text()).toContain('1000');
+  });
+
+  it('appends +extras to meter display when extras > 0', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 300, meterQuota: 1000, extrasRemaining: 75 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    expect(wrapper.vm.meterDisplay).toContain('+75');
+  });
+
+  it('does not append +extras when extras is 0', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 300, meterQuota: 1000, extrasRemaining: 0 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    expect(wrapper.vm.meterDisplay).not.toContain('+');
+  });
+
+  it('emits open-drawer on click in meter mode', async () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 100, meterQuota: 500 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    await wrapper.find('.billing-usage-bar--meter').trigger('click');
+    expect(wrapper.emitted('open-drawer')).toHaveLength(1);
+  });
+
+  it('emits open-drawer on Enter key in meter mode', async () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 100, meterQuota: 500 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    await wrapper.find('.billing-usage-bar--meter').trigger('keydown.enter');
+    expect(wrapper.emitted('open-drawer')).toHaveLength(1);
+  });
+
+  it('meter mode root has role=button', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 0, meterQuota: 0 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    expect(wrapper.find('.billing-usage-bar--meter').attributes('role')).toBe('button');
+  });
+
+  it('uses custom label in meter mode', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 100, meterQuota: 500 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter', label: 'Compute' });
+    expect(wrapper.text()).toContain('Compute');
+  });
+
+  it('uses "Weekly usage" fallback when no label provided in meter mode', () => {
+    const store = useBillingStore();
+    store.usageMeter = { meterUsed: 0, meterQuota: 0 };
+    const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
+    expect(wrapper.text()).toContain('Weekly usage');
+  });
+
+  it('legacy mode is unchanged when mode prop is omitted', () => {
+    const wrapper = mountComponent(
+      { resource: 'documents', action: 'create' },
+      {
+        plan: 'starter',
+        period: '2026-03',
+        usage: { 'documents.create': 5 },
+        limits: { 'documents.create': 20 },
+      },
+    );
+    expect(wrapper.find('.billing-usage-bar--meter').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'v-progress-linear' }).exists()).toBe(true);
   });
 });

--- a/src/modules/billing/views/billing.billing.view.vue
+++ b/src/modules/billing/views/billing.billing.view.vue
@@ -9,73 +9,124 @@
     <template v-else>
       <h1 class="text-headline-large font-weight-bold mb-6">Billing</h1>
 
-      <!-- Free plan state -->
-      <v-card v-if="!subscription || currentPlan === 'free'" :class="config.vuetify.theme.rounded" class="pa-6">
-        <div class="d-flex align-center mb-4">
-          <span class="text-title-large font-weight-medium mr-3">Current Plan</span>
-          <billingPlanBadgeComponent plan="free" />
-        </div>
-        <p class="text-body-medium mb-6">
-          You're on the free plan. Upgrade to unlock more projects, team members, and advanced features.
-        </p>
-        <v-btn
-          color="primary"
-          variant="flat"
-          :class="config.vuetify.theme.rounded"
-          class="text-none text-body-medium"
-          to="/pricing"
-        >
-          Upgrade
-        </v-btn>
-      </v-card>
+      <!-- ── Meter mode section ──────────────────────────────────────── -->
+      <template v-if="meterMode">
+        <!-- Meter progress card -->
+        <v-card :class="config.vuetify.theme.rounded" class="pa-6 mb-6">
+          <!-- i18n key: billing.usage.weekly -->
+          <p class="text-title-medium font-weight-medium mb-4">Weekly meter</p>
+          <BillingMeterProgressComponent
+            :used="meterUsed"
+            :quota="meterQuota"
+            :extras="meterExtras"
+            label=""
+          />
+        </v-card>
 
-      <!-- Active subscription state -->
-      <v-card v-else :class="config.vuetify.theme.rounded" class="pa-6">
-        <div class="d-flex align-center mb-4">
-          <span class="text-title-large font-weight-medium mr-3">Current Plan</span>
-          <billingPlanBadgeComponent :plan="currentPlan" />
-        </div>
+        <!-- Breakdown card -->
+        <v-card :class="config.vuetify.theme.rounded" class="pa-6 mb-6">
+          <!-- i18n key: billing.usage.breakdown -->
+          <p class="text-title-medium font-weight-medium mb-4">Breakdown</p>
+          <BillingMeterBreakdownChartComponent :breakdown="meterBreakdown" />
+        </v-card>
 
-        <v-list density="compact" class="bg-transparent pa-0 mb-6">
-          <v-list-item class="px-0">
-            <template #prepend>
-              <v-icon icon="fa-solid fa-circle-check" size="small" color="success" class="mr-3" />
-            </template>
-            <v-list-item-title class="text-body-medium">
-              Status: <strong class="text-capitalize">{{ subscription.status }}</strong>
-            </v-list-item-title>
-          </v-list-item>
-          <v-list-item v-if="nextBillingDate" class="px-0">
-            <template #prepend>
-              <v-icon icon="fa-solid fa-calendar" size="small" class="mr-3" />
-            </template>
-            <v-list-item-title class="text-body-medium">
-              Next billing date: <strong>{{ nextBillingDate }}</strong>
-            </v-list-item-title>
-          </v-list-item>
-        </v-list>
-
-        <div class="d-flex ga-3 flex-wrap">
+        <!-- Extras card -->
+        <v-card :class="config.vuetify.theme.rounded" class="pa-6 mb-6">
+          <!-- i18n key: billing.extras.title -->
+          <p class="text-title-medium font-weight-medium mb-2">Extra units</p>
+          <!-- i18n key: billing.extras.balance -->
+          <p class="text-body-medium text-medium-emphasis mb-4">
+            {{ meterExtras }} units remaining
+          </p>
+          <!-- i18n key: billing.extras.cta -->
           <v-btn
             color="primary"
             variant="flat"
             :class="config.vuetify.theme.rounded"
             class="text-none text-body-medium"
-            :loading="portalLoading"
-            @click="manageSubscription"
+            @click="extrasModalOpen = true"
           >
-            Manage Subscription
+            Buy units
           </v-btn>
+        </v-card>
+
+        <!-- Extras checkout modal -->
+        <BillingExtrasCheckoutModalComponent
+          v-model="extrasModalOpen"
+          :packs="packsAvailable"
+        />
+      </template>
+
+      <!-- ── Legacy mode section ────────────────────────────────────── -->
+      <template v-else>
+        <!-- Free plan state -->
+        <v-card v-if="!subscription || currentPlan === 'free'" :class="config.vuetify.theme.rounded" class="pa-6">
+          <div class="d-flex align-center mb-4">
+            <span class="text-title-large font-weight-medium mr-3">Current Plan</span>
+            <billingPlanBadgeComponent plan="free" />
+          </div>
+          <p class="text-body-medium mb-6">
+            You're on the free plan. Upgrade to unlock more projects, team members, and advanced features.
+          </p>
           <v-btn
-            variant="outlined"
+            color="primary"
+            variant="flat"
             :class="config.vuetify.theme.rounded"
             class="text-none text-body-medium"
             to="/pricing"
           >
             Upgrade
           </v-btn>
-        </div>
-      </v-card>
+        </v-card>
+
+        <!-- Active subscription state -->
+        <v-card v-else :class="config.vuetify.theme.rounded" class="pa-6">
+          <div class="d-flex align-center mb-4">
+            <span class="text-title-large font-weight-medium mr-3">Current Plan</span>
+            <billingPlanBadgeComponent :plan="currentPlan" />
+          </div>
+
+          <v-list density="compact" class="bg-transparent pa-0 mb-6">
+            <v-list-item class="px-0">
+              <template #prepend>
+                <v-icon icon="fa-solid fa-circle-check" size="small" color="success" class="mr-3" />
+              </template>
+              <v-list-item-title class="text-body-medium">
+                Status: <strong class="text-capitalize">{{ subscription.status }}</strong>
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item v-if="nextBillingDate" class="px-0">
+              <template #prepend>
+                <v-icon icon="fa-solid fa-calendar" size="small" class="mr-3" />
+              </template>
+              <v-list-item-title class="text-body-medium">
+                Next billing date: <strong>{{ nextBillingDate }}</strong>
+              </v-list-item-title>
+            </v-list-item>
+          </v-list>
+
+          <div class="d-flex ga-3 flex-wrap">
+            <v-btn
+              color="primary"
+              variant="flat"
+              :class="config.vuetify.theme.rounded"
+              class="text-none text-body-medium"
+              :loading="portalLoading"
+              @click="manageSubscription"
+            >
+              Manage Subscription
+            </v-btn>
+            <v-btn
+              variant="outlined"
+              :class="config.vuetify.theme.rounded"
+              class="text-none text-body-medium"
+              to="/pricing"
+            >
+              Upgrade
+            </v-btn>
+          </div>
+        </v-card>
+      </template>
     </template>
   </v-container>
 </template>
@@ -86,7 +137,11 @@
  */
 import { useBillingStore } from '../stores/billing.store';
 import { useAuthStore } from '../../auth/stores/auth.store';
+import { useMeter } from '../composables/billing.useMeter';
 import billingPlanBadgeComponent from '../components/billing.planBadge.component.vue';
+import BillingMeterProgressComponent from '../components/billing.meterProgress.component.vue';
+import BillingMeterBreakdownChartComponent from '../components/billing.meterBreakdownChart.component.vue';
+import BillingExtrasCheckoutModalComponent from '../components/billing.extrasCheckoutModal.component.vue';
 
 /**
  * Component definition.
@@ -95,10 +150,22 @@ export default {
   name: 'BillingView',
   components: {
     billingPlanBadgeComponent,
+    BillingMeterProgressComponent,
+    BillingMeterBreakdownChartComponent,
+    BillingExtrasCheckoutModalComponent,
+  },
+  /**
+   * @desc Wire useMeter composable for the meter-mode section.
+   */
+  setup() {
+    const { used: meterUsed, quota: meterQuota, extras: meterExtras, breakdown: meterBreakdown } = useMeter({ pollIntervalMs: 30000 });
+    return { meterUsed, meterQuota, meterExtras, meterBreakdown };
   },
   data() {
     return {
       portalLoading: false,
+      /** @type {boolean} Controls extras checkout modal visibility */
+      extrasModalOpen: false,
     };
   },
   computed: {
@@ -109,6 +176,26 @@ export default {
     subscription() {
       const billingStore = useBillingStore();
       return billingStore.subscription;
+    },
+    /**
+     * @desc Whether meter billing mode is active (from server config).
+     * @returns {boolean}
+     */
+    meterMode() {
+      const authStore = useAuthStore();
+      return authStore.serverConfig?.billing?.meterMode === true;
+    },
+    /**
+     * @desc Available extras packs for checkout modal.
+     * @returns {Array}
+     */
+    packsAvailable() {
+      const billingStore = useBillingStore();
+      return (
+        billingStore.usageMeter?.packsAvailable ??
+        billingStore.extrasBalance?.packsAvailable ??
+        []
+      );
     },
     /**
      * @desc Derive current plan from subscription or default to free.

--- a/src/modules/billing/views/billing.billing.view.vue
+++ b/src/modules/billing/views/billing.billing.view.vue
@@ -156,10 +156,13 @@ export default {
   },
   /**
    * @desc Wire useMeter composable for the meter-mode section.
+   * Injects billingStore once here so computed properties reference
+   * this.billingStore instead of calling useBillingStore() on every evaluation.
    */
   setup() {
     const { used: meterUsed, quota: meterQuota, extras: meterExtras, breakdown: meterBreakdown } = useMeter({ pollIntervalMs: 30000 });
-    return { meterUsed, meterQuota, meterExtras, meterBreakdown };
+    const billingStore = useBillingStore();
+    return { meterUsed, meterQuota, meterExtras, meterBreakdown, billingStore };
   },
   data() {
     return {
@@ -170,12 +173,10 @@ export default {
   },
   computed: {
     fetchLoading() {
-      const billingStore = useBillingStore();
-      return billingStore.loading;
+      return this.billingStore.loading;
     },
     subscription() {
-      const billingStore = useBillingStore();
-      return billingStore.subscription;
+      return this.billingStore.subscription;
     },
     /**
      * @desc Whether meter billing mode is active (from server config).
@@ -187,13 +188,13 @@ export default {
     },
     /**
      * @desc Available extras packs for checkout modal.
+     * Uses billingStore injected in setup to avoid repeated useBillingStore() calls.
      * @returns {Array}
      */
     packsAvailable() {
-      const billingStore = useBillingStore();
       return (
-        billingStore.usageMeter?.packsAvailable ??
-        billingStore.extrasBalance?.packsAvailable ??
+        this.billingStore.usageMeter?.packsAvailable ??
+        this.billingStore.extrasBalance?.packsAvailable ??
         []
       );
     },
@@ -227,9 +228,8 @@ export default {
     const hasOrg = !!authStore.user?.currentOrganization;
     if (!authStore.isLoggedIn || (orgsEnabled && !hasOrg)) return;
 
-    const billingStore = useBillingStore();
     try {
-      await billingStore.fetchSubscription();
+      await this.billingStore.fetchSubscription();
     } catch (error) {
       console.error('Failed to load billing details:', error);
     }
@@ -242,8 +242,7 @@ export default {
     async manageSubscription() {
       this.portalLoading = true;
       try {
-        const billingStore = useBillingStore();
-        await billingStore.openPortal();
+        await this.billingStore.openPortal();
       } catch (error) {
         console.error('Failed to open billing portal:', error);
       } finally {

--- a/src/modules/billing/views/billing.billing.view.vue
+++ b/src/modules/billing/views/billing.billing.view.vue
@@ -155,14 +155,21 @@ export default {
     BillingExtrasCheckoutModalComponent,
   },
   /**
-   * @desc Wire useMeter composable for the meter-mode section.
-   * Injects billingStore once here so computed properties reference
-   * this.billingStore instead of calling useBillingStore() on every evaluation.
+   * @desc Wire useMeter composable only when meter mode is active so legacy
+   * tenants do not incur polling overhead.  Injects billingStore once here so
+   * computed properties reference this.billingStore instead of calling
+   * useBillingStore() on every evaluation.
+   * @param {Object} props - Component props
+   * @returns {{ billingStore: Object, meterUsed?: ComputedRef, meterQuota?: ComputedRef, meterExtras?: ComputedRef, meterBreakdown?: ComputedRef }}
    */
   setup() {
-    const { used: meterUsed, quota: meterQuota, extras: meterExtras, breakdown: meterBreakdown } = useMeter({ pollIntervalMs: 30000 });
     const billingStore = useBillingStore();
-    return { meterUsed, meterQuota, meterExtras, meterBreakdown, billingStore };
+    const authStore = useAuthStore();
+    if (authStore.serverConfig?.billing?.meterMode === true) {
+      const { used: meterUsed, quota: meterQuota, extras: meterExtras, breakdown: meterBreakdown } = useMeter({ pollIntervalMs: 30000 });
+      return { meterUsed, meterQuota, meterExtras, meterBreakdown, billingStore };
+    }
+    return { billingStore };
   },
   data() {
     return {

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -73,6 +73,7 @@
           :annual="annual"
           :current="isCurrentPlan(plan.id)"
           :loading="checkoutLoading"
+          :equivalences="meterMode && plan.equivalences && plan.equivalences.length > 0 ? plan.equivalences : null"
           @select="onSelectPlan"
         />
       </v-col>
@@ -89,6 +90,7 @@ import { useAuthStore } from '../../auth/stores/auth.store';
 import { plans as plansConfig } from '../config/billing.development.config';
 import billingPricingToggleComponent from '../components/billing.pricingToggle.component.vue';
 import billingPricingCardComponent from '../components/billing.pricingCard.component.vue';
+
 
 /**
  * Component definition.
@@ -146,6 +148,14 @@ export default {
     currentPlanId() {
       const billingStore = useBillingStore();
       return billingStore.subscription?.plan ?? 'free';
+    },
+    /**
+     * @desc Whether meter billing mode is active (from server config).
+     * @returns {boolean}
+     */
+    meterMode() {
+      const authStore = useAuthStore();
+      return authStore.serverConfig?.billing?.meterMode === true;
     },
   },
   /**


### PR DESCRIPTION
## Summary

Closes #4036 (PR-V3 task list).

Implements all meter UX surfaces consuming the V1 (useMeter + store) and V2 (meterProgress, meterBreakdownChart, extrasLedger) primitives:

- **usageBar** — `mode='meter'|'legacy'` prop; meter branch wires `useMeter`, displays `{used} / {quota} +{extras}`, emits `open-drawer` on click
- **meterDrawer** (NEW) — right-side `v-navigation-drawer` (400px desktop / full-width mobile) with progress widget, breakdown chart, extras balance, Buy CTA opening extrasCheckoutModal
- **extrasCheckoutModal** (NEW) — `v-dialog` with pack radio list; Buy CTA delegates to `useMeter().purchasePack(packId)` (Stripe redirect); Cancel closes
- **pricingCard** — `equivalences: Array<{label, count}>` prop; renders `~{count} {label}` bullets instead of features when present; backward compat (absent → features list unchanged)
- **billing.view** — meterMode branch: BillingMeterProgress + BillingMeterBreakdownChart + extras CTA section; legacy view untouched
- **pricing.view** — passes `equivalences` to BillingPricingCard when `serverConfig.billing.meterMode === true`
- **config** — `equivalences` per plan (devkit illustrative defaults) + top-level `packs: []` array
- **lang/en.js + lang/fr.js** — billing i18n key catalogue for future vue-i18n adoption

## Test plan

- [ ] Lint: `npm run lint` — clean
- [ ] Unit tests: `npm run test:unit` — 1254 passed (+54 from baseline 1200)
  - `billing.usageBar.component.unit.tests.js` extended: meter mode branch (open-drawer emit, meterDisplay, role=button, label fallback, legacy backward compat)
  - `billing.meterDrawer.component.unit.tests.js` (NEW): props, emits, content sections, meter data reflection, extrasModal open/close, packsAvailable sourcing
  - `billing.extrasCheckoutModal.component.unit.tests.js` (NEW): rendering, default selection, CTA label, emits, buy flow, error handling, disabled state
  - `billing.pricingCard.component.unit.tests.js` extended: equivalences rendering, feature list hidden when present, backward compat (null/missing/empty)