### PR TITLE
feat(billing): add 'Manage subscription' footer link in meterDrawer

### DIFF
--- a/src/modules/billing/components/billing.meterDrawer.component.vue
+++ b/src/modules/billing/components/billing.meterDrawer.component.vue
@@ -93,6 +93,20 @@
       v-model="extrasModalOpen"
       :packs="packsAvailable"
     />
+
+    <v-divider class="my-4" />
+    <v-card-actions class="px-6 pb-6">
+      <v-btn
+        variant="text"
+        color="primary"
+        class="text-none"
+        to="/billing"
+        @click="$emit('update:modelValue', false)"
+      >
+        <v-icon icon="fa-solid fa-credit-card" size="small" class="mr-2" />
+        Manage subscription
+      </v-btn>
+    </v-card-actions>
   </v-navigation-drawer>
 </template>
 

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -14,6 +14,8 @@ export const billingEn = {
       progress: '{used} of {quota} units used',
       /** i18n key: billing.usage.exhausted */
       exhausted: 'Quota exhausted',
+      /** i18n key: billing.usage.manageSubscription */
+      manageSubscription: 'Manage subscription',
       bucket: {
         /** i18n key: billing.usage.bucket.scrap */
         scrap: 'Scrape',

--- a/src/modules/billing/lang/fr.js
+++ b/src/modules/billing/lang/fr.js
@@ -14,6 +14,8 @@ export const billingFr = {
       progress: '{used} sur {quota} unités utilisées',
       /** i18n key: billing.usage.exhausted */
       exhausted: 'Quota épuisé',
+      /** i18n key: billing.usage.manageSubscription */
+      manageSubscription: 'Gérer l’abonnement',
       bucket: {
         /** i18n key: billing.usage.bucket.scrap */
         scrap: 'Scrape',

--- a/src/modules/billing/tests/billing.meterDrawer.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterDrawer.component.unit.tests.js
@@ -170,6 +170,32 @@ describe('BillingMeterDrawerComponent', () => {
     expect(wrapper.vm.extrasModalOpen).toBe(true);
   });
 
+  // ── Manage subscription link ─────────────────────────────────────────────
+
+  it('renders "Manage subscription" button', () => {
+    wrapper = mountComponent({ modelValue: true });
+    expect(wrapper.text()).toContain('Manage subscription');
+  });
+
+  it('"Manage subscription" button has to="/billing"', () => {
+    wrapper = mountComponent({ modelValue: true });
+    // findComponent by name to access Vue props (findAll returns DOMWrappers without .props())
+    const allBtns = wrapper.findAllComponents({ name: 'v-btn' });
+    const btn = allBtns.find((b) => b.text().includes('Manage subscription'));
+    expect(btn).toBeDefined();
+    expect(btn.props('to')).toBe('/billing');
+  });
+
+  it('"Manage subscription" button emits update:modelValue false on click', async () => {
+    wrapper = mountComponent({ modelValue: true });
+    const btn = wrapper.findAll('.v-btn').find((b) => b.text().includes('Manage subscription'));
+    expect(btn).toBeDefined();
+    await btn.trigger('click');
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    const allEmits = wrapper.emitted('update:modelValue').flat();
+    expect(allEmits).toContain(false);
+  });
+
   // ── packsAvailable ───────────────────────────────────────────────────────
 
   it('sources packsAvailable from usageMeter when available', () => {


### PR DESCRIPTION
## Summary

- Adds a `v-card-actions` footer in `BillingMeterDrawerComponent` with a "Manage subscription" `v-btn` that navigates to `/billing` and emits `update:modelValue=false` to close the drawer on click
- Adds `billing.usage.manageSubscription` i18n key in `en.js` and `fr.js`
- Adds 3 unit tests covering: button renders, `to="/billing"` prop, and emit on click

Closes #4056

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 1329 tests pass (was 1326)
- [x] New tests: "renders 'Manage subscription' button", "button has to='/billing'", "emits update:modelValue false on click"
- [x] Pre-existing audit vulnerabilities only (commitizen/inquirer — unrelated to this change)