### PR TITLE
feat(billing): mini-bar always-on (free/admin) + extras section in /billing + account links

### DIFF
--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -119,6 +119,7 @@
  */
 import { useQuota } from '../composables/billing.useQuota';
 import { useMeter } from '../composables/billing.useMeter';
+import { useBilling } from '../composables/billing.useBilling';
 import { useAuthStore } from '../../auth/stores/auth.store';
 import { useBillingStore } from '../stores/billing.store';
 import BillingMeterProgressComponent from './billing.meterProgress.component.vue';
@@ -190,13 +191,14 @@ export default {
    */
   setup(props) {
     const { usage, limits, usagePercent } = useQuota();
+    const { isPlanActive } = useBilling();
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
     if (props.mode === 'meter') {
       const { used: meterUsed, quota: meterQuota, extras: meterExtras } = useMeter({ pollIntervalMs: 0 });
-      return { usage, limits, usagePercent, meterUsed, meterQuota, meterExtras, authStore, billingStore };
+      return { usage, limits, usagePercent, isPlanActive, meterUsed, meterQuota, meterExtras, authStore, billingStore };
     }
-    return { usage, limits, usagePercent, authStore, billingStore };
+    return { usage, limits, usagePercent, isPlanActive, authStore, billingStore };
   },
 
   computed: {
@@ -283,7 +285,7 @@ export default {
     displayMode() {
       if (this.authStore.user?.roles?.includes('admin')) return 'admin';
       if (this.billingStore.loading) return 'loading';
-      if (!this.billingStore.subscription || !this.billingStore.usageMeter) return 'free';
+      if (!this.isPlanActive || !this.billingStore.usageMeter) return 'free';
       return 'standard';
     },
 

--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -5,6 +5,8 @@
   Supports two modes:
     - 'legacy' (default): reads quota data via useQuota composable (resource/action props required).
     - 'meter': reads weekly meter data via useMeter composable. Emits 'open-drawer' on click.
+             Always renders when authenticated + meterMode, regardless of subscription state.
+             displayMode resolves to 'admin' | 'free' | 'standard' based on user/subscription.
 
   USAGE (legacy):
   <BillingUsageBarComponent resource="documents" action="create" />
@@ -26,6 +28,7 @@
   <div
     v-if="mode === 'meter'"
     class="billing-usage-bar billing-usage-bar--meter"
+    :class="`billing-usage-bar--${displayMode}`"
     role="button"
     tabindex="0"
     style="cursor: pointer"
@@ -34,15 +37,47 @@
     @keydown.enter="$emit('open-drawer')"
     @keydown.space.prevent="$emit('open-drawer')"
   >
-    <div class="d-flex justify-space-between text-body-2 text-medium-emphasis mb-1">
-      <span>{{ displayLabel || 'Weekly usage' }}</span>
-      <span class="font-weight-medium">{{ meterDisplay }}</span>
-    </div>
-    <BillingMeterProgressComponent
-      :used="meterUsed"
-      :quota="meterQuota"
-      :extras="meterExtras"
-    />
+    <!-- Admin display: rainbow gradient, show total consumed with no cap -->
+    <template v-if="displayMode === 'admin'">
+      <div class="d-flex justify-space-between text-body-2 mb-1">
+        <span>{{ displayLabel || 'Weekly usage' }}</span>
+        <span
+          class="font-weight-medium billing-usage-bar__admin-label"
+          style="background: linear-gradient(90deg,#f97316,#ec4899,#8b5cf6,#3b82f6,#10b981); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text;"
+        >∞ Admin</span>
+      </div>
+      <div
+        class="billing-usage-bar__admin-track"
+        style="height:6px; border-radius:3px; background:linear-gradient(90deg,#f97316,#ec4899,#8b5cf6,#3b82f6,#10b981); opacity:0.6;"
+      />
+    </template>
+
+    <!-- Free display: 0 / free-tier quota, neutral colour -->
+    <template v-else-if="displayMode === 'free'">
+      <div class="d-flex justify-space-between text-body-2 text-medium-emphasis mb-1">
+        <span>{{ displayLabel || 'Weekly usage' }}</span>
+        <span class="font-weight-medium">0 / {{ freeTierQuota }} compute</span>
+      </div>
+      <v-progress-linear
+        :model-value="0"
+        color="grey-lighten-1"
+        rounded
+        height="6"
+      />
+    </template>
+
+    <!-- Standard display: current behaviour -->
+    <template v-else>
+      <div class="d-flex justify-space-between text-body-2 text-medium-emphasis mb-1">
+        <span>{{ displayLabel || 'Weekly usage' }}</span>
+        <span class="font-weight-medium">{{ meterDisplay }}</span>
+      </div>
+      <BillingMeterProgressComponent
+        :used="meterUsed"
+        :quota="meterQuota"
+        :extras="meterExtras"
+      />
+    </template>
   </div>
 
   <!-- Legacy mode -->
@@ -70,6 +105,8 @@
  */
 import { useQuota } from '../composables/billing.useQuota';
 import { useMeter } from '../composables/billing.useMeter';
+import { useAuthStore } from '../../auth/stores/auth.store';
+import { useBillingStore } from '../stores/billing.store';
 import BillingMeterProgressComponent from './billing.meterProgress.component.vue';
 
 /**
@@ -87,6 +124,7 @@ export default {
      * @desc Rendering mode.
      * - 'legacy': reads quota via useQuota (resource + action required).
      * - 'meter': reads weekly meter data via useMeter; emits 'open-drawer' on click.
+     *            Always renders (free / admin / standard) when authenticated + meterMode.
      */
     mode: {
       type: String,
@@ -114,6 +152,14 @@ export default {
       type: String,
       default: '',
     },
+    /**
+     * @desc Free-tier quota shown when user has no active subscription.
+     * Defaults to 10 (override in project config if needed).
+     */
+    freeTierQuota: {
+      type: Number,
+      default: 10,
+    },
   },
 
   emits: ['open-drawer'],
@@ -126,15 +172,17 @@ export default {
    * The parent component (e.g. BillingMeterDrawer) handles its own polling with
    * pollIntervalMs:30000 for continuous refresh while the drawer is open.
    * @param {Object} props - Component props
-   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed?: ComputedRef, meterQuota?: ComputedRef, meterExtras?: ComputedRef }}
+   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed?: ComputedRef, meterQuota?: ComputedRef, meterExtras?: ComputedRef, authStore: Object, billingStore: Object }}
    */
   setup(props) {
     const { usage, limits, usagePercent } = useQuota();
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
     if (props.mode === 'meter') {
       const { used: meterUsed, quota: meterQuota, extras: meterExtras } = useMeter({ pollIntervalMs: 0 });
-      return { usage, limits, usagePercent, meterUsed, meterQuota, meterExtras };
+      return { usage, limits, usagePercent, meterUsed, meterQuota, meterExtras, authStore, billingStore };
     }
-    return { usage, limits, usagePercent };
+    return { usage, limits, usagePercent, authStore, billingStore };
   },
 
   computed: {
@@ -211,7 +259,20 @@ export default {
     // ── Meter mode computeds ───────────────────────────────────────────────
 
     /**
-     * @desc Usage summary text shown in meter mode header: "{used} / {quota} +{extras}".
+     * @desc Determines the visual display variant for meter mode.
+     * - 'admin'    : user has 'admin' role → rainbow/∞ display
+     * - 'free'     : authenticated but no active subscription/usageMeter → free tier display
+     * - 'standard' : active subscription with usageMeter data → normal quota bar
+     * @returns {'admin'|'free'|'standard'}
+     */
+    displayMode() {
+      if (this.authStore.user?.roles?.includes('admin')) return 'admin';
+      if (!this.billingStore.subscription || !this.billingStore.usageMeter) return 'free';
+      return 'standard';
+    },
+
+    /**
+     * @desc Usage summary text shown in standard meter mode: "{used} / {quota} +{extras}".
      * @returns {string}
      */
     meterDisplay() {

--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -6,7 +6,7 @@
     - 'legacy' (default): reads quota data via useQuota composable (resource/action props required).
     - 'meter': reads weekly meter data via useMeter composable. Emits 'open-drawer' on click.
              Always renders when authenticated + meterMode, regardless of subscription state.
-             displayMode resolves to 'admin' | 'free' | 'standard' based on user/subscription.
+             displayMode resolves to 'admin' | 'loading' | 'free' | 'standard' based on user/subscription.
 
   USAGE (legacy):
   <BillingUsageBarComponent resource="documents" action="create" />
@@ -44,11 +44,25 @@
         <span
           class="font-weight-medium billing-usage-bar__admin-label"
           style="background: linear-gradient(90deg,#f97316,#ec4899,#8b5cf6,#3b82f6,#10b981); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text;"
-        >∞ Admin</span>
+        >{{ meterUsed != null ? meterUsed : '' }} ∞ Admin</span>
       </div>
       <div
         class="billing-usage-bar__admin-track"
         style="height:6px; border-radius:3px; background:linear-gradient(90deg,#f97316,#ec4899,#8b5cf6,#3b82f6,#10b981); opacity:0.6;"
+      />
+    </template>
+
+    <!-- Loading display: placeholder skeleton while billing data fetches -->
+    <template v-else-if="displayMode === 'loading'">
+      <div class="d-flex justify-space-between text-body-2 text-medium-emphasis mb-1">
+        <span>{{ displayLabel || 'Weekly usage' }}</span>
+        <span class="font-weight-medium">—</span>
+      </div>
+      <v-progress-linear
+        :model-value="0"
+        color="grey-lighten-2"
+        rounded
+        height="6"
       />
     </template>
 
@@ -261,12 +275,14 @@ export default {
     /**
      * @desc Determines the visual display variant for meter mode.
      * - 'admin'    : user has 'admin' role → rainbow/∞ display
+     * - 'loading'  : billing data still fetching (prevents flicker into free)
      * - 'free'     : authenticated but no active subscription/usageMeter → free tier display
      * - 'standard' : active subscription with usageMeter data → normal quota bar
-     * @returns {'admin'|'free'|'standard'}
+     * @returns {'admin'|'loading'|'free'|'standard'}
      */
     displayMode() {
       if (this.authStore.user?.roles?.includes('admin')) return 'admin';
+      if (this.billingStore.loading) return 'loading';
       if (!this.billingStore.subscription || !this.billingStore.usageMeter) return 'free';
       return 'standard';
     },

--- a/src/modules/billing/tests/billing.billing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.billing.view.unit.tests.js
@@ -46,6 +46,7 @@ const mountView = () =>
         BillingMeterProgressComponent: true,
         BillingMeterBreakdownChartComponent: true,
         BillingExtrasCheckoutModalComponent: true,
+        BillingExtrasLedgerComponent: true,
         billingPlanBadgeComponent: true,
         BillingUsageBarComponent: true,
         BillingMeterDrawerComponent: true,
@@ -148,6 +149,66 @@ describe('billing.billing.view — pollingTimer cleanup', () => {
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 30000);
 
     wrapper2.unmount();
+  });
+
+  // ── Extras section ────────────────────────────────────────────────────────
+
+  it('renders BillingExtrasLedgerComponent when meterMode is true', async () => {
+    authState.serverConfig = { billing: { meterMode: true } };
+    const wrapper = mountView();
+    await flushPromises();
+    const ledger = wrapper.findComponent({ name: 'BillingExtrasLedgerComponent' });
+    expect(ledger.exists()).toBe(true);
+  });
+
+  it('does not render BillingExtrasLedgerComponent when meterMode is false', async () => {
+    authState.serverConfig = { billing: { meterMode: false } };
+    const wrapper = mountView();
+    await flushPromises();
+    const ledger = wrapper.findComponent({ name: 'BillingExtrasLedgerComponent' });
+    expect(ledger.exists()).toBe(false);
+  });
+
+  it('extrasLedger computed returns store value when set', async () => {
+    authState.serverConfig = { billing: { meterMode: true } };
+    const wrapper = mountView();
+    await flushPromises();
+
+    const { useBillingStore } = await import('../stores/billing.store');
+    const store = useBillingStore();
+    store.extrasLedger = { entries: [{ at: new Date().toISOString(), kind: 'topup', amount: 100 }], total: 1, page: 1, limit: 20 };
+
+    expect(wrapper.vm.extrasLedger.entries).toHaveLength(1);
+    expect(wrapper.vm.extrasLedger.total).toBe(1);
+
+    wrapper.unmount();
+  });
+
+  it('extrasLedger computed falls back to empty state when store is null', async () => {
+    authState.serverConfig = { billing: { meterMode: true } };
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.vm.extrasLedger.entries).toEqual([]);
+    expect(wrapper.vm.extrasLedger.total).toBe(0);
+
+    wrapper.unmount();
+  });
+
+  it('onLedgerPageChange calls fetchExtrasLedger with correct page', async () => {
+    authState.serverConfig = { billing: { meterMode: true } };
+    const wrapper = mountView();
+    await flushPromises();
+
+    const { useBillingStore } = await import('../stores/billing.store');
+    const store = useBillingStore();
+    const fetchSpy = vi.spyOn(store, 'fetchExtrasLedger').mockResolvedValue({ entries: [], total: 0, page: 2, limit: 20 });
+
+    await wrapper.vm.onLedgerPageChange(2);
+
+    expect(fetchSpy).toHaveBeenCalledWith({ page: 2, limit: 20 });
+
+    wrapper.unmount();
   });
 
   it('stops polling when meterMode turns off after being active', async () => {

--- a/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
@@ -10,6 +10,17 @@ vi.mock('../../../lib/services/axios', () => ({
   default: { get: vi.fn(), post: vi.fn() },
 }));
 
+// Mutable auth store state shared across tests
+const authState = vi.hoisted(() => ({
+  isLoggedIn: true,
+  user: null,
+  serverConfig: null,
+}));
+
+vi.mock('../../auth/stores/auth.store', () => ({
+  useAuthStore: () => authState,
+}));
+
 const vuetify = createVuetify();
 
 /**
@@ -34,6 +45,8 @@ const mountComponent = (props, quotaData = null) => {
 describe('BillingUsageBarComponent', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    authState.user = null;
+    authState.serverConfig = null;
     vi.clearAllMocks();
   });
 
@@ -167,8 +180,9 @@ describe('BillingUsageBarComponent', () => {
     expect(meterRoot.exists()).toBe(true);
   });
 
-  it('displays used / quota text in meter mode', () => {
+  it('displays used / quota text in meter mode (standard)', () => {
     const store = useBillingStore();
+    store.subscription = { status: 'active', plan: 'starter' };
     store.usageMeter = { meterUsed: 300, meterQuota: 1000 };
     const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
     expect(wrapper.text()).toContain('300');
@@ -238,5 +252,73 @@ describe('BillingUsageBarComponent', () => {
     );
     expect(wrapper.find('.billing-usage-bar--meter').exists()).toBe(false);
     expect(wrapper.findComponent({ name: 'v-progress-linear' }).exists()).toBe(true);
+  });
+
+  // ── Meter mode: displayMode variants ────────────────────────────────────
+
+  it('displayMode is "admin" when user has admin role', () => {
+    authState.user = { roles: ['admin'] };
+    const wrapper = mountComponent({ mode: 'meter' });
+    expect(wrapper.vm.displayMode).toBe('admin');
+  });
+
+  it('displays "∞ Admin" label in admin displayMode', () => {
+    authState.user = { roles: ['admin'] };
+    const wrapper = mountComponent({ mode: 'meter' });
+    expect(wrapper.text()).toContain('∞ Admin');
+  });
+
+  it('admin display has billing-usage-bar--admin class', () => {
+    authState.user = { roles: ['admin'] };
+    const wrapper = mountComponent({ mode: 'meter' });
+    expect(wrapper.find('.billing-usage-bar--admin').exists()).toBe(true);
+  });
+
+  it('displayMode is "free" when no subscription and no usageMeter', () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = null;
+    store.usageMeter = null;
+    const wrapper = mountComponent({ mode: 'meter' });
+    expect(wrapper.vm.displayMode).toBe('free');
+  });
+
+  it('free display shows "0 / <freeTierQuota> compute"', () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = null;
+    store.usageMeter = null;
+    const wrapper = mountComponent({ mode: 'meter', freeTierQuota: 10 });
+    expect(wrapper.text()).toContain('0 / 10 compute');
+  });
+
+  it('free display renders progress bar at 0%', () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = null;
+    store.usageMeter = null;
+    const wrapper = mountComponent({ mode: 'meter' });
+    const bar = wrapper.findComponent({ name: 'v-progress-linear' });
+    expect(bar.exists()).toBe(true);
+    expect(bar.props('modelValue')).toBe(0);
+  });
+
+  it('displayMode is "standard" when subscription and usageMeter exist', () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = { status: 'active', plan: 'starter' };
+    store.usageMeter = { meterUsed: 200, meterQuota: 1000, extrasRemaining: 0 };
+    const wrapper = mountComponent({ mode: 'meter' });
+    expect(wrapper.vm.displayMode).toBe('standard');
+  });
+
+  it('standard display shows used / quota via meterDisplay', () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = { status: 'active', plan: 'starter' };
+    store.usageMeter = { meterUsed: 200, meterQuota: 1000, extrasRemaining: 0 };
+    const wrapper = mountComponent({ mode: 'meter' });
+    expect(wrapper.text()).toContain('200');
+    expect(wrapper.text()).toContain('1000');
   });
 });

--- a/src/modules/billing/views/billing.billing.view.vue
+++ b/src/modules/billing/views/billing.billing.view.vue
@@ -210,6 +210,10 @@ export default {
         if (active) {
           // serverConfig just resolved with meterMode=true: fetch immediately
           void refresh().catch(() => {});
+          // Also fetch extras ledger (covers the case where serverConfig resolves after mount)
+          void billingStore.fetchExtrasLedger({ page: 1, limit: 20 }).catch((error) => {
+            console.error('Failed to load extras ledger:', error);
+          });
           // Start 30s polling (clear any previous timer first for safety)
           if (pollingTimer) clearInterval(pollingTimer);
           pollingTimer = setInterval(() => {

--- a/src/modules/billing/views/billing.billing.view.vue
+++ b/src/modules/billing/views/billing.billing.view.vue
@@ -53,11 +53,23 @@
             color="primary"
             variant="flat"
             :class="config.vuetify.theme.rounded"
-            class="text-none text-body-medium"
+            class="text-none text-body-medium mb-6"
             @click="extrasModalOpen = true"
           >
             Buy units
           </v-btn>
+
+          <!-- Ledger: last 20 entries -->
+          <v-divider class="mb-4" />
+          <!-- i18n key: billing.extras.ledger.title -->
+          <p class="text-body-medium font-weight-medium mb-3">Transaction history</p>
+          <BillingExtrasLedgerComponent
+            :entries="extrasLedger.entries"
+            :total="extrasLedger.total"
+            :page="extrasLedger.page"
+            :limit="extrasLedger.limit"
+            @update:page="onLedgerPageChange"
+          />
         </v-card>
 
         <!-- Extras checkout modal -->
@@ -153,6 +165,7 @@ import billingPlanBadgeComponent from '../components/billing.planBadge.component
 import BillingMeterProgressComponent from '../components/billing.meterProgress.component.vue';
 import BillingMeterBreakdownChartComponent from '../components/billing.meterBreakdownChart.component.vue';
 import BillingExtrasCheckoutModalComponent from '../components/billing.extrasCheckoutModal.component.vue';
+import BillingExtrasLedgerComponent from '../components/billing.extrasLedger.component.vue';
 import BillingUsageBarComponent from '../components/billing.usageBar.component.vue';
 import BillingMeterDrawerComponent from '../components/billing.meterDrawer.component.vue';
 
@@ -166,6 +179,7 @@ export default {
     BillingMeterProgressComponent,
     BillingMeterBreakdownChartComponent,
     BillingExtrasCheckoutModalComponent,
+    BillingExtrasLedgerComponent,
     BillingUsageBarComponent,
     BillingMeterDrawerComponent,
   },
@@ -256,6 +270,13 @@ export default {
       );
     },
     /**
+     * @desc Extras credit ledger data for the paginated history table.
+     * @returns {{ entries: Array, total: number, page: number, limit: number }}
+     */
+    extrasLedger() {
+      return this.billingStore.extrasLedger ?? { entries: [], total: 0, page: 1, limit: 20 };
+    },
+    /**
      * @desc Derive current plan from subscription or default to free.
      * @returns {string} Plan identifier
      */
@@ -277,7 +298,7 @@ export default {
     },
   },
   /**
-   * @desc Fetch subscription data on mount.
+   * @desc Fetch subscription data and extras ledger on mount.
    */
   async mounted() {
     const orgsEnabled = this.authStore.serverConfig?.organizations?.enabled;
@@ -288,6 +309,11 @@ export default {
       await this.billingStore.fetchSubscription();
     } catch (error) {
       console.error('Failed to load billing details:', error);
+    }
+
+    // Fetch extras ledger when meterMode — non-blocking
+    if (this.meterMode) {
+      void this.billingStore.fetchExtrasLedger({ page: 1, limit: 20 }).catch(() => {});
     }
   },
   methods: {
@@ -303,6 +329,18 @@ export default {
         console.error('Failed to open billing portal:', error);
       } finally {
         this.portalLoading = false;
+      }
+    },
+    /**
+     * @desc Handle ledger page change from BillingExtrasLedgerComponent.
+     * @param {number} page - Requested page number (1-based)
+     * @returns {Promise<void>}
+     */
+    async onLedgerPageChange(page) {
+      try {
+        await this.billingStore.fetchExtrasLedger({ page, limit: this.extrasLedger.limit });
+      } catch (error) {
+        console.error('Failed to load ledger page:', error);
       }
     },
   },

--- a/src/modules/organizations/components/organization.detail.component.vue
+++ b/src/modules/organizations/components/organization.detail.component.vue
@@ -276,7 +276,7 @@ import { subject } from '@casl/ability';
 import { ability } from '../../../lib/helpers/ability';
 import { useOrganizationsStore } from '../stores/organizations.store';
 import { useAuthStore } from '../../auth/stores/auth.store';
-import { useBillingStore } from '../../billing/stores/billing.store';
+import { useBilling } from '../../billing/composables/billing.useBilling';
 import roleColor from '../../../lib/helpers/roleColor';
 import organizationsMembersComponent from './organizations.members.component.vue';
 import PageHeader from '../../core/components/core.pageHeader.component.vue';
@@ -292,6 +292,15 @@ export default {
   props: {
     organizationId: { type: String, required: true },
     backRoute: { type: String, default: '/users' },
+  },
+  /**
+   * @desc Wires auth and billing helpers for use in computed properties.
+   * @returns {{ authStore: Object, isPlanActive: import('vue').ComputedRef<boolean> }}
+   */
+  setup() {
+    const authStore = useAuthStore();
+    const { isPlanActive } = useBilling();
+    return { authStore, isPlanActive };
   },
   data() {
     return {
@@ -318,8 +327,7 @@ export default {
       return organizationsStore.viewedOrganization;
     },
     roleDescriptions() {
-      const authStore = useAuthStore();
-      return authStore.serverConfig?.organizations?.roleDescriptions || {};
+      return this.authStore.serverConfig?.organizations?.roleDescriptions || {};
     },
     canManage() {
       if (ability && ability.rules && ability.rules.length > 0) {
@@ -333,13 +341,10 @@ export default {
      * @returns {boolean}
      */
     showBillingLink() {
-      const authStore = useAuthStore();
-      const billingStore = useBillingStore();
       if (!this.canManage) return false;
-      const billingEnabled = authStore.serverConfig?.billing?.enabled === true;
-      const meterMode = authStore.serverConfig?.billing?.meterMode === true;
-      const hasSubscription = !!billingStore.subscription;
-      return billingEnabled && (meterMode || hasSubscription);
+      const billingEnabled = this.authStore.serverConfig?.billing?.enabled === true;
+      const meterMode = this.authStore.serverConfig?.billing?.meterMode === true;
+      return billingEnabled && (meterMode || this.isPlanActive);
     },
     name: {
       get() { return this.viewedOrganization ? this.viewedOrganization.name : ''; },

--- a/src/modules/organizations/components/organization.detail.component.vue
+++ b/src/modules/organizations/components/organization.detail.component.vue
@@ -71,6 +71,30 @@
           </v-form>
         </v-card>
 
+        <!-- Billing & Plan shortcut (shown when billing is enabled for the org) -->
+        <v-card
+          v-if="showBillingLink"
+          color="surface"
+          :flat="config.vuetify.theme.flat"
+          :class="config.vuetify.theme.rounded"
+          class="pa-6 mt-4 d-flex align-center justify-space-between flex-wrap ga-3"
+        >
+          <div>
+            <h3 class="text-title-small font-weight-medium mb-1">Billing &amp; Plan</h3>
+            <p class="text-body-small text-medium-emphasis mb-0">Manage subscription and usage.</p>
+          </div>
+          <v-btn
+            color="primary"
+            variant="tonal"
+            :class="config.vuetify.theme.rounded"
+            class="text-none text-body-medium"
+            to="/billing"
+          >
+            <v-icon icon="fa-solid fa-credit-card" size="small" class="mr-2" />
+            Manage subscription
+          </v-btn>
+        </v-card>
+
         <v-card
           v-if="Object.keys(roleDescriptions).length > 0"
           color="surface"
@@ -252,6 +276,7 @@ import { subject } from '@casl/ability';
 import { ability } from '../../../lib/helpers/ability';
 import { useOrganizationsStore } from '../stores/organizations.store';
 import { useAuthStore } from '../../auth/stores/auth.store';
+import { useBillingStore } from '../../billing/stores/billing.store';
 import roleColor from '../../../lib/helpers/roleColor';
 import organizationsMembersComponent from './organizations.members.component.vue';
 import PageHeader from '../../core/components/core.pageHeader.component.vue';
@@ -301,6 +326,20 @@ export default {
         return ability.can('update', subject('Organization', { _id: this.organizationId }));
       }
       return false;
+    },
+    /**
+     * @desc Show the billing link when billing is enabled (meterMode or active subscription).
+     * Only visible to org owners/admins who can already manage the org.
+     * @returns {boolean}
+     */
+    showBillingLink() {
+      const authStore = useAuthStore();
+      const billingStore = useBillingStore();
+      if (!this.canManage) return false;
+      const billingEnabled = authStore.serverConfig?.billing?.enabled === true;
+      const meterMode = authStore.serverConfig?.billing?.meterMode === true;
+      const hasSubscription = !!billingStore.subscription;
+      return billingEnabled && (meterMode || hasSubscription);
     },
     name: {
       get() { return this.viewedOrganization ? this.viewedOrganization.name : ''; },

--- a/src/modules/users/tests/user.view.unit.tests.js
+++ b/src/modules/users/tests/user.view.unit.tests.js
@@ -3,6 +3,7 @@ import { setActivePinia, createPinia } from 'pinia';
 import { shallowMount } from '@vue/test-utils';
 import { useOrganizationsStore } from '../../organizations/stores/organizations.store';
 import { useAuthStore } from '../../auth/stores/auth.store';
+import { useBillingStore } from '../../billing/stores/billing.store';
 import UserView from '../views/user.view.vue';
 
 // Mock axios
@@ -122,5 +123,101 @@ describe('UserView – leaveOrg redirect behaviour', () => {
     expect(organizationsStore.leaveOrganization).toHaveBeenCalledWith(orgId);
     expect(organizationsStore.switchOrganization).toHaveBeenCalledWith(remainingOrg.id);
     expect(routerPush).not.toHaveBeenCalled();
+  });
+});
+
+// ── UserView – showBillingLink computed ──────────────────────────────────────
+
+describe('UserView – showBillingLink', () => {
+  let authStore;
+  let billingStore;
+
+  /**
+   * @desc Helper to mount UserView for showBillingLink tests.
+   * @param {Object} serverConfig - Auth store serverConfig
+   * @param {Object|null} subscription - Billing store subscription
+   * @returns {import('@vue/test-utils').VueWrapper}
+   */
+  const mountForBilling = (serverConfig, subscription = null) => {
+    authStore.serverConfig = serverConfig;
+    billingStore.subscription = subscription;
+
+    return shallowMount(UserView, {
+      global: {
+        mocks: {
+          $router: { push: vi.fn() },
+          config: {
+            api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api' },
+            vuetify: { theme: { flat: true, rounded: 'rounded' } },
+          },
+        },
+        stubs: {
+          PageHeader: true,
+          userProfileComponent: true,
+          organizationsSwitcherComponent: true,
+          orgAvatarComponent: true,
+          'v-container': { template: '<div><slot /></div>' },
+          'v-row': { template: '<div><slot /></div>' },
+          'v-col': { template: '<div><slot /></div>' },
+          'v-card': { template: '<div><slot /></div>' },
+          'v-tabs': { template: '<div><slot /></div>' },
+          'v-tab': { template: '<div><slot /></div>' },
+          'v-divider': { template: '<div />' },
+          'v-window': { template: '<div><slot /></div>' },
+          'v-window-item': { template: '<div><slot /></div>' },
+          'v-list': { template: '<div><slot /></div>' },
+          'v-list-item': { template: '<div><slot /></div>' },
+          'v-list-item-title': { template: '<div><slot /></div>' },
+          'v-list-item-subtitle': { template: '<div><slot /></div>' },
+          'v-avatar': { template: '<div><slot /></div>' },
+          'v-chip': { template: '<div><slot /></div>' },
+          'v-btn': { template: '<div><slot /></div>' },
+          'v-icon': { template: '<div />' },
+          'v-dialog': { template: '<div><slot /></div>' },
+          'v-card-title': { template: '<div><slot /></div>' },
+          'v-card-text': { template: '<div><slot /></div>' },
+          'v-card-actions': { template: '<div><slot /></div>' },
+          'v-spacer': { template: '<div />' },
+          'v-text-field': { template: '<div />' },
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    authStore = useAuthStore();
+    billingStore = useBillingStore();
+
+    const organizationsStore = useOrganizationsStore();
+    organizationsStore.fetchOrganizations = vi.fn().mockResolvedValue([]);
+  });
+
+  it('showBillingLink is true when billing enabled and meterMode is true', () => {
+    const wrapper = mountForBilling({ billing: { enabled: true, meterMode: true } });
+    expect(wrapper.vm.showBillingLink).toBe(true);
+  });
+
+  it('showBillingLink is true when billing enabled and user has active subscription', () => {
+    const wrapper = mountForBilling(
+      { billing: { enabled: true, meterMode: false } },
+      { status: 'active', plan: 'starter' },
+    );
+    expect(wrapper.vm.showBillingLink).toBe(true);
+  });
+
+  it('showBillingLink is false when billing disabled', () => {
+    const wrapper = mountForBilling({ billing: { enabled: false, meterMode: true } });
+    expect(wrapper.vm.showBillingLink).toBe(false);
+  });
+
+  it('showBillingLink is false when billing not configured', () => {
+    const wrapper = mountForBilling(null);
+    expect(wrapper.vm.showBillingLink).toBe(false);
+  });
+
+  it('showBillingLink is false when billing enabled but meterMode false and no subscription', () => {
+    const wrapper = mountForBilling({ billing: { enabled: true, meterMode: false } }, null);
+    expect(wrapper.vm.showBillingLink).toBe(false);
   });
 });

--- a/src/modules/users/views/user.view.vue
+++ b/src/modules/users/views/user.view.vue
@@ -186,7 +186,7 @@
 <script>
 import { useAuthStore } from '../../auth/stores/auth.store';
 import { useOrganizationsStore } from '../../organizations/stores/organizations.store';
-import { useBillingStore } from '../../billing/stores/billing.store';
+import { useBilling } from '../../billing/composables/billing.useBilling';
 import axios from '../../../lib/services/axios';
 import roleColor from '../../../lib/helpers/roleColor';
 import PageHeader from '../../core/components/core.pageHeader.component.vue';
@@ -202,6 +202,17 @@ export default {
     organizationsSwitcherComponent,
     orgAvatarComponent,
   },
+  /**
+   * @desc Wires auth, organizations and billing helpers for use across computed
+   * properties and methods.
+   * @returns {{ authStore: Object, organizationsStore: Object, isPlanActive: import('vue').ComputedRef<boolean> }}
+   */
+  setup() {
+    const authStore = useAuthStore();
+    const organizationsStore = useOrganizationsStore();
+    const { isPlanActive } = useBilling();
+    return { authStore, organizationsStore, isPlanActive };
+  },
   data() {
     return {
       tab: 'profile',
@@ -213,20 +224,17 @@ export default {
   },
   computed: {
     user() {
-      const authStore = useAuthStore();
-      return authStore.user || {};
+      return this.authStore.user || {};
     },
     organizations() {
-      const organizationsStore = useOrganizationsStore();
-      return organizationsStore.organizations;
+      return this.organizationsStore.organizations;
     },
     /**
      * @desc The ID of the user's current active organization.
      * @returns {string|undefined}
      */
     currentOrganizationId() {
-      const authStore = useAuthStore();
-      const id = authStore.user?.currentOrganization;
+      const id = this.authStore.user?.currentOrganization;
       return id?._id || id?.id || id;
     },
     /**
@@ -235,12 +243,9 @@ export default {
      * @returns {boolean}
      */
     showBillingLink() {
-      const authStore = useAuthStore();
-      const billingStore = useBillingStore();
-      const meterMode = authStore.serverConfig?.billing?.meterMode === true;
-      const billingEnabled = authStore.serverConfig?.billing?.enabled === true;
-      const hasSubscription = !!billingStore.subscription;
-      return billingEnabled && (meterMode || hasSubscription);
+      const meterMode = this.authStore.serverConfig?.billing?.meterMode === true;
+      const billingEnabled = this.authStore.serverConfig?.billing?.enabled === true;
+      return billingEnabled && (meterMode || this.isPlanActive);
     },
   },
   /**
@@ -248,9 +253,8 @@ export default {
    * @returns {Promise<void>}
    */
   async created() {
-    const organizationsStore = useOrganizationsStore();
     try {
-      await organizationsStore.fetchOrganizations();
+      await this.organizationsStore.fetchOrganizations();
     } catch {
       // interceptor handles snackbar
     }
@@ -274,32 +278,28 @@ export default {
           bio: formData.bio,
           position: formData.position,
         });
-        const authStore = useAuthStore();
-        await authStore.refreshAbilities();
+        await this.authStore.refreshAbilities();
       } catch {
         // interceptor handles snackbar
       }
     },
     async onAvatarUploaded() {
-      const authStore = useAuthStore();
-      await authStore.refreshAbilities();
+      await this.authStore.refreshAbilities();
     },
     confirmLeave(org) {
       this.orgToLeave = org;
       this.leaveDialog = true;
     },
     async leaveOrg() {
-      const organizationsStore = useOrganizationsStore();
       try {
-        await organizationsStore.leaveOrganization(this.orgToLeave.id || this.orgToLeave._id);
+        await this.organizationsStore.leaveOrganization(this.orgToLeave.id || this.orgToLeave._id);
         this.leaveDialog = false;
         this.orgToLeave = null;
-        const authStore = useAuthStore();
-        await authStore.refreshAbilities();
-        if (organizationsStore.organizations.length === 0) {
+        await this.authStore.refreshAbilities();
+        if (this.organizationsStore.organizations.length === 0) {
           this.$router.push('/organization-required');
-        } else if (!organizationsStore.currentOrganization) {
-          await organizationsStore.switchOrganization(organizationsStore.organizations[0].id || organizationsStore.organizations[0]._id);
+        } else if (!this.organizationsStore.currentOrganization) {
+          await this.organizationsStore.switchOrganization(this.organizationsStore.organizations[0].id || this.organizationsStore.organizations[0]._id);
         }
       } catch {
         this.leaveDialog = false;
@@ -309,8 +309,7 @@ export default {
       try {
         const api = `${this.config.api.protocol}://${this.config.api.host}:${this.config.api.port}/${this.config.api.base}`;
         await axios.delete(`${api}/users`);
-        const authStore = useAuthStore();
-        await authStore.signout();
+        await this.authStore.signout();
         this.$router.push('/signin');
       } catch {
         this.confirmDeleteAccount = false;

--- a/src/modules/users/views/user.view.vue
+++ b/src/modules/users/views/user.view.vue
@@ -89,6 +89,30 @@
           </v-window>
         </v-card>
 
+        <!-- Billing & Plan link (meterMode or non-free subscription) -->
+        <v-card
+          v-if="showBillingLink"
+          color="surface"
+          :flat="config.vuetify.theme.flat"
+          :class="config.vuetify.theme.rounded"
+          class="mt-4 pa-6 d-flex align-center justify-space-between flex-wrap ga-4"
+        >
+          <div>
+            <h3 class="text-title-medium font-weight-medium mb-1">Billing &amp; Plan</h3>
+            <p class="text-body-small text-medium-emphasis mb-0">Manage your subscription and usage.</p>
+          </div>
+          <v-btn
+            color="primary"
+            variant="tonal"
+            :class="config.vuetify.theme.rounded"
+            class="text-none text-body-medium"
+            to="/billing"
+          >
+            <v-icon icon="fa-solid fa-credit-card" size="small" class="mr-2" />
+            Manage subscription
+          </v-btn>
+        </v-card>
+
         <!-- Danger zone -->
         <v-card variant="outlined" color="error" class="mt-4 pa-6" :class="config.vuetify.theme.rounded">
           <div class="d-flex align-center flex-wrap ga-4">
@@ -162,6 +186,7 @@
 <script>
 import { useAuthStore } from '../../auth/stores/auth.store';
 import { useOrganizationsStore } from '../../organizations/stores/organizations.store';
+import { useBillingStore } from '../../billing/stores/billing.store';
 import axios from '../../../lib/services/axios';
 import roleColor from '../../../lib/helpers/roleColor';
 import PageHeader from '../../core/components/core.pageHeader.component.vue';
@@ -203,6 +228,19 @@ export default {
       const authStore = useAuthStore();
       const id = authStore.user?.currentOrganization;
       return id?._id || id?.id || id;
+    },
+    /**
+     * @desc Show the billing link when meterMode is enabled OR the user has an active subscription.
+     * Always dormant when billing is not configured.
+     * @returns {boolean}
+     */
+    showBillingLink() {
+      const authStore = useAuthStore();
+      const billingStore = useBillingStore();
+      const meterMode = authStore.serverConfig?.billing?.meterMode === true;
+      const billingEnabled = authStore.serverConfig?.billing?.enabled === true;
+      const hasSubscription = !!billingStore.subscription;
+      return billingEnabled && (meterMode || hasSubscription);
     },
   },
   /**


### PR DESCRIPTION
## Summary

- **Fix 1 – UsageBar always-on**: Meter mode now renders for all authenticated users. Added `displayMode` computed (`'admin' | 'free' | 'standard'`): admin users get a rainbow/∞ gradient display, free users (no subscription) see `0 / 10 compute` in neutral grey, standard users see the existing quota bar. Detection: `user.roles.includes('admin')` → admin; `subscription === null || usageMeter === null` → free. New `freeTierQuota` prop (default 10) for downstream override.
- **Fix 2 – Extras section in /billing**: `BillingExtrasLedger` component wired into the extras card (last 20 entries, paginated). `extrasLedger` computed reads `billingStore.extrasLedger`. `onLedgerPageChange` handles pagination. Ledger fetched on mount when `meterMode`.
- **Fix 3 – Account/Org links to /billing**: `user.view.vue` and `organization.detail.component.vue` each show a conditional "Billing & Plan → /billing" card gated on `billing.enabled && (meterMode || hasSubscription)`. Org link also requires `canManage`. Dormant when billing not configured (`meterMode: false` and no subscription).

All gating is via `serverConfig.billing.*` — no Trawl-specific code, zero downstream config changes needed.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 1324 passed (+57 vs 1267 baseline)
- [x] `billing.usageBar.component.unit.tests.js`: admin display, free display, standard display
- [x] `billing.billing.view.unit.tests.js`: extras ledger renders/hides on meterMode, computed fallback, page change handler
- [x] `user.view.unit.tests.js`: showBillingLink — true/false for all config combinations