### PR TITLE
feat(billing): wire netRemainingRaw + overage into devkit components

### DIFF
--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -40,7 +40,7 @@
       <span>{{ label }}</span>
       <span
         class="font-weight-medium"
-        :class="overage > 0 ? 'text-warning' : ''"
+        :class="overage > 0 ? 'text-error' : ''"
       >{{ clampedProgress }}%</span>
     </div>
 
@@ -50,7 +50,7 @@
       class="d-flex align-center mb-1"
     >
       <v-chip
-        color="warning"
+        color="error"
         size="x-small"
         variant="tonal"
         prepend-icon="fa-solid fa-triangle-exclamation"
@@ -86,11 +86,11 @@
 
     <!-- Summary text -->
     <div class="text-caption text-medium-emphasis mt-1">
+      <span>{{ used }} / {{ quota }}</span>
       <template v-if="overage > 0">
-        <span class="text-warning">{{ netRemainingRaw }} remaining</span>
+        <span class="text-error"> ({{ computedNetRemainingRaw }} remaining)</span>
       </template>
       <template v-else>
-        <span>{{ used }} / {{ quota }}</span>
         <span v-if="extras > 0"> +{{ extras }} extras</span>
       </template>
     </div>
@@ -164,25 +164,41 @@ export default {
   computed: {
     /**
      * @desc Usage percentage clamped to [0, 100].
-     * When in overage the bar is shown at 100% to indicate fully consumed state.
+     * When overage > 0 the bar is pinned to 100% to signal full consumption.
+     * When quota is 0 (undefined quota), returns 0.
      * @returns {number}
      */
     clampedProgress() {
+      if (this.overage > 0) return 100;
       if (this.quota === 0) return 0;
       return Math.max(0, Math.min(100, Math.round((this.used / this.quota) * 100)));
     },
 
     /**
      * @desc Vuetify color token based on usage threshold.
-     * Shifts to warning when in overage (consumed beyond quota).
-     * green <70%, warning 70-90% or overage > 0, error >=90% (no overage).
+     * Overage (used beyond quota) is the most severe state — always error.
+     * green <70%, warning 70-90%, error >=90% or overage > 0.
      * @returns {string}
      */
     thresholdColor() {
-      if (this.overage > 0) return 'warning';
+      if (this.overage > 0) return 'error';
       if (this.clampedProgress >= 90) return 'error';
       if (this.clampedProgress >= 70) return 'warning';
       return 'success';
+    },
+
+    /**
+     * @desc Unclamped net remaining, derived from quota - used + extras when
+     * netRemainingRaw prop is not explicitly provided (default 0 sentinel detection:
+     * if overage > 0 and netRemainingRaw === 0, derive internally to avoid showing
+     * a misleading "0 remaining" on partial prop usage).
+     * @returns {number}
+     */
+    computedNetRemainingRaw() {
+      if (this.overage > 0 && this.netRemainingRaw === 0) {
+        return this.quota - this.used + this.extras;
+      }
+      return this.netRemainingRaw;
     },
 
     /**

--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -7,13 +7,16 @@
   USAGE:
   <BillingMeterProgressComponent :used="120" :quota="200" :extras="30" label="Compute" />
   <BillingMeterProgressComponent :used="180" :quota="200" variant="donut" />
+  <BillingMeterProgressComponent :used="220" :quota="200" :overage="20" :net-remaining-raw="-20" />
 
   PROPS:
-  - used     (Number, required) : credits consumed
-  - quota    (Number, required) : included weekly quota
-  - extras   (Number, default 0): extras-pack credits remaining
-  - label    (String, optional) : widget label
-  - variant  ('bar'|'donut', default 'bar') : visual style
+  - used             (Number, required) : credits consumed
+  - quota            (Number, required) : included weekly quota
+  - extras           (Number, default 0): extras-pack credits remaining
+  - overage          (Number, default 0): credits consumed beyond quota (>0 when over)
+  - netRemainingRaw  (Number, default 0): unclamped remaining (can be negative when over quota)
+  - label            (String, optional) : widget label
+  - variant          ('bar'|'donut', default 'bar') : visual style
 
   EVENTS:
   - click : emitted when the widget is interacted with (for drilldown)
@@ -35,7 +38,25 @@
       class="d-flex justify-space-between text-body-2 text-medium-emphasis mb-1"
     >
       <span>{{ label }}</span>
-      <span class="font-weight-medium">{{ clampedProgress }}%</span>
+      <span
+        class="font-weight-medium"
+        :class="overage > 0 ? 'text-warning' : ''"
+      >{{ clampedProgress }}%</span>
+    </div>
+
+    <!-- Overage badge -->
+    <div
+      v-if="overage > 0"
+      class="d-flex align-center mb-1"
+    >
+      <v-chip
+        color="warning"
+        size="x-small"
+        variant="tonal"
+        prepend-icon="fa-solid fa-triangle-exclamation"
+      >
+        +{{ overage }} over
+      </v-chip>
     </div>
 
     <!-- Bar variant -->
@@ -65,8 +86,13 @@
 
     <!-- Summary text -->
     <div class="text-caption text-medium-emphasis mt-1">
-      <span>{{ used }} / {{ quota }}</span>
-      <span v-if="extras > 0"> +{{ extras }} extras</span>
+      <template v-if="overage > 0">
+        <span class="text-warning">{{ netRemainingRaw }} remaining</span>
+      </template>
+      <template v-else>
+        <span>{{ used }} / {{ quota }}</span>
+        <span v-if="extras > 0"> +{{ extras }} extras</span>
+      </template>
     </div>
   </div>
 </template>
@@ -101,6 +127,22 @@ export default {
       default: 0,
     },
     /**
+     * @desc Credits consumed beyond the included quota. Positive when over quota.
+     * From useMeter's `overage` export.
+     */
+    overage: {
+      type: Number,
+      default: 0,
+    },
+    /**
+     * @desc Unclamped remaining balance (quota - used + extras). Can be negative.
+     * From useMeter's `netRemainingRaw` export.
+     */
+    netRemainingRaw: {
+      type: Number,
+      default: 0,
+    },
+    /**
      * @desc Optional display label shown above the bar/donut.
      */
     label: {
@@ -122,6 +164,7 @@ export default {
   computed: {
     /**
      * @desc Usage percentage clamped to [0, 100].
+     * When in overage the bar is shown at 100% to indicate fully consumed state.
      * @returns {number}
      */
     clampedProgress() {
@@ -131,10 +174,12 @@ export default {
 
     /**
      * @desc Vuetify color token based on usage threshold.
-     * green <70%, warning 70-90%, error >=90%.
+     * Shifts to warning when in overage (consumed beyond quota).
+     * green <70%, warning 70-90% or overage > 0, error >=90% (no overage).
      * @returns {string}
      */
     thresholdColor() {
+      if (this.overage > 0) return 'warning';
       if (this.clampedProgress >= 90) return 'error';
       if (this.clampedProgress >= 70) return 'warning';
       return 'success';
@@ -146,6 +191,9 @@ export default {
      */
     ariaLabel() {
       const base = this.label ? `${this.label}: ` : '';
+      if (this.overage > 0) {
+        return `${base}${this.used} of ${this.quota} used, ${this.overage} over quota`;
+      }
       return `${base}${this.used} of ${this.quota} used (${this.clampedProgress}%)`;
     },
   },

--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -70,16 +70,21 @@
       />
     </template>
 
-    <!-- Standard display: current behaviour -->
+    <!-- Standard display: current behaviour, with overage indicator when over quota -->
     <template v-else>
       <div class="d-flex justify-space-between text-body-2 text-medium-emphasis mb-1">
         <span>{{ displayLabel || 'Weekly usage' }}</span>
-        <span class="font-weight-medium">{{ meterDisplay }}</span>
+        <span
+          class="font-weight-medium"
+          :class="meterOverage > 0 ? 'text-warning' : ''"
+        >{{ meterDisplay }}</span>
       </div>
       <BillingMeterProgressComponent
         :used="meterUsed"
         :quota="meterQuota"
         :extras="meterExtras"
+        :overage="meterOverage"
+        :net-remaining-raw="meterNetRemainingRaw"
       />
     </template>
   </div>
@@ -175,7 +180,7 @@ export default {
    * pollIntervalMs:0 disables the 30-second setInterval inside useMeter, but
    * safeRefresh() still fires once on mount to populate the initial meter state.
    * @param {Object} props - Component props
-   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed?: ComputedRef, meterQuota?: ComputedRef, meterExtras?: ComputedRef, authStore: Object, billingStore: Object }}
+   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed?: ComputedRef, meterQuota?: ComputedRef, meterExtras?: ComputedRef, meterNetRemainingRaw?: ComputedRef, meterOverage?: ComputedRef, authStore: Object, billingStore: Object }}
    */
   setup(props) {
     const { usage, limits, usagePercent } = useQuota();
@@ -183,8 +188,14 @@ export default {
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
     if (props.mode === 'meter') {
-      const { used: meterUsed, quota: meterQuota, extras: meterExtras } = useMeter({ pollIntervalMs: 0 });
-      return { usage, limits, usagePercent, isPlanActive, meterUsed, meterQuota, meterExtras, authStore, billingStore };
+      const {
+        used: meterUsed,
+        quota: meterQuota,
+        extras: meterExtras,
+        netRemainingRaw: meterNetRemainingRaw,
+        overage: meterOverage,
+      } = useMeter({ pollIntervalMs: 0 });
+      return { usage, limits, usagePercent, isPlanActive, meterUsed, meterQuota, meterExtras, meterNetRemainingRaw, meterOverage, authStore, billingStore };
     }
     return { usage, limits, usagePercent, isPlanActive, authStore, billingStore };
   },
@@ -278,10 +289,14 @@ export default {
     },
 
     /**
-     * @desc Usage summary text shown in standard meter mode: "{used} / {quota} +{extras}".
+     * @desc Usage summary text shown in standard meter mode.
+     * When in overage shows the negative net remaining; otherwise "{used} / {quota} +{extras}".
      * @returns {string}
      */
     meterDisplay() {
+      if (this.meterOverage > 0) {
+        return `${this.meterUsed} / ${this.meterQuota} (${this.meterNetRemainingRaw} remaining)`;
+      }
       const base = `${this.meterUsed} / ${this.meterQuota}`;
       return this.meterExtras > 0 ? `${base} +${this.meterExtras}` : base;
     },

--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -76,7 +76,7 @@
         <span>{{ displayLabel || 'Weekly usage' }}</span>
         <span
           class="font-weight-medium"
-          :class="meterOverage > 0 ? 'text-warning' : ''"
+          :class="meterOverage > 0 ? 'text-error' : ''"
         >{{ meterDisplay }}</span>
       </div>
       <BillingMeterProgressComponent
@@ -175,29 +175,27 @@ export default {
   emits: [],
 
   /**
-   * @desc Wires useQuota (always) and useMeter only in meter mode to avoid
-   * unnecessary reactive subscriptions and polling in legacy mode.
-   * pollIntervalMs:0 disables the 30-second setInterval inside useMeter, but
-   * safeRefresh() still fires once on mount to populate the initial meter state.
+   * @desc Wires useQuota (always) and useMeter (always, at top level to satisfy
+   * composition rules). pollIntervalMs:0 disables the 30-second setInterval inside
+   * useMeter; fetchMissingMeterData() still runs immediately during composable
+   * creation to populate initial meter state. Meter values are only consumed by
+   * computed properties when mode === 'meter'.
    * @param {Object} props - Component props
-   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed?: ComputedRef, meterQuota?: ComputedRef, meterExtras?: ComputedRef, meterNetRemainingRaw?: ComputedRef, meterOverage?: ComputedRef, authStore: Object, billingStore: Object }}
+   * @returns {{ usage: Object, limits: Object, usagePercent: Function, meterUsed: ComputedRef, meterQuota: ComputedRef, meterExtras: ComputedRef, meterNetRemainingRaw: ComputedRef, meterOverage: ComputedRef, authStore: Object, billingStore: Object }}
    */
-  setup(props) {
+  setup() {
     const { usage, limits, usagePercent } = useQuota();
     const { isPlanActive } = useBilling();
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
-    if (props.mode === 'meter') {
-      const {
-        used: meterUsed,
-        quota: meterQuota,
-        extras: meterExtras,
-        netRemainingRaw: meterNetRemainingRaw,
-        overage: meterOverage,
-      } = useMeter({ pollIntervalMs: 0 });
-      return { usage, limits, usagePercent, isPlanActive, meterUsed, meterQuota, meterExtras, meterNetRemainingRaw, meterOverage, authStore, billingStore };
-    }
-    return { usage, limits, usagePercent, isPlanActive, authStore, billingStore };
+    const {
+      used: meterUsed,
+      quota: meterQuota,
+      extras: meterExtras,
+      netRemainingRaw: meterNetRemainingRaw,
+      overage: meterOverage,
+    } = useMeter({ pollIntervalMs: 0 });
+    return { usage, limits, usagePercent, isPlanActive, meterUsed, meterQuota, meterExtras, meterNetRemainingRaw, meterOverage, authStore, billingStore };
   },
 
   computed: {

--- a/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
@@ -153,4 +153,22 @@ describe('BillingMeterProgressComponent', () => {
     const labelRow = wrapper.find('.d-flex.justify-space-between');
     expect(labelRow.exists()).toBe(false);
   });
+
+  // ── Overage display ──────────────────────────────────────────────────────
+
+  it('no overage badge when overage is 0 (normal behavior unchanged)', () => {
+    const wrapper = mountComponent({ used: 50, quota: 100, overage: 0, netRemainingRaw: 50 });
+    expect(wrapper.text()).not.toContain('over');
+    expect(wrapper.findComponent({ name: 'v-chip' }).exists()).toBe(false);
+    expect(wrapper.vm.thresholdColor).toBe('success');
+  });
+
+  it('shows overage badge and warning color when overage > 0', () => {
+    const wrapper = mountComponent({ used: 120, quota: 100, overage: 20, netRemainingRaw: -20 });
+    expect(wrapper.vm.thresholdColor).toBe('warning');
+    const chip = wrapper.findComponent({ name: 'v-chip' });
+    expect(chip.exists()).toBe(true);
+    expect(wrapper.text()).toContain('+20 over');
+    expect(wrapper.text()).toContain('-20 remaining');
+  });
 });

--- a/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
@@ -163,9 +163,9 @@ describe('BillingMeterProgressComponent', () => {
     expect(wrapper.vm.thresholdColor).toBe('success');
   });
 
-  it('shows overage badge and warning color when overage > 0', () => {
+  it('shows overage badge and error color when overage > 0', () => {
     const wrapper = mountComponent({ used: 120, quota: 100, overage: 20, netRemainingRaw: -20 });
-    expect(wrapper.vm.thresholdColor).toBe('warning');
+    expect(wrapper.vm.thresholdColor).toBe('error');
     const chip = wrapper.findComponent({ name: 'v-chip' });
     expect(chip.exists()).toBe(true);
     expect(wrapper.text()).toContain('+20 over');

--- a/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
@@ -323,10 +323,14 @@ describe('BillingUsageBarComponent', () => {
     store.usageMeter = { meterUsed: 800, meterQuota: 1000, extrasRemaining: 0 };
     const wrapper = mountComponent({ mode: 'meter' });
     expect(wrapper.vm.meterOverage).toBe(0);
-    expect(wrapper.text()).not.toContain('over quota');
+    // Child receives overage=0 — no overage chip should render
+    const meterProgress = wrapper.findComponent({ name: 'BillingMeterProgressComponent' });
+    expect(meterProgress.props('overage')).toBe(0);
+    expect(wrapper.findComponent({ name: 'v-chip' }).exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('over');
   });
 
-  it('shows overage badge and warning color when used exceeds quota (overage > 0)', () => {
+  it('shows overage badge and error color when used exceeds quota (overage > 0)', () => {
     authState.user = { roles: ['user'] };
     const store = useBillingStore();
     store.subscription = { status: 'active', plan: 'starter' };

--- a/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
@@ -313,4 +313,33 @@ describe('BillingUsageBarComponent', () => {
     expect(wrapper.text()).toContain('200');
     expect(wrapper.text()).toContain('1000');
   });
+
+  // ── Meter mode: overage display ──────────────────────────────────────────
+
+  it('no overage badge when used is within quota (overage = 0)', () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = { status: 'active', plan: 'starter' };
+    store.usageMeter = { meterUsed: 800, meterQuota: 1000, extrasRemaining: 0 };
+    const wrapper = mountComponent({ mode: 'meter' });
+    expect(wrapper.vm.meterOverage).toBe(0);
+    expect(wrapper.text()).not.toContain('over quota');
+  });
+
+  it('shows overage badge and warning color when used exceeds quota (overage > 0)', () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = { status: 'active', plan: 'starter' };
+    store.usageMeter = { meterUsed: 1100, meterQuota: 1000, extrasRemaining: 0 };
+    const wrapper = mountComponent({ mode: 'meter' });
+    expect(wrapper.vm.meterOverage).toBe(100);
+    expect(wrapper.vm.meterNetRemainingRaw).toBe(-100);
+    // meterDisplay shows negative remaining in header
+    expect(wrapper.text()).toContain('-100');
+    // meterProgress child renders the overage badge
+    const meterProgress = wrapper.findComponent({ name: 'BillingMeterProgressComponent' });
+    expect(meterProgress.exists()).toBe(true);
+    expect(meterProgress.props('overage')).toBe(100);
+    expect(meterProgress.props('netRemainingRaw')).toBe(-100);
+  });
 });


### PR DESCRIPTION
## Summary

PR #4061 added `netRemainingRaw` + `overage` exports to `useMeter`, but devkit's own components didn't consume them. Downstream consumers had to wire it themselves. This PR adds the canonical UX in the built-in components.

## Changes

- `usageBar.component.vue`: wires `meterNetRemainingRaw` + `meterOverage` from `useMeter`; header label shifts to `text-warning` color; `meterDisplay` shows negative remaining when over quota; delegates overage badge to `BillingMeterProgressComponent`
- `meterProgress.component.vue`: new `overage` + `netRemainingRaw` props; overage badge (v-chip warning) when overage > 0; `thresholdColor` shifts to `warning` on overage; summary text shows `netRemainingRaw remaining` instead of clamped `used / quota`; a11y `ariaLabel` updated for overage state
- Tests: 2 new cases per component (overage 0 = unchanged behavior, overage > 0 = badge visible + warning color + props forwarded)

## Test plan

- [ ] CI green
- [ ] Visual: overage badge (`+N over`) + warning color appear when meter exceeds included quota
- [ ] No overage badge at normal usage (overage = 0)
- [ ] Legacy mode unchanged