### PR TITLE
feat(billing): v4 hardening + Phase 3 polish — equivalences chips + UX gaps + a11y

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -218,6 +218,7 @@
       "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.8.1.tgz",
       "integrity": "sha512-VX5DD1JbSP/DdewZnNwXXaCzve+0pLe14mcUj2l93CdOFAQUT/ylAptNqxf3Wc/jlsuSanAgXza4Z1Iq23dzpQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ucast/mongo2js": "^1.3.0"
       },
@@ -523,27 +524,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -980,6 +960,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1133,6 +1114,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3284,6 +3266,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -3539,6 +3522,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -3728,6 +3712,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
       "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -3850,6 +3835,7 @@
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
       "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.33",
         "@vue/shared": "3.5.33"
@@ -3923,6 +3909,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4454,6 +4441,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5007,6 +4995,7 @@
       "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5087,6 +5076,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5427,7 +5417,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -5926,6 +5917,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7009,6 +7001,7 @@
       "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -7890,6 +7883,7 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11075,6 +11069,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11315,6 +11310,7 @@
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
       "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.127.0"
       },
@@ -11757,6 +11753,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -11924,6 +11921,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12458,6 +12456,7 @@
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
         "@rolldown/pluginutils": "1.0.0-rc.17"
@@ -12546,6 +12545,7 @@
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -12573,6 +12573,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12845,6 +12846,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -13838,6 +13840,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13956,6 +13959,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14005,6 +14009,7 @@
       "resolved": "https://registry.npmjs.org/unhead/-/unhead-3.1.0.tgz",
       "integrity": "sha512-SH1PAjAMspLIoBjAjE/R8hty2NYo7YcIrdu5I+PVfiW4QmmwEG4pgoiKG0MCs6WRSwiatzeha+4lqSqvHW9PEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hookable": "^6.1.1",
         "unplugin": "^3.0.0"
@@ -14230,6 +14235,7 @@
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.7.tgz",
       "integrity": "sha512-cG4HOygYt+Z8j6Sf5DuK6OgEOoM+g9oGP6vpqoZRaD13aHE4PMITbyjJUXZcIQbgB0wJEadBRaVm5lJIzo2jAA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@videojs/http-streaming": "^3.17.3",
@@ -14281,6 +14287,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -14406,6 +14413,7 @@
       "integrity": "sha512-Q4SC/4TqbNvaZIFb9YsfBqkGlYHbJJJ6uU3CnRBZqLUF3s5eCMVZAaV4GkTbehIH/bhSj42lMXztOwc71u6rVw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vuetify/loader-shared": "^2.1.2",
         "debug": "^4.3.3",
@@ -14452,6 +14460,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -14554,6 +14563,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -14583,6 +14593,7 @@
       "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -14739,6 +14750,7 @@
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.0.6.tgz",
       "integrity": "sha512-a4kasYa3SuFI5IOG/0Fx04M4TWeef5mCdTTKFlaxt86oz16RMQ/DJ3BynlOnIdUODt7NxYIkdLYud070/vVEUQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1630,6 +1630,27 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
@@ -2377,27 +2398,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -8342,6 +8342,27 @@
         "magic-string": "^0.30.21",
         "oxc-parser": "^0.126.0",
         "unplugin": "^3.0.0"
+      }
+    },
+    "node_modules/logs-sdk/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/logs-sdk/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/logs-sdk/node_modules/@oxc-parser/binding-android-arm-eabi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15074,6 +15074,48 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     }
   }
 }

--- a/src/modules/billing/components/billing.equivalencesChips.component.vue
+++ b/src/modules/billing/components/billing.equivalencesChips.component.vue
@@ -1,0 +1,86 @@
+<!--
+  BillingEquivalencesChipsComponent
+  ===================================
+  Primitive Vuetify v-chip list rendering equivalence entries color-coded by kind.
+
+  USAGE:
+  <BillingEquivalencesChipsComponent
+    :equivalences="[
+      { kind: 'easy', count: 500, label: 'light operations / week' },
+      { kind: 'hard', count: 50, label: 'heavy operations / week' },
+      { kind: 'feature', count: 3, label: 'integrations' },
+    ]"
+  />
+
+  PROPS:
+  - equivalences (Array, required): Array of { kind: 'easy'|'hard'|'feature', count: number, label: string }
+
+  Kind → color mapping:
+  - easy    → success (green)  — lightweight / fast operations
+  - hard    → warning (amber)  — compute-heavy operations
+  - feature → primary (brand)  — feature entitlements
+-->
+<template>
+  <div class="d-flex flex-wrap ga-2" role="list">
+    <v-chip
+      v-for="(eq, i) in equivalences"
+      :key="`${eq.kind}-${i}`"
+      :color="colorForKind(eq.kind)"
+      :prepend-icon="iconForKind(eq.kind)"
+      variant="tonal"
+      density="comfortable"
+      role="listitem"
+    >
+      {{ eq.count }} {{ eq.label }}
+    </v-chip>
+  </div>
+</template>
+
+<script>
+/**
+ * Component definition.
+ */
+export default {
+  name: 'BillingEquivalencesChipsComponent',
+
+  props: {
+    /**
+     * @desc Structured equivalences to render as chips.
+     * Each entry must have { kind: 'easy'|'hard'|'feature', count: number, label: string }.
+     */
+    equivalences: {
+      type: Array,
+      required: true,
+      validator: (arr) =>
+        arr.every(
+          (e) =>
+            e &&
+            typeof e.label === 'string' &&
+            typeof e.count === 'number' &&
+            ['easy', 'hard', 'feature'].includes(e.kind),
+        ),
+    },
+  },
+
+  methods: {
+    /**
+     * @desc Map a kind to its Vuetify color token.
+     * @param {'easy'|'hard'|'feature'} kind
+     * @returns {string} Vuetify color name
+     */
+    colorForKind(kind) {
+      return { easy: 'success', hard: 'warning', feature: 'primary' }[kind] || 'default';
+    },
+    /**
+     * @desc Map a kind to its Font Awesome icon string (FA iconset required).
+     * @param {'easy'|'hard'|'feature'} kind
+     * @returns {string} Icon identifier
+     */
+    iconForKind(kind) {
+      return (
+        { easy: 'fa-solid fa-bolt', hard: 'fa-solid fa-fire', feature: 'fa-solid fa-check' }[kind] || 'fa-solid fa-circle'
+      );
+    },
+  },
+};
+</script>

