### PR TITLE
feat(billing): expose netRemainingRaw + overage in useMeter for negative quota display

### DIFF
--- a/src/modules/billing/composables/billing.useMeter.js
+++ b/src/modules/billing/composables/billing.useMeter.js
@@ -43,6 +43,8 @@ function fetchMissingMeterData(billingStore) {
  *   progress: import('vue').ComputedRef<number>,
  *   breakdownPercent: import('vue').ComputedRef<Object>,
  *   totalRemaining: import('vue').ComputedRef<number>,
+ *   netRemainingRaw: import('vue').ComputedRef<number>,
+ *   overage: import('vue').ComputedRef<number>,
  *   refresh: () => Promise<[Object, Object]>,
  *   purchasePack: (packId: string) => Promise<void>
  * }}
@@ -96,8 +98,25 @@ export function useMeter({ pollIntervalMs = 30000 } = {}) {
   /**
    * @type {import('vue').ComputedRef<number>}
    * Sum of remaining included quota and extras credits (floor 0).
+   * Used by progress bars and visual indicators — always >= 0 (backward-compat).
    */
   const totalRemaining = computed(() => Math.max(0, quota.value - used.value) + extras.value);
+
+  /**
+   * @type {import('vue').ComputedRef<number>}
+   * Unclamped balance: quota - used + extras. Can be negative when in-flight jobs
+   * push usage past quota (e.g. a long-running scrape finishing after quota is hit).
+   * Use this in detail views / ledger displays that must show the real debt.
+   */
+  const netRemainingRaw = computed(() => quota.value - used.value + extras.value);
+
+  /**
+   * @type {import('vue').ComputedRef<number>}
+   * Credits consumed beyond the included quota (floor 0).
+   * Positive only when used > quota, regardless of extras balance.
+   * Use this to show an "over quota" chip in drawer / detail views.
+   */
+  const overage = computed(() => Math.max(0, used.value - quota.value));
 
   /**
    * @desc Trigger parallel refresh of meter usage and extras balance.
@@ -140,6 +159,8 @@ export function useMeter({ pollIntervalMs = 30000 } = {}) {
     progress,
     breakdownPercent,
     totalRemaining,
+    netRemainingRaw,
+    overage,
     refresh,
     purchasePack,
   };

--- a/src/modules/billing/tests/billing.useMeter.unit.tests.js
+++ b/src/modules/billing/tests/billing.useMeter.unit.tests.js
@@ -206,6 +206,72 @@ describe('useMeter composable', () => {
     expect(result.totalRemaining.value).toBe(1500);
   });
 
+  // ── netRemainingRaw ───────────────────────────────────────────────────────
+
+  it('netRemainingRaw is quota - used + extras (positive case)', () => {
+    store.usageMeter = { meterUsed: 2000, meterQuota: 8000, extrasRemaining: 500 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.netRemainingRaw.value).toBe(6500);
+  });
+
+  it('netRemainingRaw can be negative when used > quota and extras = 0', () => {
+    store.usageMeter = { meterUsed: 10000, meterQuota: 8000, extrasRemaining: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.netRemainingRaw.value).toBe(-2000);
+  });
+
+  it('netRemainingRaw accounts for extras even when used > quota', () => {
+    store.usageMeter = { meterUsed: 10000, meterQuota: 8000, extrasRemaining: 5000 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.netRemainingRaw.value).toBe(3000);
+  });
+
+  it('netRemainingRaw is 0 when used equals quota and extras = 0', () => {
+    store.usageMeter = { meterUsed: 8000, meterQuota: 8000, extrasRemaining: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.netRemainingRaw.value).toBe(0);
+  });
+
+  // ── overage ───────────────────────────────────────────────────────────────
+
+  it('overage is 0 when used < quota', () => {
+    store.usageMeter = { meterUsed: 2000, meterQuota: 8000, extrasRemaining: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.overage.value).toBe(0);
+  });
+
+  it('overage is 0 when used equals quota', () => {
+    store.usageMeter = { meterUsed: 8000, meterQuota: 8000, extrasRemaining: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.overage.value).toBe(0);
+  });
+
+  it('overage is positive when used > quota', () => {
+    store.usageMeter = { meterUsed: 10000, meterQuota: 8000, extrasRemaining: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.overage.value).toBe(2000);
+  });
+
+  it('overage ignores extras balance (reflects raw quota breach)', () => {
+    store.usageMeter = { meterUsed: 10000, meterQuota: 8000, extrasRemaining: 5000 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.overage.value).toBe(2000);
+  });
+
+  // ── totalRemaining regression (always >= 0) ───────────────────────────────
+
+  it('totalRemaining is always >= 0 even when used > quota (regression)', () => {
+    store.usageMeter = { meterUsed: 50000, meterQuota: 8000, extrasRemaining: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.totalRemaining.value).toBeGreaterThanOrEqual(0);
+  });
+
+  it('totalRemaining stays >= 0 when used far exceeds quota with no extras', () => {
+    store.usageMeter = { meterUsed: 100000, meterQuota: 1000, extrasRemaining: 0 };
+    const { result } = mountMeter({ pollIntervalMs: 0 });
+    expect(result.totalRemaining.value).toBe(0);
+  });
+
   // ── refresh ────────────────────────────────────────────────────────────────
 
   it('refresh calls fetchUsageMeter and fetchExtrasBalance in parallel', async () => {


### PR DESCRIPTION
## Summary

- **`netRemainingRaw`**: unclamped balance (`quota - used + extras`) — can be negative when in-flight jobs push usage past quota; use in ledger/detail views to show real debt
- **`overage`**: raw quota breach (`Math.max(0, used - quota)`) — extras-agnostic, use for "over quota" chips in drawer/detail views
- **`totalRemaining`**: unchanged — stays `Math.max(0, quota - used) + extras` (floor 0, backward-compat for progress bars)

All three are exported from `useMeter`. No breaking changes to existing consumers.

Closes #4060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new billing metrics: `netRemainingRaw` (unclamped remaining balance that may be negative) and `overage` (clamped over-quota amount).
  * Existing `totalRemaining` metric remains unchanged and continues to stay non-negative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->