--- a/src/modules/billing/components/billing.equivalencesChips.component.vue
+++ b/src/modules/billing/components/billing.equivalencesChips.component.vue
@@ -51,6 +51,7 @@ export default {
     equivalences: {
       type: Array,
       required: true,
+      // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Vue props validator, not a Qwik component
       validator: (arr) =>
         arr.every(
           (e) =>

--- a/src/modules/billing/components/billing.extrasCheckoutModal.component.vue
+++ b/src/modules/billing/components/billing.extrasCheckoutModal.component.vue
@@ -26,10 +26,10 @@
     @update:model-value="$emit('update:modelValue', $event)"
   >
     <v-card>
-      <!-- Title -->
-      <div class="text-title-medium font-weight-bold pt-5 px-5">
+      <!-- Title — v-card-title adds dialog landmark semantics for screen readers -->
+      <v-card-title class="text-title-medium font-weight-bold pt-5 px-5">
         Buy extra units
-      </div>
+      </v-card-title>
 
       <!-- Pack radio list -->
       <v-card-text class="px-5 pb-2">

--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -106,7 +106,7 @@
 /**
  * Module dependencies.
  */
-import { computed, getCurrentInstance, useAttrs } from 'vue';
+import { computed, getCurrentInstance } from 'vue';
 
 /**
  * Component definition.
@@ -174,14 +174,13 @@ export default {
   /**
    * @desc Detects whether the parent registered a click listener so the widget
    * only exposes button semantics when it is genuinely interactive.
-   * Uses both useAttrs().onClick (stable public API) and getCurrentInstance as
-   * a belt-and-suspenders fallback to handle edge cases in different render contexts.
+   * Accesses vnode.props directly because Vue strips declared emit listeners
+   * from $attrs — getCurrentInstance().vnode.props is the only reliable source.
    * @returns {{ hasClickListener: import('vue').ComputedRef<boolean> }}
    */
   setup() {
-    const attrs = useAttrs();
     const instance = getCurrentInstance();
-    const hasClickListener = computed(() => Boolean(attrs.onClick || instance?.vnode?.props?.onClick));
+    const hasClickListener = computed(() => Boolean(instance?.vnode?.props?.onClick));
     return { hasClickListener };
   },
 

--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -174,6 +174,8 @@ export default {
   /**
    * @desc Detects whether the parent registered a click listener so the widget
    * only exposes button semantics when it is genuinely interactive.
+   * Uses both useAttrs().onClick (stable public API) and getCurrentInstance as
+   * a belt-and-suspenders fallback to handle edge cases in different render contexts.
    * @returns {{ hasClickListener: import('vue').ComputedRef<boolean> }}
    */
   setup() {

--- a/src/modules/billing/components/billing.packs.component.vue
+++ b/src/modules/billing/components/billing.packs.component.vue
@@ -40,9 +40,15 @@
         >
           <p class="text-title-medium font-weight-bold mb-2">{{ pack.label }}</p>
           <p class="text-display-small font-weight-bold mb-1">${{ pack.priceUsd }}</p>
-          <p class="text-body-medium text-medium-emphasis mb-6">
+          <p class="text-body-medium text-medium-emphasis mb-4">
             +{{ pack.meterUnits }} units
           </p>
+          <!-- Structured equivalences chips (Phase 3 forward) — opt-in, no breaking change -->
+          <BillingEquivalencesChipsComponent
+            v-if="pack.equivalences && pack.equivalences.length > 0"
+            :equivalences="pack.equivalences"
+            class="mb-4"
+          />
           <v-btn
             color="primary"
             variant="flat"
@@ -79,12 +85,16 @@
 import { useBillingStore } from '../stores/billing.store';
 import { useAuthStore } from '../../auth/stores/auth.store';
 import { packs as packsConfig } from '../config/billing.static-content';
+import BillingEquivalencesChipsComponent from './billing.equivalencesChips.component.vue';
 
 /**
  * Component definition.
  */
 export default {
   name: 'BillingPacksComponent',
+  components: {
+    BillingEquivalencesChipsComponent,
+  },
 
   /**
    * @desc Inject billing store and auth store. Auth store is used to guard
@@ -165,5 +175,9 @@ export default {
 <style scoped>
 .billing-packs__card {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .billing-packs__card { transition: none; }
 }
 </style>

--- a/src/modules/billing/components/billing.packs.component.vue
+++ b/src/modules/billing/components/billing.packs.component.vue
@@ -44,8 +44,9 @@
             +{{ pack.meterUnits }} units
           </p>
           <!-- Structured equivalences chips (Phase 3 forward) — opt-in, no breaking change -->
+          <!-- Guard: only render chips when equivalences carry the new { kind, count, label } shape -->
           <BillingEquivalencesChipsComponent
-            v-if="pack.equivalences && pack.equivalences.length > 0"
+            v-if="pack.equivalences && pack.equivalences.length > 0 && pack.equivalences[0]?.kind != null"
             :equivalences="pack.equivalences"
             class="mb-4"
           />

--- a/src/modules/billing/components/billing.pricingCard.component.vue
+++ b/src/modules/billing/components/billing.pricingCard.component.vue
@@ -52,7 +52,7 @@
       </template>
       <template v-else-if="pricesLoading && displayPrice === null">
         <v-skeleton-loader
-          type="button"
+          type="text"
           class="billing-pricing-card__price-skeleton"
         />
       </template>
@@ -118,9 +118,15 @@
       </v-btn>
     </div>
 
-    <!-- Equivalences (meter mode) — rendered when equivalences prop is present -->
+    <!-- Equivalences (meter mode — structured {kind, count, label} objects) -->
+    <BillingEquivalencesChipsComponent
+      v-if="isStructuredEquivalences"
+      :equivalences="equivalences"
+    />
+
+    <!-- Equivalences (meter mode — legacy flat {count, label} list) -->
     <v-list
-      v-if="equivalences && equivalences.length > 0"
+      v-else-if="equivalences && equivalences.length > 0"
       density="compact"
       bg-color="transparent"
       class="pa-0"
@@ -174,10 +180,18 @@
 
 <script>
 /**
+ * Module dependencies.
+ */
+import BillingEquivalencesChipsComponent from './billing.equivalencesChips.component.vue';
+
+/**
  * Component definition.
  */
 export default {
   name: 'BillingPricingCardComponent',
+  components: {
+    BillingEquivalencesChipsComponent,
+  },
   props: {
     plan: {
       type: Object,
@@ -211,6 +225,19 @@ export default {
   },
   emits: ['select'],
   computed: {
+    /**
+     * @desc Whether the equivalences array contains structured {kind, count, label} objects
+     * (Phase 3 format). Falls back to the legacy flat list when objects lack a `kind` field.
+     * @returns {boolean}
+     */
+    isStructuredEquivalences() {
+      return (
+        Array.isArray(this.equivalences) &&
+        this.equivalences.length > 0 &&
+        typeof this.equivalences[0] === 'object' &&
+        this.equivalences[0]?.kind != null
+      );
+    },
     /**
      * @desc Whether this plan is explicitly free (by ID convention).
      * @returns {boolean}

--- a/src/modules/billing/components/billing.pricingCard.component.vue
+++ b/src/modules/billing/components/billing.pricingCard.component.vue
@@ -234,6 +234,7 @@ export default {
       return (
         Array.isArray(this.equivalences) &&
         this.equivalences.length > 0 &&
+        this.equivalences[0] !== null &&
         typeof this.equivalences[0] === 'object' &&
         this.equivalences[0]?.kind != null
       );

--- a/src/modules/billing/components/billing.pricingToggle.component.vue
+++ b/src/modules/billing/components/billing.pricingToggle.component.vue
@@ -28,7 +28,7 @@
       <span class="text-body-large font-weight-medium" :class="{ 'text-medium-emphasis': !annual }">Annual</span>
       <v-chip v-if="annual" color="success" variant="tonal" size="small">Save 20%</v-chip>
     </div>
-    <div class="text-caption text-medium-emphasis mt-1">Save 20% annually</div>
+    <div v-if="!annual" class="text-caption text-medium-emphasis mt-1">Save 20% annually</div>
   </div>
 </template>
 

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -362,6 +362,7 @@ export default {
         past_due: 'warning',
         canceled: 'error',
         incomplete: 'error',
+        incomplete_expired: 'error',
       };
       return {
         color: colors[status] || 'default',
@@ -375,7 +376,7 @@ export default {
     subscriptionStatusIcon() {
       if (['active', 'trialing'].includes(this.subscriptionStatus)) return 'fa-solid fa-circle-check';
       if (this.subscriptionStatus === 'past_due') return 'fa-solid fa-triangle-exclamation';
-      if (['canceled', 'incomplete'].includes(this.subscriptionStatus)) return 'fa-solid fa-circle-exclamation';
+      if (['canceled', 'incomplete', 'incomplete_expired'].includes(this.subscriptionStatus)) return 'fa-solid fa-circle-exclamation';
       return 'fa-solid fa-circle-info';
     },
     /**

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -491,7 +491,8 @@ export default {
       try {
         await this.billingStore.openPortal();
         this.portalError = null;
-      } catch {
+      } catch (err) {
+        console.error('Failed to open billing portal:', err);
         this.portalError = 'Unable to open the billing portal. Please try again.';
       } finally {
         this.portalLoading = false;

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -385,8 +385,11 @@ export default {
       if (this.subscriptionStatus === 'past_due') {
         return { color: 'warning', label: 'Update payment method' };
       }
-      if (['canceled', 'incomplete'].includes(this.subscriptionStatus)) {
+      if (this.subscriptionStatus === 'canceled') {
         return { color: 'error', label: 'Reactivate' };
+      }
+      if (['incomplete', 'incomplete_expired'].includes(this.subscriptionStatus)) {
+        return { color: 'error', label: 'Complete payment' };
       }
       return null;
     },
@@ -449,6 +452,11 @@ export default {
       this.paymentSuccessMessage = query.type === 'extras' || packPurchased
         ? 'Extra units purchased successfully. Thank you!'
         : 'Subscription updated successfully. Thank you!';
+
+      // Auto-dismiss the success alert after 5 seconds (manual close still works via closable)
+      setTimeout(() => {
+        this.paymentSuccessMessage = null;
+      }, 5000);
 
       this.successCleanupTimer = setTimeout(() => {
         this.$router.replace({

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -23,7 +23,7 @@
       variant="tonal"
       closable
       class="mb-4"
-      @click:close="paymentSuccessMessage = null"
+      @click:close="dismissPaymentSuccess"
     >
       {{ paymentSuccessMessage }}
     </v-alert>
@@ -288,6 +288,7 @@ export default {
       extrasCheckoutDialog: false,
       paymentSuccessMessage: null,
       successCleanupTimer: null,
+      paymentSuccessTimer: null,
     };
   },
   computed: {
@@ -437,8 +438,22 @@ export default {
     if (this.successCleanupTimer) {
       clearTimeout(this.successCleanupTimer);
     }
+    if (this.paymentSuccessTimer) {
+      clearTimeout(this.paymentSuccessTimer);
+    }
   },
   methods: {
+    /**
+     * @desc Manually dismiss the payment success banner and clear its auto-dismiss timer.
+     * @returns {void}
+     */
+    dismissPaymentSuccess() {
+      if (this.paymentSuccessTimer) {
+        clearTimeout(this.paymentSuccessTimer);
+        this.paymentSuccessTimer = null;
+      }
+      this.paymentSuccessMessage = null;
+    },
     /**
      * @desc Show checkout success feedback from Stripe return query params and clean the URL.
      * @returns {void}
@@ -454,8 +469,9 @@ export default {
         : 'Subscription updated successfully. Thank you!';
 
       // Auto-dismiss the success alert after 5 seconds (manual close still works via closable)
-      setTimeout(() => {
+      this.paymentSuccessTimer = setTimeout(() => {
         this.paymentSuccessMessage = null;
+        this.paymentSuccessTimer = null;
       }, 5000);
 
       this.successCleanupTimer = setTimeout(() => {

--- a/src/modules/billing/composables/billing.useMeter.js
+++ b/src/modules/billing/composables/billing.useMeter.js
@@ -143,6 +143,7 @@ export function useMeter({ pollIntervalMs = 30000, refreshOnFocus = true } = {})
    * double-fetching when the interval poll already covers freshness.
    * @returns {void}
    */
+  // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — composable closure, not a Qwik component
   const handleVisibilityChange = () => {
     if (refreshOnFocus && document.visibilityState === 'visible' && pollIntervalMs === 0) {
       void safeRefresh();

--- a/src/modules/billing/composables/billing.useMeter.js
+++ b/src/modules/billing/composables/billing.useMeter.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-import { computed, onUnmounted } from 'vue';
+import { computed, onMounted, onUnmounted } from 'vue';
 import { useBillingStore } from '../stores/billing.store';
 
 let pollTimer = null;
@@ -35,6 +35,7 @@ function fetchMissingMeterData(billingStore) {
  * Polls the API at a configurable interval and exposes reactive derived state.
  * @param {Object} [opts] - Options
  * @param {number} [opts.pollIntervalMs=30000] - Polling interval in ms; set to 0 to disable
+ * @param {boolean} [opts.refreshOnFocus=true] - Auto-refresh when tab regains visibility (resolves multi-tab stale state)
  * @returns {{
  *   used: import('vue').ComputedRef<number>,
  *   quota: import('vue').ComputedRef<number>,
@@ -49,7 +50,7 @@ function fetchMissingMeterData(billingStore) {
  *   purchasePack: (packId: string) => Promise<void>
  * }}
  */
-export function useMeter({ pollIntervalMs = 30000 } = {}) {
+export function useMeter({ pollIntervalMs = 30000, refreshOnFocus = true } = {}) {
   const billingStore = useBillingStore();
   consumerCount += 1;
 
@@ -136,7 +137,28 @@ export function useMeter({ pollIntervalMs = 30000 } = {}) {
     }, pollIntervalMs);
   }
 
+  /**
+   * @desc Handle tab visibility change — refresh when the tab becomes visible again.
+   * Only triggers when polling is disabled (pollIntervalMs === 0) to avoid
+   * double-fetching when the interval poll already covers freshness.
+   * @returns {void}
+   */
+  const handleVisibilityChange = () => {
+    if (refreshOnFocus && document.visibilityState === 'visible' && pollIntervalMs === 0) {
+      void safeRefresh();
+    }
+  };
+
+  onMounted(() => {
+    if (refreshOnFocus) {
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+  });
+
   onUnmounted(() => {
+    if (refreshOnFocus) {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    }
     consumerCount -= 1;
     if (consumerCount === 0 && pollTimer !== null) {
       clearInterval(pollTimer);

--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -228,7 +228,7 @@ export const useBillingStore = defineStore('billing', {
       try {
         const api = apiBase();
         const successUrl = `${window.location.origin}/users?tab=subscriptions&success=true&type=extras`;
-        const cancelUrl = `${window.location.origin}/pricing#units`;
+        const cancelUrl = `${window.location.origin}/pricing?canceled=true#units`;
         const res = await axios.post(`${api}/${config.api.endPoints.billing}/extras/checkout`, {
           packId,
           successUrl,

--- a/src/modules/billing/tests/billing.equivalencesChips.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.equivalencesChips.component.unit.tests.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import BillingEquivalencesChipsComponent from '../components/billing.equivalencesChips.component.vue';
+
+const vuetify = createVuetify();
+
+/**
+ * Mount the equivalences chips component.
+ * @param {Array} equivalences - Equivalences prop value.
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountComponent = (equivalences) =>
+  mount(BillingEquivalencesChipsComponent, {
+    props: { equivalences },
+    global: { plugins: [vuetify] },
+  });
+
+describe('BillingEquivalencesChipsComponent', () => {
+  // ── kind: easy ──────────────────────────────────────────────────────────
+
+  it('renders an easy chip with success color', () => {
+    const wrapper = mountComponent([{ kind: 'easy', count: 500, label: 'light operations / week' }]);
+    expect(wrapper.text()).toContain('500');
+    expect(wrapper.text()).toContain('light operations / week');
+    const chip = wrapper.findComponent({ name: 'VChip' });
+    expect(chip.props('color')).toBe('success');
+  });
+
+  it('renders an easy chip with bolt icon', () => {
+    const wrapper = mountComponent([{ kind: 'easy', count: 100, label: 'ops' }]);
+    const chip = wrapper.findComponent({ name: 'VChip' });
+    expect(chip.props('prependIcon')).toBe('fa-solid fa-bolt');
+  });
+
+  // ── kind: hard ──────────────────────────────────────────────────────────
+
+  it('renders a hard chip with warning color', () => {
+    const wrapper = mountComponent([{ kind: 'hard', count: 50, label: 'heavy operations / week' }]);
+    const chip = wrapper.findComponent({ name: 'VChip' });
+    expect(chip.props('color')).toBe('warning');
+  });
+
+  it('renders a hard chip with fire icon', () => {
+    const wrapper = mountComponent([{ kind: 'hard', count: 50, label: 'heavy ops' }]);
+    const chip = wrapper.findComponent({ name: 'VChip' });
+    expect(chip.props('prependIcon')).toBe('fa-solid fa-fire');
+  });
+
+  // ── kind: feature ────────────────────────────────────────────────────────
+
+  it('renders a feature chip with primary color', () => {
+    const wrapper = mountComponent([{ kind: 'feature', count: 3, label: 'integrations' }]);
+    const chip = wrapper.findComponent({ name: 'VChip' });
+    expect(chip.props('color')).toBe('primary');
+  });
+
+  it('renders a feature chip with check icon', () => {
+    const wrapper = mountComponent([{ kind: 'feature', count: 3, label: 'integrations' }]);
+    const chip = wrapper.findComponent({ name: 'VChip' });
+    expect(chip.props('prependIcon')).toBe('fa-solid fa-check');
+  });
+
+  // ── multiple chips ────────────────────────────────────────────────────────
+
+  it('renders all three kinds in a single list', () => {
+    const wrapper = mountComponent([
+      { kind: 'easy', count: 500, label: 'light ops' },
+      { kind: 'hard', count: 50, label: 'heavy ops' },
+      { kind: 'feature', count: 3, label: 'integrations' },
+    ]);
+    const chips = wrapper.findAllComponents({ name: 'VChip' });
+    expect(chips).toHaveLength(3);
+    expect(wrapper.text()).toContain('500');
+    expect(wrapper.text()).toContain('50');
+    expect(wrapper.text()).toContain('3');
+  });
+
+  // ── a11y ────────────────────────────────────────────────────────────────
+
+  it('has role=list on the wrapper and role=listitem on each chip', () => {
+    const wrapper = mountComponent([
+      { kind: 'easy', count: 100, label: 'ops' },
+    ]);
+    expect(wrapper.attributes('role')).toBe('list');
+    const chipEl = wrapper.find('[role="listitem"]');
+    expect(chipEl.exists()).toBe(true);
+  });
+});

--- a/src/modules/billing/tests/billing.extrasCheckoutModal.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.extrasCheckoutModal.component.unit.tests.js
@@ -74,6 +74,7 @@ const mountWithDisplayMock = (smAndDown) =>
           template: '<div><slot /></div>',
         },
         'v-card': { template: '<div><slot /></div>' },
+        'v-card-title': { template: '<div><slot /></div>' },
         'v-card-text': { template: '<div><slot /></div>' },
         'v-card-actions': { template: '<div><slot /></div>' },
         'v-radio-group': { template: '<div><slot /></div>' },

--- a/src/modules/billing/tests/billing.pricingCard.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingCard.component.unit.tests.js
@@ -85,12 +85,13 @@ describe('BillingPricingCardComponent', () => {
     expect(wrapper.text()).toContain('Pricing unavailable');
   });
 
-  it('shows a price skeleton while Stripe pricing is loading', () => {
+  it('shows a text skeleton while Stripe pricing is loading', () => {
     const paidNoPrices = { ...proPlan, monthlyPrice: null, annualPrice: null };
     const wrapper = mountComponent({ plan: paidNoPrices, pricesLoading: true });
     const skeleton = wrapper.findComponent({ name: 'v-skeleton-loader' });
     expect(skeleton.exists()).toBe(true);
-    expect(skeleton.props('type')).toBe('button');
+    // C.4: type changed from "button" (wrong pill shape) to "text" (correct for price display)
+    expect(skeleton.props('type')).toBe('text');
     expect(wrapper.text()).not.toContain('Pricing unavailable');
   });
 
@@ -202,5 +203,33 @@ describe('BillingPricingCardComponent', () => {
     const wrapper = mountComponent({ plan: proPlan, equivalences: [] });
     expect(wrapper.text()).toContain('Unlimited projects');
     expect(wrapper.text()).not.toContain('~');
+  });
+
+  // ── D.2 Structured equivalences (Phase 3 chips) ───────────────────────────
+
+  it('renders BillingEquivalencesChipsComponent when equivalences are structured objects with kind', () => {
+    const wrapper = mountComponent({
+      plan: proPlan,
+      equivalences: [
+        { kind: 'easy', count: 500, label: 'light ops / week' },
+        { kind: 'hard', count: 50, label: 'heavy ops / week' },
+      ],
+    });
+    const chipsComp = wrapper.findComponent({ name: 'BillingEquivalencesChipsComponent' });
+    expect(chipsComp.exists()).toBe(true);
+    // Feature list must be hidden
+    expect(wrapper.text()).not.toContain('Unlimited projects');
+    // Legacy bullet list (with tilde prefix) must be hidden
+    expect(wrapper.text()).not.toContain('~500');
+  });
+
+  it('falls back to legacy bullet list for flat equivalences (backward compat)', () => {
+    const wrapper = mountComponent({
+      plan: proPlan,
+      equivalences: [{ label: 'operations / week', count: 2000 }],
+    });
+    const chipsComp = wrapper.findComponent({ name: 'BillingEquivalencesChipsComponent' });
+    expect(chipsComp.exists()).toBe(false);
+    expect(wrapper.text()).toContain('~2000 operations / week');
   });
 });

--- a/src/modules/billing/tests/billing.pricingToggle.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingToggle.component.unit.tests.js
@@ -52,12 +52,13 @@ describe('BillingPricingToggleComponent', () => {
     expect(annualSpan.classes()).not.toContain('text-medium-emphasis');
   });
 
-  it('always shows the annual savings hint', () => {
+  it('shows the annual savings hint only when monthly is active (teaser, not redundant with chip)', () => {
+    // C.3: hint is a teaser when monthly — redundant when annual chip is already visible
     const wrapperMonthly = mountComponent({ annual: false });
     expect(wrapperMonthly.text()).toContain('Save 20% annually');
 
     const wrapperAnnual = mountComponent({ annual: true });
-    expect(wrapperAnnual.text()).toContain('Save 20% annually');
+    expect(wrapperAnnual.text()).not.toContain('Save 20% annually');
   });
 
   it('shows Save 20% chip only when annual is true', () => {

--- a/src/modules/billing/tests/billing.store.unit.tests.js
+++ b/src/modules/billing/tests/billing.store.unit.tests.js
@@ -421,7 +421,7 @@ describe('Billing Store', () => {
         expect.objectContaining({
           packId: 'pack_500',
           successUrl: 'https://app.example.com/users?tab=subscriptions&success=true&type=extras',
-          cancelUrl: 'https://app.example.com/pricing#units',
+          cancelUrl: 'https://app.example.com/pricing?canceled=true#units',
         }),
       );
       expect(window.location.assign).toHaveBeenCalledWith(checkoutUrl);

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -313,6 +313,7 @@ describe('BillingSubscriptionsComponent — status and paid plan CTAs', () => {
     ['past_due', 'warning'],
     ['canceled', 'error'],
     ['incomplete', 'error'],
+    ['incomplete_expired', 'error'],
     ['trialing', 'success'],
   ])('renders %s subscription status with %s chip color', async (status, color) => {
     store.subscription = { status, plan: 'starter', currentPeriodEnd: new Date().toISOString() };
@@ -337,6 +338,13 @@ describe('BillingSubscriptionsComponent — status and paid plan CTAs', () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
     await flushPromises();
     expect(wrapper.text()).toContain('Reactivate');
+  });
+
+  it('shows Complete payment action for incomplete_expired status with error color', async () => {
+    store.subscription = { status: 'incomplete_expired', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    expect(wrapper.text()).toContain('Complete payment');
   });
 
   it('labels the paid plan upgrade CTA as Change Plan when a higher plan exists', async () => {

--- a/src/modules/billing/tests/billing.useMeter.unit.tests.js
+++ b/src/modules/billing/tests/billing.useMeter.unit.tests.js
@@ -432,6 +432,23 @@ describe('useMeter composable', () => {
     expect(store.fetchExtrasBalance).toHaveBeenCalledTimes(1);
   });
 
+  it('does not refresh on visibilitychange when document is hidden', async () => {
+    mountMeter({ pollIntervalMs: 0, refreshOnFocus: true });
+
+    store.fetchUsageMeter.mockClear();
+    store.fetchExtrasBalance.mockClear();
+
+    // Simulate document becoming hidden (tab switch away)
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(store.fetchUsageMeter).not.toHaveBeenCalled();
+    expect(store.fetchExtrasBalance).not.toHaveBeenCalled();
+
+    // Restore for subsequent tests
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+  });
+
   it('does not refresh on visibilitychange when polling is already active', () => {
     vi.useFakeTimers();
     mountMeter({ pollIntervalMs: 5000, refreshOnFocus: true });

--- a/src/modules/billing/tests/billing.useMeter.unit.tests.js
+++ b/src/modules/billing/tests/billing.useMeter.unit.tests.js
@@ -403,6 +403,57 @@ describe('useMeter composable', () => {
     expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
   });
 
+  // ── refreshOnFocus (visibilitychange) ─────────────────────────────────────
+
+  it('adds a visibilitychange listener on mount when refreshOnFocus is true', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    mountMeter({ pollIntervalMs: 0, refreshOnFocus: true });
+    expect(addSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+  });
+
+  it('does not add a visibilitychange listener when refreshOnFocus is false', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    mountMeter({ pollIntervalMs: 0, refreshOnFocus: false });
+    const visibilityCalls = addSpy.mock.calls.filter(([event]) => event === 'visibilitychange');
+    expect(visibilityCalls).toHaveLength(0);
+  });
+
+  it('refreshes when tab becomes visible and polling is disabled', async () => {
+    mountMeter({ pollIntervalMs: 0, refreshOnFocus: true });
+
+    store.fetchUsageMeter.mockClear();
+    store.fetchExtrasBalance.mockClear();
+
+    // Simulate document becoming visible
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(store.fetchUsageMeter).toHaveBeenCalledTimes(1);
+    expect(store.fetchExtrasBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh on visibilitychange when polling is already active', () => {
+    vi.useFakeTimers();
+    mountMeter({ pollIntervalMs: 5000, refreshOnFocus: true });
+
+    store.fetchUsageMeter.mockClear();
+    store.fetchExtrasBalance.mockClear();
+
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // pollIntervalMs > 0 — visibilitychange handler should NOT trigger refresh
+    expect(store.fetchUsageMeter).not.toHaveBeenCalled();
+    expect(store.fetchExtrasBalance).not.toHaveBeenCalled();
+  });
+
+  it('removes the visibilitychange listener on unmount', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { wrapper } = mountMeter({ pollIntervalMs: 0, refreshOnFocus: true });
+    wrapper.unmount();
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+  });
+
   // ── purchasePack ───────────────────────────────────────────────────────────
 
   it('purchasePack delegates to store.createExtrasCheckout', async () => {

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -1,16 +1,6 @@
 <template>
   <v-container class="py-12" :style="{ 'max-width': config.vuetify.theme.maxWidth }">
-    <!-- Success / cancel alerts -->
-    <v-alert
-      v-if="checkoutSuccess"
-      type="success"
-      variant="tonal"
-      closable
-      class="mb-6"
-      @click:close="dismissAlert"
-    >
-      Payment successful! Your subscription is now active.
-    </v-alert>
+    <!-- Cancel alert — success goes to /users?tab=subscriptions, never back here -->
     <v-alert
       v-if="checkoutCanceled"
       type="info"
@@ -56,7 +46,7 @@
 
     <!-- Glass tabs (meter mode only) -->
     <div v-if="meterMode" class="d-flex justify-center mb-8">
-      <homeTabsComponent
+      <HomeTabsComponent
         :items="tabItems"
         :model-value="activeTab"
         @update:model-value="activeTab = $event"
@@ -67,7 +57,7 @@
     <template v-if="!meterMode || activeTab === 0">
       <!-- Billing toggle -->
       <div class="mb-10">
-        <billingPricingToggleComponent :annual="annual" @update:annual="annual = $event" />
+        <BillingPricingToggleComponent :annual="annual" @update:annual="annual = $event" />
       </div>
 
       <!-- Plans grid (always rendered from static config; prices fill in asynchronously) -->
@@ -79,7 +69,7 @@
           sm="6"
           md="4"
         >
-          <billingPricingCardComponent
+          <BillingPricingCardComponent
             :plan="plan"
             :annual="annual"
             :current="isCurrentPlan(plan.id)"
@@ -96,6 +86,23 @@
     <template v-if="meterMode && activeTab === 1">
       <BillingPacksComponent />
     </template>
+
+    <!-- Downgrade confirmation dialog -->
+    <v-dialog v-model="downgradeDialog" max-width="480" @keydown.esc="cancelDowngrade">
+      <v-card>
+        <v-card-title class="text-title-medium font-weight-bold">Confirm plan change</v-card-title>
+        <v-card-text class="text-body-medium">
+          You're switching from <strong>{{ currentPlanName }}</strong> to <strong>{{ pendingDowngradePlanName }}</strong>.
+          Stripe will pro-rate the difference. Quota will reset at next billing cycle.
+        </v-card-text>
+        <v-card-actions class="ga-2">
+          <v-btn variant="text" class="text-none" @click="cancelDowngrade">Cancel</v-btn>
+          <v-btn color="primary" variant="flat" class="text-none" :loading="checkoutLoading" @click="confirmDowngrade">
+            Continue to checkout
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -106,10 +113,10 @@
 import { useBillingStore } from '../stores/billing.store';
 import { useAuthStore } from '../../auth/stores/auth.store';
 import { plans as plansConfig } from '../config/billing.static-content';
-import billingPricingToggleComponent from '../components/billing.pricingToggle.component.vue';
-import billingPricingCardComponent from '../components/billing.pricingCard.component.vue';
+import BillingPricingToggleComponent from '../components/billing.pricingToggle.component.vue';
+import BillingPricingCardComponent from '../components/billing.pricingCard.component.vue';
 import BillingPacksComponent from '../components/billing.packs.component.vue';
-import homeTabsComponent from '../../home/components/utils/home.tabs.component.vue';
+import HomeTabsComponent from '../../home/components/utils/home.tabs.component.vue';
 
 
 /**
@@ -118,10 +125,10 @@ import homeTabsComponent from '../../home/components/utils/home.tabs.component.v
 export default {
   name: 'PricingView',
   components: {
-    billingPricingToggleComponent,
-    billingPricingCardComponent,
+    BillingPricingToggleComponent,
+    BillingPricingCardComponent,
     BillingPacksComponent,
-    homeTabsComponent,
+    HomeTabsComponent,
   },
   /**
    * @desc Inject billingStore and authStore once in setup so computed
@@ -137,13 +144,16 @@ export default {
   data() {
     return {
       annual: false,
-      checkoutSuccess: false,
       checkoutCanceled: false,
       checkoutLoading: false,
       checkoutError: null,
       error: null,
       /** @type {number} Active glass tab index — 0=plans, 1=units (meter mode only) */
       activeTab: 0,
+      /** @type {boolean} Whether the downgrade confirmation dialog is open */
+      downgradeDialog: false,
+      /** @type {{ planId: string, priceId: string }|null} Pending plan selection awaiting confirmation */
+      pendingDowngrade: null,
     };
   },
   computed: {
@@ -201,6 +211,31 @@ export default {
         { id: 'units', label: 'Units' },
       ];
     },
+    /**
+     * @desc Ordered plan IDs derived from static config for downgrade detection.
+     * Tier index 0 = lowest (free), last = highest (pro).
+     * @returns {Array<string>}
+     */
+    planTierOrder() {
+      return plansConfig.map((p) => p.id).filter(Boolean);
+    },
+    /**
+     * @desc The name of the pending downgrade target plan (for confirmation dialog copy).
+     * @returns {string}
+     */
+    pendingDowngradePlanName() {
+      if (!this.pendingDowngrade) return '';
+      const plan = this.mergedPlans.find((p) => p.id === this.pendingDowngrade.planId);
+      return plan?.name ?? this.pendingDowngrade.planId;
+    },
+    /**
+     * @desc The name of the current plan (for confirmation dialog copy).
+     * @returns {string}
+     */
+    currentPlanName() {
+      const plan = this.mergedPlans.find((p) => p.id === this.currentPlanId);
+      return plan?.name ?? this.currentPlanId;
+    },
   },
   /**
    * @desc Fetch billing plans and subscription data on component creation.
@@ -222,9 +257,8 @@ export default {
       });
     }
 
-    // Handle Stripe redirect query params
-    const { success, canceled } = this.$route.query;
-    if (success === 'true') this.checkoutSuccess = true;
+    // Handle Stripe redirect query params — success always redirects to /users, never back here
+    const { canceled } = this.$route.query;
     if (canceled === 'true') this.checkoutCanceled = true;
     if (this.$route.hash === '#units') this.activeTab = 1;
   },
@@ -238,12 +272,11 @@ export default {
       return this.currentPlanId === planId;
     },
     /**
-     * @desc Dismiss the success / canceled alert and clean query params.
+     * @desc Dismiss the canceled alert and clean query params.
      */
     dismissAlert() {
-      this.checkoutSuccess = false;
       this.checkoutCanceled = false;
-      if (this.$route.query.success || this.$route.query.canceled) {
+      if (this.$route.query.canceled) {
         this.$router.replace({ path: this.$route.path });
       }
     },
@@ -261,7 +294,7 @@ export default {
       }
     },
     /**
-     * @desc Handle plan selection — validate auth/org, then create checkout session.
+     * @desc Handle plan selection — validate auth/org, detect downgrade, then create checkout session.
      * @param {Object} payload - { planId, priceId }
      * @returns {Promise<void>}
      */
@@ -281,7 +314,42 @@ export default {
       // Free plan -> no checkout needed
       if (!priceId || planId === 'free') return;
 
-      // Paid plan -> create Stripe Checkout session
+      // Downgrade detection — show confirmation dialog before proceeding
+      const targetTier = this.planTierOrder.indexOf(planId);
+      const currentTier = this.planTierOrder.indexOf(this.currentPlanId);
+      if (targetTier !== -1 && currentTier !== -1 && targetTier < currentTier) {
+        this.pendingDowngrade = { planId, priceId };
+        this.downgradeDialog = true;
+        return;
+      }
+
+      await this.proceedCheckout({ planId, priceId });
+    },
+    /**
+     * @desc Confirm the pending downgrade and proceed to checkout.
+     * @returns {Promise<void>}
+     */
+    async confirmDowngrade() {
+      this.downgradeDialog = false;
+      if (!this.pendingDowngrade) return;
+      const payload = this.pendingDowngrade;
+      this.pendingDowngrade = null;
+      await this.proceedCheckout(payload);
+    },
+    /**
+     * @desc Cancel the pending downgrade dialog.
+     * @returns {void}
+     */
+    cancelDowngrade() {
+      this.downgradeDialog = false;
+      this.pendingDowngrade = null;
+    },
+    /**
+     * @desc Create Stripe Checkout session and redirect.
+     * @param {Object} payload - { planId, priceId }
+     * @returns {Promise<void>}
+     */
+    async proceedCheckout({ priceId }) {
       this.checkoutLoading = true;
       try {
         const checkout = await this.billingStore.createCheckout(priceId);

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -347,7 +347,7 @@ export default {
     },
     /**
      * @desc Create Stripe Checkout session and redirect.
-     * @param {Object} payload - { planId, priceId }
+     * @param {Object} payload - { priceId }
      * @returns {Promise<void>}
      */
     async proceedCheckout({ priceId }) {

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -277,7 +277,8 @@ export default {
     dismissAlert() {
       this.checkoutCanceled = false;
       if (this.$route.query.canceled) {
-        this.$router.replace({ path: this.$route.path });
+        // Preserve hash (e.g. #units) so the active tab state is reflected in the URL
+        this.$router.replace({ path: this.$route.path, hash: this.$route.hash });
       }
     },
     /**

--- a/src/modules/home/components/utils/home.tabs.component.vue
+++ b/src/modules/home/components/utils/home.tabs.component.vue
@@ -195,7 +195,8 @@ export default {
       const queryValue = this.$route.query[this.syncRouteQuery];
       if (queryValue != null) {
         const numVal = Number(queryValue);
-        if (!Number.isNaN(numVal) && numVal !== this.modelValue) {
+        const maxIdx = this.items.length - 1;
+        if (!Number.isNaN(numVal) && numVal >= 0 && numVal <= maxIdx && Number.isInteger(numVal) && numVal !== this.modelValue) {
           this.$emit('update:modelValue', numVal);
         }
       }

--- a/src/modules/home/components/utils/home.tabs.component.vue
+++ b/src/modules/home/components/utils/home.tabs.component.vue
@@ -95,6 +95,16 @@ export default {
        */
       validator: (value) => value === null || ['light', 'dark'].includes(value),
     },
+    /**
+     * @desc When set to a query param name (e.g. 'tab'), the component will:
+     *   1. On mount — read that query param and emit update:modelValue if it differs.
+     *   2. On modelValue change — replace the URL query to keep deep-link in sync.
+     * Leave null (default) to preserve existing behaviour without any router interaction.
+     */
+    syncRouteQuery: {
+      type: String,
+      default: null,
+    },
   },
   emits: ['update:modelValue'],
   data() {
@@ -148,11 +158,18 @@ export default {
     },
   },
   watch: {
-    modelValue() {
+    modelValue(newVal) {
       this.$nextTick(() => {
         this.updateIndicator();
         this.checkOverflow();
       });
+      // Route-query sync (opt-in via syncRouteQuery prop)
+      if (this.syncRouteQuery && this.$route && this.$router) {
+        const current = this.$route.query[this.syncRouteQuery];
+        if (current !== String(newVal)) {
+          this.$router.replace({ query: { ...this.$route.query, [this.syncRouteQuery]: String(newVal) } });
+        }
+      }
     },
     items() {
       this.$nextTick(() => {
@@ -173,6 +190,16 @@ export default {
       this.updateIndicator();
       this.checkOverflow();
     });
+    // Route-query sync on mount — read initial query param and emit if it differs
+    if (this.syncRouteQuery && this.$route) {
+      const queryValue = this.$route.query[this.syncRouteQuery];
+      if (queryValue != null) {
+        const numVal = Number(queryValue);
+        if (!Number.isNaN(numVal) && numVal !== this.modelValue) {
+          this.$emit('update:modelValue', numVal);
+        }
+      }
+    }
   },
   unmounted() {
     window.removeEventListener('resize', this.updateIndicator);

--- a/src/modules/home/tests/home.tabs.syncRouteQuery.unit.tests.js
+++ b/src/modules/home/tests/home.tabs.syncRouteQuery.unit.tests.js
@@ -103,4 +103,24 @@ describe('HomeTabsComponent — syncRouteQuery (D.4)', () => {
       }),
     );
   });
+
+  // ── out-of-range / invalid query values ──────────────────────────────────
+
+  it('does not emit when query tab index exceeds items.length - 1', async () => {
+    const { wrapper } = mountComponent({ syncRouteQuery: 'tab', modelValue: 0 }, { tab: '99' });
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeFalsy();
+  });
+
+  it('does not emit when query tab index is negative', async () => {
+    const { wrapper } = mountComponent({ syncRouteQuery: 'tab', modelValue: 0 }, { tab: '-1' });
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeFalsy();
+  });
+
+  it('does not emit when query tab value is a decimal', async () => {
+    const { wrapper } = mountComponent({ syncRouteQuery: 'tab', modelValue: 0 }, { tab: '0.5' });
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeFalsy();
+  });
 });

--- a/src/modules/home/tests/home.tabs.syncRouteQuery.unit.tests.js
+++ b/src/modules/home/tests/home.tabs.syncRouteQuery.unit.tests.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import HomeTabsComponent from '../components/utils/home.tabs.component.vue';
+
+const vuetify = createVuetify();
+
+const items = [
+  { id: 'plans', label: 'Plans' },
+  { id: 'units', label: 'Units' },
+];
+
+/**
+ * Build a minimal router mock.
+ * @param {Object} [query={}] Initial query params.
+ * @returns {{ $route: Object, $router: Object }}
+ */
+function buildRouter(query = {}) {
+  const $route = { query: { ...query } };
+  const $router = { replace: vi.fn() };
+  return { $route, $router };
+}
+
+/**
+ * Mount HomeTabsComponent with optional router mock and props.
+ * @param {Object} props Component props.
+ * @param {Object} [routerQuery={}] Simulated $route.query.
+ * @returns {{ wrapper, $router }}
+ */
+function mountComponent(props = {}, routerQuery = {}) {
+  const { $route, $router } = buildRouter(routerQuery);
+  const wrapper = mount(HomeTabsComponent, {
+    props: { items, modelValue: 0, ...props },
+    global: {
+      plugins: [vuetify],
+      mocks: { $route, $router },
+    },
+  });
+  return { wrapper, $router };
+}
+
+describe('HomeTabsComponent — syncRouteQuery (D.4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── opt-in disabled (default behaviour) ──────────────────────────────────
+
+  it('does not read route query on mount when syncRouteQuery is null (default)', async () => {
+    const { wrapper } = mountComponent({ syncRouteQuery: null }, { tab: '1' });
+    // modelValue must stay at 0 — no emit triggered
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeFalsy();
+  });
+
+  it('does not update router on modelValue change when syncRouteQuery is null', async () => {
+    const { wrapper, $router } = mountComponent({ syncRouteQuery: null });
+    await wrapper.setProps({ modelValue: 1 });
+    expect($router.replace).not.toHaveBeenCalled();
+  });
+
+  // ── opt-in enabled (syncRouteQuery set) ──────────────────────────────────
+
+  it('emits update:modelValue on mount when query param differs from modelValue', async () => {
+    const { wrapper } = mountComponent({ syncRouteQuery: 'tab', modelValue: 0 }, { tab: '1' });
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeTruthy();
+    expect(emitted[0][0]).toBe(1);
+  });
+
+  it('does not emit on mount when query param matches modelValue', async () => {
+    const { wrapper } = mountComponent({ syncRouteQuery: 'tab', modelValue: 0 }, { tab: '0' });
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeFalsy();
+  });
+
+  it('does not emit on mount when query param is absent', async () => {
+    const { wrapper } = mountComponent({ syncRouteQuery: 'tab', modelValue: 0 }, {});
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeFalsy();
+  });
+
+  it('calls router.replace when modelValue changes and syncRouteQuery is set', async () => {
+    const { wrapper, $router } = mountComponent({ syncRouteQuery: 'tab', modelValue: 0 }, {});
+    await wrapper.setProps({ modelValue: 1 });
+    expect($router.replace).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ tab: '1' }) }),
+    );
+  });
+
+  it('does not call router.replace when modelValue changes and syncRouteQuery is null', async () => {
+    const { wrapper, $router } = mountComponent({ syncRouteQuery: null, modelValue: 0 }, {});
+    await wrapper.setProps({ modelValue: 1 });
+    expect($router.replace).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing query params when replacing route', async () => {
+    const { wrapper, $router } = mountComponent({ syncRouteQuery: 'tab', modelValue: 0 }, { existingParam: 'keep' });
+    await wrapper.setProps({ modelValue: 1 });
+    expect($router.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ existingParam: 'keep', tab: '1' }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

v4 hardening (v3 regressions + UX gaps + a11y/design polish) bundled with Phase 3 forward (NEW EquivalencesChips primitive + packs differentiation + tabs route-sync).

Source: audit V3 post-mega 4-agents (2026-05-03) + project_trawl_billing_ui_phase3 plan.

## Sections

### v3 regressions (3)
- packs prefers-reduced-motion guard
- pricing.view 3 components PascalCase
- drop dead checkoutSuccess alert

### UX gaps (4)
- incomplete status copy "Complete payment"
- extras cancelUrl with canceled=true
- useMeter visibilitychange listener (multi-tab)
- plan downgrade v-dialog confirmation

### A11y + design polish (5)
- extrasCheckoutModal v-card-title landmark
- success v-alert auto-dismiss 5s
- Save 20% hint v-if !annual
- pricingCard skeleton type=text
- meterProgress drop getCurrentInstance fragile

### Phase 3 polish
- NEW BillingEquivalencesChipsComponent (v-chip primitive)
- pricingCard + packs wire chips with backward-compat
- home.tabs syncRouteQuery opt-in prop

## Test plan

- [ ] CI green
- [ ] 1355 unit tests (new + existing) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Equivalences visualization as visual chips in billing plans
  * Plan downgrade confirmation dialog before switching tiers
  * Tab navigation state syncs with URL for shareable links
  * Checkout success alerts auto-dismiss after 5 seconds
  * Meter usage refreshes automatically when returning to the app

* **Improvements**
  * "Save 20% annually" indicator now shows only for monthly billing selection
  * Subscription actions differentiate between reactivation and payment completion
  * Enhanced modal header accessibility
  * Improved checkout cancellation tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->