### PR TITLE
fix(billing): subscription state safety + webhook lag polling (audit Codex P1)

### DIFF
--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -16,9 +16,42 @@
 -->
 <template>
   <v-container class="py-6 px-0" :style="{ 'max-width': config.vuetify.theme.maxWidth }">
-    <!-- Checkout success banner, surfaced after Stripe redirects back to the subscriptions tab. -->
+    <!-- Checkout success / processing banner -->
     <v-alert
-      v-if="paymentSuccessMessage"
+      v-if="checkoutProcessing"
+      type="info"
+      variant="tonal"
+      class="mb-4"
+      aria-live="polite"
+    >
+      <div class="d-flex align-center ga-3">
+        <v-progress-circular indeterminate size="18" width="2" color="info" />
+        <span>
+          <!-- i18n key: billing.checkout.success.processing -->
+          Processing your payment...
+        </span>
+      </div>
+    </v-alert>
+
+    <v-alert
+      v-else-if="checkoutTimeout"
+      type="warning"
+      variant="tonal"
+      class="mb-4"
+      aria-live="polite"
+    >
+      <!-- i18n key: billing.checkout.success.timeout -->
+      Payment received, your subscription is being synced. Please refresh in a few seconds.
+      <template #append>
+        <v-btn variant="text" size="small" @click="retryFetchSubscription">
+          <!-- i18n key: billing.checkout.success.refresh -->
+          Refresh
+        </v-btn>
+      </template>
+    </v-alert>
+
+    <v-alert
+      v-else-if="paymentSuccessMessage"
       type="success"
       variant="tonal"
       closable
@@ -32,6 +65,35 @@
     <v-row v-if="fetchLoading" justify="center" class="py-10">
       <v-progress-circular indeterminate color="primary" />
     </v-row>
+
+    <!-- P1-1: Subscription fetch error — do NOT show free-plan fallback -->
+    <v-card
+      v-else-if="subscriptionError && !subscription"
+      role="alert"
+      aria-live="assertive"
+      :class="config.vuetify.theme.rounded"
+      class="pa-6 mb-4"
+    >
+      <div class="d-flex align-center mb-4">
+        <v-icon icon="fa-solid fa-triangle-exclamation" color="error" size="small" class="mr-3" />
+        <span class="text-title-large font-weight-medium">Subscription unavailable</span>
+      </div>
+      <p class="text-body-medium text-medium-emphasis mb-4">
+        <!-- i18n key: billing.subscription.error.fetchFailed -->
+        Unable to load your subscription details. Please try again.
+      </p>
+      <v-btn
+        color="primary"
+        variant="flat"
+        :class="config.vuetify.theme.rounded"
+        class="text-none text-body-medium"
+        :loading="fetchLoading"
+        @click="retryFetchSubscription"
+      >
+        <!-- i18n key: billing.subscription.error.retry -->
+        Retry
+      </v-btn>
+    </v-card>
 
     <!-- Content -->
     <template v-else>
@@ -204,6 +266,46 @@
       v-model="extrasCheckoutDialog"
       :packs="extrasPacks"
     />
+
+    <!-- Bonus: 409 subscription_already_active dialog -->
+    <v-dialog v-model="alreadyActiveDialog" max-width="480">
+      <v-card :class="config.vuetify.theme.rounded" class="pa-6">
+        <div class="d-flex align-center mb-3">
+          <v-icon icon="fa-solid fa-circle-check" color="success" size="small" class="mr-2" />
+          <span class="text-title-medium font-weight-medium">
+            <!-- i18n key: billing.checkout.error.alreadyActive.title -->
+            Subscription already active
+          </span>
+        </div>
+        <p class="text-body-medium text-medium-emphasis mb-6">
+          <!-- i18n key: billing.checkout.error.alreadyActive.message -->
+          You already have an active subscription. Manage it via the Customer Portal.
+        </p>
+        <div class="d-flex ga-3 justify-end">
+          <v-btn
+            variant="outlined"
+            :class="config.vuetify.theme.rounded"
+            class="text-none text-body-medium"
+            @click="alreadyActiveDialog = false"
+          >
+            Close
+          </v-btn>
+          <v-btn
+            v-if="alreadyActivePortalUrl"
+            color="primary"
+            variant="flat"
+            :class="config.vuetify.theme.rounded"
+            class="text-none text-body-medium"
+            :href="alreadyActivePortalUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <!-- i18n key: billing.checkout.error.alreadyActive.cta -->
+            Open Customer Portal
+          </v-btn>
+        </div>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -222,6 +324,11 @@ import BillingMeterBreakdownChartComponent from './billing.meterBreakdownChart.c
 import BillingExtrasLedgerComponent from './billing.extrasLedger.component.vue';
 import BillingUsageBarComponent from './billing.usageBar.component.vue';
 import BillingExtrasCheckoutModalComponent from './billing.extrasCheckoutModal.component.vue';
+
+/** Maximum number of polling attempts after checkout success (2s × 8 = 16s max). */
+const CHECKOUT_POLL_MAX = 8;
+/** Interval between polling attempts in milliseconds. */
+const CHECKOUT_POLL_INTERVAL_MS = 2000;
 
 /**
  * Component definition.
@@ -289,6 +396,16 @@ export default {
       paymentSuccessMessage: null,
       successCleanupTimer: null,
       paymentSuccessTimer: null,
+      // P1-2: checkout polling state
+      checkoutProcessing: false,
+      checkoutTimeout: false,
+      checkoutPollTimer: null,
+      checkoutPollCount: 0,
+      checkoutPollSnapshotId: null,
+      checkoutPollSnapshotStatus: null,
+      // Bonus: 409 already-active dialog
+      alreadyActiveDialog: false,
+      alreadyActivePortalUrl: null,
     };
   },
   computed: {
@@ -297,6 +414,13 @@ export default {
     },
     subscription() {
       return this.billingStore.subscription;
+    },
+    /**
+     * @desc Error message from the last fetchSubscription failure (P1-1).
+     * @returns {string|null}
+     */
+    subscriptionError() {
+      return this.billingStore.subscriptionError;
     },
     /**
      * @desc Extras credit ledger data for the paginated history table.
@@ -420,19 +544,22 @@ export default {
     const hasOrg = !!this.authStore.user?.currentOrganization;
     if (!this.authStore.isLoggedIn || (orgsEnabled && !hasOrg)) return;
 
-    this.handleCheckoutSuccessQuery();
+    const isCheckoutSuccess = this.handleCheckoutSuccessQuery();
 
-    try {
-      await this.billingStore.fetchSubscription();
-    } catch (error) {
-      console.error('Failed to load billing details:', error);
+    if (!isCheckoutSuccess) {
+      // Normal load: fetch once and surface errors
+      try {
+        await this.billingStore.fetchSubscription();
+      } catch {
+        // subscriptionError is already set in the store; component shows error card
+      }
     }
 
     // Note: fetchExtrasLedger is handled by the immediate watcher in setup(),
     // no duplicate call needed here.
   },
   /**
-   * @desc Clear pending checkout-success URL cleanup timer on component teardown.
+   * @desc Clear pending timers on component teardown.
    * @returns {void}
    */
   beforeUnmount() {
@@ -441,6 +568,9 @@ export default {
     }
     if (this.paymentSuccessTimer) {
       clearTimeout(this.paymentSuccessTimer);
+    }
+    if (this.checkoutPollTimer) {
+      clearTimeout(this.checkoutPollTimer);
     }
   },
   methods: {
@@ -455,32 +585,101 @@ export default {
       }
       this.paymentSuccessMessage = null;
     },
+
     /**
-     * @desc Show checkout success feedback from Stripe return query params and clean the URL.
-     * @returns {void}
+     * @desc Re-fetch subscription on demand (Retry button / Refresh button).
+     * @returns {Promise<void>}
+     */
+    async retryFetchSubscription() {
+      try {
+        await this.billingStore.fetchSubscription();
+      } catch {
+        // subscriptionError updated in store
+      }
+    },
+
+    /**
+     * @desc Detect ?success=true or ?checkout=success from Stripe redirect and start polling.
+     * Returns true when checkout-success polling is initiated (skips normal single fetch).
+     * @returns {boolean} True when polling was started
      */
     handleCheckoutSuccessQuery() {
       const query = this.$route?.query || {};
       const packPurchased = query.packPurchased === true || query.packPurchased === 'true';
       const isSuccess = query.success === 'true' || packPurchased;
-      if (!isSuccess) return;
+      if (!isSuccess) return false;
 
-      this.paymentSuccessMessage = query.type === 'extras' || packPurchased
-        ? 'Extra units purchased successfully. Thank you!'
-        : 'Subscription updated successfully. Thank you!';
+      if (query.type === 'extras' || packPurchased) {
+        // Extras purchase: no subscription state to poll — show success directly
+        this.paymentSuccessMessage = 'Extra units purchased successfully. Thank you!';
+        this.scheduleQueryCleanup();
+        return false;
+      }
 
-      // Auto-dismiss the success alert after 5 seconds (manual close still works via closable)
-      this.paymentSuccessTimer = setTimeout(() => {
-        this.paymentSuccessMessage = null;
-        this.paymentSuccessTimer = null;
-      }, 5000);
+      // Subscription checkout success: capture pre-poll snapshot and start polling
+      this.checkoutProcessing = true;
+      this.checkoutTimeout = false;
+      this.checkoutPollCount = 0;
+      this.checkoutPollSnapshotId = this.billingStore.subscription?.stripeSubscriptionId ?? null;
+      this.checkoutPollSnapshotStatus = this.billingStore.subscription?.status ?? null;
+      this.scheduleQueryCleanup();
+      this.pollSubscription();
+      return true;
+    },
 
+    /**
+     * @desc Poll fetchSubscription until the subscription changes or max attempts reached.
+     * Criteria: stripeSubscriptionId appeared, OR status changed to active/trialing, OR priceId changed.
+     * @returns {void}
+     */
+    pollSubscription() {
+      this.checkoutPollTimer = setTimeout(async () => {
+        try {
+          await this.billingStore.fetchSubscription();
+        } catch {
+          // Keep polling even on transient errors
+        }
+
+        const sub = this.billingStore.subscription;
+        const newId = sub?.stripeSubscriptionId ?? null;
+        const newStatus = sub?.status ?? null;
+
+        const activated =
+          (newId && newId !== this.checkoutPollSnapshotId) ||
+          (['active', 'trialing'].includes(newStatus) && newStatus !== this.checkoutPollSnapshotStatus);
+
+        if (activated) {
+          this.checkoutProcessing = false;
+          this.checkoutTimeout = false;
+          this.paymentSuccessMessage =
+            // i18n key: billing.checkout.success.synced
+            'Subscription activated successfully. Thank you!';
+          return;
+        }
+
+        this.checkoutPollCount += 1;
+        if (this.checkoutPollCount >= CHECKOUT_POLL_MAX) {
+          this.checkoutProcessing = false;
+          this.checkoutTimeout = true;
+          return;
+        }
+
+        this.pollSubscription();
+      }, CHECKOUT_POLL_INTERVAL_MS);
+    },
+
+    /**
+     * @desc Schedule URL query cleanup after success detection.
+     * @returns {void}
+     */
+    scheduleQueryCleanup() {
       this.successCleanupTimer = setTimeout(() => {
         this.$router.replace({
           query: { ...this.$route.query, success: undefined, type: undefined, packPurchased: undefined, tab: 'subscriptions' },
         });
       }, 100);
     },
+
     /**
      * @desc Open the Stripe customer portal.
      * @returns {Promise<void>}
@@ -498,6 +697,7 @@ export default {
         this.portalLoading = false;
       }
     },
+
     /**
      * @desc Handle ledger page change from BillingExtrasLedgerComponent.
      * @param {number} page
@@ -509,6 +709,17 @@ export default {
       } catch (error) {
         console.error('Failed to load ledger page:', error);
       }
+    },
+
+    /**
+     * @desc Show the 409 already-active dialog with a portal URL.
+     * Called by consumers (e.g. pricing view) that catch the structured error.
+     * @param {string} portalUrl - Stripe customer portal URL from the 409 payload
+     * @returns {void}
+     */
+    showAlreadyActiveDialog(portalUrl) {
+      this.alreadyActivePortalUrl = portalUrl || null;
+      this.alreadyActiveDialog = true;
     },
   },
 };

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -66,9 +66,11 @@
       <v-progress-circular indeterminate color="primary" />
     </v-row>
 
-    <!-- P1-1: Subscription fetch error — do NOT show free-plan fallback -->
+    <!-- P1-1: Subscription fetch error — do NOT show free-plan fallback.
+         Suppressed while checkout polling/timeout UX is active to prevent
+         transient fetch errors from disrupting the payment flow. -->
     <v-card
-      v-else-if="subscriptionError && !subscription"
+      v-else-if="subscriptionError && !subscription && !checkoutProcessing && !checkoutTimeout"
       role="alert"
       aria-live="assertive"
       :class="config.vuetify.theme.rounded"
@@ -403,6 +405,7 @@ export default {
       checkoutPollCount: 0,
       checkoutPollSnapshotId: null,
       checkoutPollSnapshotStatus: null,
+      checkoutPollSnapshotPlan: null,
       // Bonus: 409 already-active dialog
       alreadyActiveDialog: false,
       alreadyActivePortalUrl: null,
@@ -588,11 +591,20 @@ export default {
 
     /**
      * @desc Re-fetch subscription on demand (Retry button / Refresh button).
+     * When called after a checkout timeout, clears the timeout banner if the
+     * subscription is now active/trialing.
      * @returns {Promise<void>}
      */
     async retryFetchSubscription() {
       try {
-        await this.billingStore.fetchSubscription();
+        const sub = await this.billingStore.fetchSubscription();
+        if (this.checkoutTimeout && ['active', 'trialing'].includes(sub?.status)) {
+          this.checkoutTimeout = false;
+          this.checkoutProcessing = false;
+          this.paymentSuccessMessage =
+            // i18n key: billing.checkout.success.synced
+            'Subscription activated successfully. Thank you!';
+        }
       } catch {
         // subscriptionError updated in store
       }
@@ -622,6 +634,7 @@ export default {
       this.checkoutPollCount = 0;
       this.checkoutPollSnapshotId = this.billingStore.subscription?.stripeSubscriptionId ?? null;
       this.checkoutPollSnapshotStatus = this.billingStore.subscription?.status ?? null;
+      this.checkoutPollSnapshotPlan = this.billingStore.subscription?.plan ?? null;
       this.scheduleQueryCleanup();
       this.pollSubscription();
       return true;
@@ -629,7 +642,8 @@ export default {
 
     /**
      * @desc Poll fetchSubscription until the subscription changes or max attempts reached.
-     * Criteria: stripeSubscriptionId appeared, OR status changed to active/trialing, OR priceId changed.
+     * Criteria: stripeSubscriptionId appeared, OR status changed to active/trialing,
+     * OR plan changed (covers upgrades that keep the same Stripe sub ID and status).
      * @returns {void}
      */
     pollSubscription() {
@@ -643,10 +657,12 @@ export default {
         const sub = this.billingStore.subscription;
         const newId = sub?.stripeSubscriptionId ?? null;
         const newStatus = sub?.status ?? null;
+        const newPlan = sub?.plan ?? null;
 
         const activated =
           (newId && newId !== this.checkoutPollSnapshotId) ||
-          (['active', 'trialing'].includes(newStatus) && newStatus !== this.checkoutPollSnapshotStatus);
+          (['active', 'trialing'].includes(newStatus) && newStatus !== this.checkoutPollSnapshotStatus) ||
+          (newPlan && newPlan !== this.checkoutPollSnapshotPlan);
 
         if (activated) {
           this.checkoutProcessing = false;
@@ -712,13 +728,24 @@ export default {
     },
 
     /**
-     * @desc Show the 409 already-active dialog with a portal URL.
+     * @desc Show the 409 already-active dialog with a validated portal URL.
+     * Only accepts HTTPS URLs to guard against malformed or compromised payloads.
      * Called by consumers (e.g. pricing view) that catch the structured error.
      * @param {string} portalUrl - Stripe customer portal URL from the 409 payload
      * @returns {void}
      */
     showAlreadyActiveDialog(portalUrl) {
-      this.alreadyActivePortalUrl = portalUrl || null;
+      this.alreadyActivePortalUrl = null;
+      if (portalUrl) {
+        try {
+          const parsed = new URL(portalUrl);
+          if (parsed.protocol === 'https:') {
+            this.alreadyActivePortalUrl = parsed.toString();
+          }
+        } catch {
+          // Invalid URL — link will not be shown
+        }
+      }
       this.alreadyActiveDialog = true;
     },
   },

--- a/src/modules/billing/composables/billing.useBilling.js
+++ b/src/modules/billing/composables/billing.useBilling.js
@@ -12,7 +12,7 @@ export function useBilling() {
   const billingStore = useBillingStore();
 
   const currentPlan = computed(() => billingStore.subscription?.plan || 'free');
-  const isPlanActive = computed(() => billingStore.subscription?.status === 'active');
+  const isPlanActive = computed(() => ['active', 'trialing'].includes(billingStore.subscription?.status));
 
   /**
    * @desc Check whether the current subscription plan matches any of the given plans.

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -78,6 +78,34 @@ export const billingEn = {
         /** i18n key: billing.subscriptions.cta.upgrade */
         upgrade: 'Upgrade',
       },
+      error: {
+        /** i18n key: billing.subscription.error.fetchFailed */
+        fetchFailed: 'Unable to load your subscription details. Please try again.',
+        /** i18n key: billing.subscription.error.retry */
+        retry: 'Retry',
+      },
+    },
+    checkout: {
+      success: {
+        /** i18n key: billing.checkout.success.processing */
+        processing: 'Processing your payment...',
+        /** i18n key: billing.checkout.success.synced */
+        synced: 'Subscription activated successfully. Thank you!',
+        /** i18n key: billing.checkout.success.timeout */
+        timeout: 'Payment received, your subscription is being synced. Please refresh in a few seconds.',
+        /** i18n key: billing.checkout.success.refresh */
+        refresh: 'Refresh',
+      },
+      error: {
+        alreadyActive: {
+          /** i18n key: billing.checkout.error.alreadyActive.title */
+          title: 'Subscription already active',
+          /** i18n key: billing.checkout.error.alreadyActive.message */
+          message: 'You already have an active subscription. Manage it via the Customer Portal.',
+          /** i18n key: billing.checkout.error.alreadyActive.cta */
+          cta: 'Open Customer Portal',
+        },
+      },
     },
     pricing: {
       tabs: {

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -79,9 +79,9 @@ export const billingEn = {
         upgrade: 'Upgrade',
       },
       error: {
-        /** i18n key: billing.subscription.error.fetchFailed */
+        /** i18n key: billing.subscriptions.error.fetchFailed */
         fetchFailed: 'Unable to load your subscription details. Please try again.',
-        /** i18n key: billing.subscription.error.retry */
+        /** i18n key: billing.subscriptions.error.retry */
         retry: 'Retry',
       },
     },

--- a/src/modules/billing/lang/fr.js
+++ b/src/modules/billing/lang/fr.js
@@ -15,7 +15,7 @@ export const billingFr = {
       /** i18n key: billing.usage.exhausted */
       exhausted: 'Quota épuisé',
       /** i18n key: billing.usage.manageSubscription */
-      manageSubscription: 'Gérer l’abonnement',
+      manageSubscription: "Gérer l'abonnement",
       bucket: {
         /** i18n key: billing.usage.bucket.scrap */
         scrap: 'Scrape',
@@ -59,7 +59,7 @@ export const billingFr = {
       /** i18n key: billing.subscriptions.empty */
       empty: 'Aucun abonnement actif.',
       /** i18n key: billing.subscriptions.portal */
-      portal: 'Gérer l’abonnement',
+      portal: "Gérer l'abonnement",
       plan: {
         /** i18n key: billing.subscriptions.plan.current */
         current: 'Plan actuel',
@@ -78,6 +78,34 @@ export const billingFr = {
         /** i18n key: billing.subscriptions.cta.upgrade */
         upgrade: 'Passer à un plan supérieur',
       },
+      error: {
+        /** i18n key: billing.subscription.error.fetchFailed */
+        fetchFailed: 'Impossible de charger les détails de votre abonnement. Veuillez réessayer.',
+        /** i18n key: billing.subscription.error.retry */
+        retry: 'Réessayer',
+      },
+    },
+    checkout: {
+      success: {
+        /** i18n key: billing.checkout.success.processing */
+        processing: 'Traitement de votre paiement...',
+        /** i18n key: billing.checkout.success.synced */
+        synced: 'Abonnement activé avec succès. Merci !',
+        /** i18n key: billing.checkout.success.timeout */
+        timeout: 'Paiement reçu, votre abonnement est en cours de synchronisation. Veuillez rafraîchir dans quelques secondes.',
+        /** i18n key: billing.checkout.success.refresh */
+        refresh: 'Rafraîchir',
+      },
+      error: {
+        alreadyActive: {
+          /** i18n key: billing.checkout.error.alreadyActive.title */
+          title: 'Abonnement déjà actif',
+          /** i18n key: billing.checkout.error.alreadyActive.message */
+          message: 'Vous avez déjà un abonnement actif. Gérez-le via le Portail client.',
+          /** i18n key: billing.checkout.error.alreadyActive.cta */
+          cta: 'Ouvrir le portail client',
+        },
+      },
     },
     pricing: {
       tabs: {
@@ -89,7 +117,7 @@ export const billingFr = {
     },
     packs: {
       /** i18n key: billing.packs.title */
-      title: 'Packs d’unités',
+      title: "Packs d'unités",
       /** i18n key: billing.packs.cta */
       cta: 'Acheter des unités',
       /** i18n key: billing.packs.purchase — interpolate {label} */

--- a/src/modules/billing/lang/fr.js
+++ b/src/modules/billing/lang/fr.js
@@ -79,9 +79,9 @@ export const billingFr = {
         upgrade: 'Passer à un plan supérieur',
       },
       error: {
-        /** i18n key: billing.subscription.error.fetchFailed */
+        /** i18n key: billing.subscriptions.error.fetchFailed */
         fetchFailed: 'Impossible de charger les détails de votre abonnement. Veuillez réessayer.',
-        /** i18n key: billing.subscription.error.retry */
+        /** i18n key: billing.subscriptions.error.retry */
         retry: 'Réessayer',
       },
     },

--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -19,6 +19,7 @@ export const useBillingStore = defineStore('billing', {
   state: () => ({
     plans: [],
     subscription: null,
+    subscriptionError: null,
     quota: null,
     /**
      * Legacy global loading flag — remains for backward compat with existing
@@ -64,6 +65,8 @@ export const useBillingStore = defineStore('billing', {
 
     /**
      * @desc Fetch current subscription for the active organization.
+     * Clears subscriptionError on success; sets it on failure so the UI can
+     * show an explicit error state instead of silently falling back to free plan.
      * @returns {Promise<Object>} Resolved subscription object
      */
     async fetchSubscription() {
@@ -72,8 +75,10 @@ export const useBillingStore = defineStore('billing', {
         const api = apiBase();
         const res = await axios.get(`${api}/${config.api.endPoints.billing}/subscription`);
         this.subscription = res.data.data;
+        this.subscriptionError = null;
         return this.subscription;
       } catch (err) {
+        this.subscriptionError = err.message || 'Failed to load subscription';
         console.error(err);
         throw err;
       } finally {
@@ -102,6 +107,8 @@ export const useBillingStore = defineStore('billing', {
 
     /**
      * @desc Create a Stripe Checkout session and return checkout data.
+     * Throws a structured error with code 'subscription_already_active' and
+     * portalUrl when the backend responds 409 (PR Node-A contract).
      * @param {string} priceId - The Stripe price ID
      * @returns {Promise<Object>} Resolved checkout data with URL
      */
@@ -117,6 +124,12 @@ export const useBillingStore = defineStore('billing', {
         capture('plan_upgraded', { price_id: priceId });
         return res.data.data;
       } catch (err) {
+        if (err.response?.status === 409 && err.response?.data?.code === 'subscription_already_active') {
+          const alreadyActiveError = new Error('subscription_already_active');
+          alreadyActiveError.code = 'subscription_already_active';
+          alreadyActiveError.portalUrl = err.response.data.portalUrl;
+          throw alreadyActiveError;
+        }
         console.error(err);
         throw err;
       } finally {

--- a/src/modules/billing/tests/billing.store.unit.tests.js
+++ b/src/modules/billing/tests/billing.store.unit.tests.js
@@ -28,6 +28,7 @@ describe('Billing Store', () => {
     const store = useBillingStore();
     expect(store.plans).toEqual([]);
     expect(store.subscription).toBeNull();
+    expect(store.subscriptionError).toBeNull();
     expect(store.loading).toBe(false);
     // Per-action in-flight counters — all start at 0
     expect(store.usageMeterRequests).toBe(0);
@@ -91,11 +92,31 @@ describe('Billing Store', () => {
       expect(store.loading).toBe(false);
     });
 
+    it('should clear subscriptionError on success (P1-1)', async () => {
+      const store = useBillingStore();
+      store.subscriptionError = 'previous error';
+      const mockSub = { plan: 'pro', status: 'active' };
+      axios.get.mockResolvedValueOnce({ data: { data: mockSub } });
+      await store.fetchSubscription();
+      expect(store.subscriptionError).toBeNull();
+    });
+
     it('should call correct API endpoint', async () => {
       const store = useBillingStore();
       axios.get.mockResolvedValueOnce({ data: { data: {} } });
       await store.fetchSubscription();
       expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/billing/subscription'));
+    });
+
+    it('should set subscriptionError on failure and keep subscription null (P1-1)', async () => {
+      const store = useBillingStore();
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      axios.get.mockRejectedValueOnce(new Error('Network error'));
+      await expect(store.fetchSubscription()).rejects.toThrow('Network error');
+      expect(store.subscriptionError).toBe('Network error');
+      expect(store.subscription).toBeNull();
+      expect(store.loading).toBe(false);
+      spy.mockRestore();
     });
 
     it('should propagate fetchSubscription error to caller', async () => {
@@ -141,6 +162,38 @@ describe('Billing Store', () => {
       await expect(store.createCheckout('price_123')).rejects.toThrow('Checkout failed');
       expect(spy).toHaveBeenCalled();
       expect(store.loading).toBe(false);
+      spy.mockRestore();
+    });
+
+    it('should throw structured error on 409 subscription_already_active (Bonus)', async () => {
+      const store = useBillingStore();
+      const portalUrl = 'https://billing.stripe.com/portal/sess_abc';
+      const axiosError = {
+        response: {
+          status: 409,
+          data: { code: 'subscription_already_active', portalUrl },
+        },
+      };
+      axios.post.mockRejectedValueOnce(axiosError);
+      let caught;
+      try {
+        await store.createCheckout('price_123');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeDefined();
+      expect(caught.code).toBe('subscription_already_active');
+      expect(caught.portalUrl).toBe(portalUrl);
+      expect(store.loading).toBe(false);
+    });
+
+    it('should pass through non-409 errors normally (Bonus)', async () => {
+      const store = useBillingStore();
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const axiosError = { response: { status: 500, data: {} } };
+      axios.post.mockRejectedValueOnce(axiosError);
+      await expect(store.createCheckout('price_123')).rejects.toEqual(axiosError);
+      expect(spy).toHaveBeenCalled();
       spy.mockRestore();
     });
   });

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -384,8 +384,10 @@ describe('BillingSubscriptionsComponent — checkout success query flow', () => 
     vi.useRealTimers();
   });
 
-  it('shows subscription success alert and cleans the URL query', async () => {
+  it('shows processing state and cleans the URL query on ?success=true (P1-2 polling flow)', async () => {
     const router = { replace: vi.fn(), push: vi.fn() };
+    // fetchSubscription never activates subscription → stays in processing/polling
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
     wrapper = mountSubscriptions({
       serverConfig: { billing: { meterMode: false } },
       routeQuery: { tab: 'subscriptions', success: 'true' },
@@ -393,8 +395,10 @@ describe('BillingSubscriptionsComponent — checkout success query flow', () => 
     });
     await flushPromises();
 
-    expect(wrapper.text()).toContain('Subscription updated successfully. Thank you!');
+    // Polling is active — checkoutProcessing shown
+    expect(wrapper.vm.checkoutProcessing).toBe(true);
 
+    // URL cleanup fires after 100ms
     vi.advanceTimersByTime(100);
     expect(router.replace).toHaveBeenCalledWith({
       query: { tab: 'subscriptions', success: undefined, type: undefined, packPurchased: undefined },
@@ -470,5 +474,230 @@ describe('BillingSubscriptionsComponent — ledger pagination', () => {
     await flushPromises();
     expect(wrapper.vm.extrasLedger.entries).toEqual([]);
     expect(wrapper.vm.extrasLedger.total).toBe(0);
+  });
+});
+
+// ─── Suite 7: P1-1 — Subscription fetch error state ─────────────────────────
+
+describe('BillingSubscriptionsComponent — subscription fetch error (P1-1)', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    store = useBillingStore();
+    seedMeterStore(store);
+    // Simulate a failed fetchSubscription: error set, subscription remains null
+    store.subscription = null;
+    store.subscriptionError = 'Network error';
+    vi.spyOn(store, 'fetchSubscription').mockRejectedValue(new Error('Network error'));
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+  });
+
+  it('shows error card instead of free-plan fallback when subscriptionError is set', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    // Error card present
+    expect(wrapper.find('[role="alert"]').exists()).toBe(true);
+    // Must NOT show the free-plan "Upgrade" CTA or free plan text
+    expect(wrapper.text()).not.toContain("You're on the free plan");
+  });
+
+  it('error card has aria-live="assertive" for a11y (P1-1)', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    const alert = wrapper.find('[role="alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.attributes('aria-live')).toBe('assertive');
+  });
+
+  it('error card contains retry button', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    const retryBtn = wrapper.findAll('.v-btn').find((b) => b.text().toLowerCase().includes('retry'));
+    expect(retryBtn).toBeDefined();
+  });
+
+  it('retry button calls fetchSubscription again', async () => {
+    const fetchSpy = vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+    store.subscriptionError = 'Network error';
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    await wrapper.vm.retryFetchSubscription();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('clears error card when retry succeeds and subscription loads', async () => {
+    const sub = { plan: 'pro', status: 'active' };
+    vi.spyOn(store, 'fetchSubscription').mockImplementation(async () => {
+      store.subscription = sub;
+      store.subscriptionError = null;
+    });
+    store.subscriptionError = 'Network error';
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    await wrapper.vm.retryFetchSubscription();
+    await flushPromises();
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+  });
+});
+
+// ─── Suite 8: P1-2 — Checkout polling after Stripe success ───────────────────
+
+describe('BillingSubscriptionsComponent — checkout success polling (P1-2)', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    store = useBillingStore();
+    seedMeterStore(store);
+    store.subscription = null;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    vi.useRealTimers();
+  });
+
+  it('shows processing spinner when ?success=true (non-extras)', async () => {
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: { tab: 'subscriptions', success: 'true' },
+    });
+    await flushPromises();
+    expect(wrapper.vm.checkoutProcessing).toBe(true);
+  });
+
+  it('transitions to success message when subscription activates on 3rd poll', async () => {
+    let callCount = 0;
+    vi.spyOn(store, 'fetchSubscription').mockImplementation(async () => {
+      callCount += 1;
+      if (callCount >= 3) {
+        store.subscription = { plan: 'starter', status: 'active', stripeSubscriptionId: 'sub_new123' };
+        store.subscriptionError = null;
+      }
+    });
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: { tab: 'subscriptions', success: 'true' },
+    });
+    await flushPromises();
+    expect(wrapper.vm.checkoutProcessing).toBe(true);
+
+    // Advance 2 polls (4s)
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushPromises();
+
+    // 3rd poll activates subscription
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushPromises();
+
+    expect(wrapper.vm.checkoutProcessing).toBe(false);
+    expect(wrapper.vm.paymentSuccessMessage).toContain('Subscription activated successfully');
+  });
+
+  it('shows timeout message after 8 polls without state change', async () => {
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: { tab: 'subscriptions', success: 'true' },
+    });
+    await flushPromises();
+
+    // Advance 8 × 2s = 16s
+    await vi.advanceTimersByTimeAsync(16000);
+    await flushPromises();
+
+    expect(wrapper.vm.checkoutProcessing).toBe(false);
+    expect(wrapper.vm.checkoutTimeout).toBe(true);
+  });
+
+  it('timeout message renders in template with refresh button', async () => {
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: { tab: 'subscriptions', success: 'true' },
+    });
+    await flushPromises();
+
+    await vi.advanceTimersByTimeAsync(16000);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Payment received');
+    const refreshBtn = wrapper.findAll('.v-btn').find((b) => b.text().toLowerCase().includes('refresh'));
+    expect(refreshBtn).toBeDefined();
+  });
+
+  it('extras purchase shows success immediately without subscription polling', async () => {
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: true } },
+      routeQuery: { tab: 'subscriptions', success: 'true', type: 'extras' },
+    });
+    await flushPromises();
+
+    // No polling active for extras
+    expect(wrapper.vm.checkoutProcessing).toBe(false);
+    expect(wrapper.vm.checkoutPollCount).toBe(0);
+    expect(wrapper.vm.paymentSuccessMessage).toContain('Extra units purchased');
+  });
+});
+
+// ─── Suite 9: Bonus — 409 already-active dialog (showAlreadyActiveDialog) ─────
+
+describe('BillingSubscriptionsComponent — 409 already-active dialog (Bonus)', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    store = useBillingStore();
+    seedMeterStore(store);
+    store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
+    // Stub v-dialog to avoid visualViewport errors in jsdom
+    componentStubs['VDialog'] = { name: 'VDialog', template: '<div><slot /></div>', props: ['modelValue'] };
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    delete componentStubs['VDialog'];
+  });
+
+  it('alreadyActiveDialog is false by default', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    expect(wrapper.vm.alreadyActiveDialog).toBe(false);
+  });
+
+  it('showAlreadyActiveDialog sets alreadyActiveDialog true and stores portalUrl', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    const portalUrl = 'https://billing.stripe.com/portal/sess_abc';
+    wrapper.vm.showAlreadyActiveDialog(portalUrl);
+    expect(wrapper.vm.alreadyActiveDialog).toBe(true);
+    expect(wrapper.vm.alreadyActivePortalUrl).toBe(portalUrl);
+  });
+
+  it('showAlreadyActiveDialog handles missing portalUrl gracefully', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    wrapper.vm.showAlreadyActiveDialog(null);
+    expect(wrapper.vm.alreadyActiveDialog).toBe(true);
+    expect(wrapper.vm.alreadyActivePortalUrl).toBeNull();
   });
 });

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -641,6 +641,56 @@ describe('BillingSubscriptionsComponent — checkout success polling (P1-2)', ()
     expect(refreshBtn).toBeDefined();
   });
 
+  it('retryFetchSubscription clears checkoutTimeout when refresh confirms active subscription', async () => {
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: { tab: 'subscriptions', success: 'true' },
+    });
+    await flushPromises();
+
+    // Force timeout
+    await vi.advanceTimersByTimeAsync(16000);
+    await flushPromises();
+    expect(wrapper.vm.checkoutTimeout).toBe(true);
+
+    // Manual refresh confirms active sub
+    vi.spyOn(store, 'fetchSubscription').mockImplementation(async () => {
+      store.subscription = { plan: 'starter', status: 'active', stripeSubscriptionId: 'sub_123' };
+      store.subscriptionError = null;
+      return store.subscription;
+    });
+    await wrapper.vm.retryFetchSubscription();
+
+    expect(wrapper.vm.checkoutTimeout).toBe(false);
+    expect(wrapper.vm.paymentSuccessMessage).toContain('Subscription activated successfully');
+  });
+
+  it('plan change detected as activation (upgrade with same stripeSubscriptionId)', async () => {
+    store.subscription = { plan: 'starter', status: 'active', stripeSubscriptionId: 'sub_same' };
+    let callCount = 0;
+    vi.spyOn(store, 'fetchSubscription').mockImplementation(async () => {
+      callCount += 1;
+      if (callCount >= 2) {
+        store.subscription = { plan: 'pro', status: 'active', stripeSubscriptionId: 'sub_same' };
+        store.subscriptionError = null;
+      }
+    });
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: { tab: 'subscriptions', success: 'true' },
+    });
+    await flushPromises();
+
+    // 2nd poll detects plan change
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushPromises();
+
+    expect(wrapper.vm.checkoutProcessing).toBe(false);
+    expect(wrapper.vm.paymentSuccessMessage).toContain('Subscription activated successfully');
+  });
+
   it('extras purchase shows success immediately without subscription polling', async () => {
     vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
     wrapper = mountSubscriptions({
@@ -684,13 +734,29 @@ describe('BillingSubscriptionsComponent — 409 already-active dialog (Bonus)', 
     expect(wrapper.vm.alreadyActiveDialog).toBe(false);
   });
 
-  it('showAlreadyActiveDialog sets alreadyActiveDialog true and stores portalUrl', async () => {
+  it('showAlreadyActiveDialog sets alreadyActiveDialog true and stores valid HTTPS portalUrl', async () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
     await flushPromises();
     const portalUrl = 'https://billing.stripe.com/portal/sess_abc';
     wrapper.vm.showAlreadyActiveDialog(portalUrl);
     expect(wrapper.vm.alreadyActiveDialog).toBe(true);
     expect(wrapper.vm.alreadyActivePortalUrl).toBe(portalUrl);
+  });
+
+  it('showAlreadyActiveDialog rejects non-HTTPS portalUrl', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    wrapper.vm.showAlreadyActiveDialog('http://evil.example.com/portal');
+    expect(wrapper.vm.alreadyActiveDialog).toBe(true);
+    expect(wrapper.vm.alreadyActivePortalUrl).toBeNull();
+  });
+
+  it('showAlreadyActiveDialog handles invalid URL gracefully', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    wrapper.vm.showAlreadyActiveDialog('not-a-url');
+    expect(wrapper.vm.alreadyActiveDialog).toBe(true);
+    expect(wrapper.vm.alreadyActivePortalUrl).toBeNull();
   });
 
   it('showAlreadyActiveDialog handles missing portalUrl gracefully', async () => {

--- a/src/modules/billing/tests/billing.useBilling.unit.tests.js
+++ b/src/modules/billing/tests/billing.useBilling.unit.tests.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useBillingStore } from '../stores/billing.store';
+import { useBilling } from '../composables/billing.useBilling';
+
+describe('useBilling composable', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('isPlanActive (P1-3)', () => {
+    it('returns true when subscription status is "active"', () => {
+      const store = useBillingStore();
+      store.subscription = { status: 'active', plan: 'starter' };
+      const { isPlanActive } = useBilling();
+      expect(isPlanActive.value).toBe(true);
+    });
+
+    it('returns true when subscription status is "trialing" (P1-3)', () => {
+      const store = useBillingStore();
+      store.subscription = { status: 'trialing', plan: 'starter' };
+      const { isPlanActive } = useBilling();
+      expect(isPlanActive.value).toBe(true);
+    });
+
+    it('returns false when subscription is null', () => {
+      const store = useBillingStore();
+      store.subscription = null;
+      const { isPlanActive } = useBilling();
+      expect(isPlanActive.value).toBe(false);
+    });
+
+    it('returns false when status is "canceled"', () => {
+      const store = useBillingStore();
+      store.subscription = { status: 'canceled', plan: 'starter' };
+      const { isPlanActive } = useBilling();
+      expect(isPlanActive.value).toBe(false);
+    });
+
+    it('returns false when status is "past_due"', () => {
+      const store = useBillingStore();
+      store.subscription = { status: 'past_due', plan: 'starter' };
+      const { isPlanActive } = useBilling();
+      expect(isPlanActive.value).toBe(false);
+    });
+
+    it('returns false when status is "incomplete"', () => {
+      const store = useBillingStore();
+      store.subscription = { status: 'incomplete', plan: 'starter' };
+      const { isPlanActive } = useBilling();
+      expect(isPlanActive.value).toBe(false);
+    });
+  });
+
+  describe('currentPlan', () => {
+    it('returns subscription plan when set', () => {
+      const store = useBillingStore();
+      store.subscription = { status: 'active', plan: 'pro' };
+      const { currentPlan } = useBilling();
+      expect(currentPlan.value).toBe('pro');
+    });
+
+    it('defaults to "free" when no subscription', () => {
+      const store = useBillingStore();
+      store.subscription = null;
+      const { currentPlan } = useBilling();
+      expect(currentPlan.value).toBe('free');
+    });
+  });
+
+  describe('hasPlan', () => {
+    it('returns true when current plan matches one of the provided plans', () => {
+      const store = useBillingStore();
+      store.subscription = { status: 'active', plan: 'starter' };
+      const { hasPlan } = useBilling();
+      expect(hasPlan('starter', 'pro')).toBe(true);
+    });
+
+    it('returns false when current plan is not in the provided plans', () => {
+      const store = useBillingStore();
+      store.subscription = { status: 'active', plan: 'free' };
+      const { hasPlan } = useBilling();
+      expect(hasPlan('starter', 'pro')).toBe(false);
+    });
+  });
+});

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -407,7 +407,17 @@ export default {
       } catch (err) {
         // Bonus: handle 409 subscription_already_active (PR Node-A contract)
         if (err.code === 'subscription_already_active') {
-          this.alreadyActivePortalUrl = err.portalUrl || null;
+          this.alreadyActivePortalUrl = null;
+          if (err.portalUrl) {
+            try {
+              const parsed = new URL(err.portalUrl);
+              if (parsed.protocol === 'https:') {
+                this.alreadyActivePortalUrl = parsed.toString();
+              }
+            } catch {
+              // Invalid URL — link will not be shown
+            }
+          }
           this.alreadyActiveDialog = true;
           return;
         }

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -44,6 +44,44 @@
       {{ checkoutError }}
     </v-alert>
 
+    <!-- Bonus: 409 subscription_already_active dialog -->
+    <v-dialog v-model="alreadyActiveDialog" max-width="480">
+      <v-card class="pa-6">
+        <div class="d-flex align-center mb-3">
+          <v-icon icon="fa-solid fa-circle-check" color="success" size="small" class="mr-2" />
+          <span class="text-title-medium font-weight-medium">
+            <!-- i18n key: billing.checkout.error.alreadyActive.title -->
+            Subscription already active
+          </span>
+        </div>
+        <p class="text-body-medium text-medium-emphasis mb-6">
+          <!-- i18n key: billing.checkout.error.alreadyActive.message -->
+          You already have an active subscription. Manage it via the Customer Portal.
+        </p>
+        <div class="d-flex ga-3 justify-end">
+          <v-btn
+            variant="outlined"
+            class="text-none text-body-medium"
+            @click="alreadyActiveDialog = false"
+          >
+            Close
+          </v-btn>
+          <v-btn
+            v-if="alreadyActivePortalUrl"
+            color="primary"
+            variant="flat"
+            class="text-none text-body-medium"
+            :href="alreadyActivePortalUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <!-- i18n key: billing.checkout.error.alreadyActive.cta -->
+            Open Customer Portal
+          </v-btn>
+        </div>
+      </v-card>
+    </v-dialog>
+
     <!-- Glass tabs (meter mode only) -->
     <div v-if="meterMode" class="d-flex justify-center mb-8">
       <HomeTabsComponent
@@ -154,6 +192,9 @@ export default {
       downgradeDialog: false,
       /** @type {{ planId: string, priceId: string }|null} Pending plan selection awaiting confirmation */
       pendingDowngrade: null,
+      // Bonus: 409 already-active dialog state
+      alreadyActiveDialog: false,
+      alreadyActivePortalUrl: null,
     };
   },
   computed: {
@@ -364,6 +405,12 @@ export default {
           console.error('Rejected non-HTTPS checkout URL');
         }
       } catch (err) {
+        // Bonus: handle 409 subscription_already_active (PR Node-A contract)
+        if (err.code === 'subscription_already_active') {
+          this.alreadyActivePortalUrl = err.portalUrl || null;
+          this.alreadyActiveDialog = true;
+          return;
+        }
         console.error('Failed to start checkout:', err);
         this.checkoutError = 'Failed to start checkout. Please try again.';
       } finally {


### PR DESCRIPTION
## Summary

4 fixes grouped from Codex audit iteration 4 — all touch the subscription display flow.

### P1-1: fetchSubscription failure → error state (not silent free-plan fallback)
- Added `subscriptionError` field to billing store (set on error, cleared on success)
- Component shows explicit error card with `role="alert"` + `aria-live="assertive"` + Retry button when `subscriptionError && !subscription`
- Prevents misleading "You're on the free plan" display for paying users when the network is down

### P1-2: Webhook lag polling after checkout success
- `?success=true` redirect now triggers a polling loop (2s × 8 attempts = max 16s) instead of a single fetch
- Shows processing spinner during polling; success message on state change; timeout+Refresh CTA if 16s elapses without activation
- Criteria for success: `stripeSubscriptionId` appeared OR `status` changed to `active`/`trialing`
- Extras purchases bypass polling (direct success message as before)
- a11y: `aria-live="polite"` on status banners

### P1-3: `trialing` recognized as active
- `isPlanActive` composable now uses `['active', 'trialing'].includes(status)` — trial users no longer fall into free-tier display in meter mode

### Bonus: 409 `subscription_already_active` (soft dep on PR Node-A)
- Store `createCheckout()` catches 409 + `code=subscription_already_active` and rethrows a structured error with `.code` and `.portalUrl`
- Pricing view catches it and opens a Vuetify dialog with a direct "Open Customer Portal" link
- Falls back to generic error toast for all other errors
- No test breakage when Node-A is not yet live — the 409 path simply won't be exercised

## i18n keys added (EN + FR)
`billing.subscription.error.fetchFailed`, `.retry`, `billing.checkout.success.processing`, `.synced`, `.timeout`, `.refresh`, `billing.checkout.error.alreadyActive.title`, `.message`, `.cta`

## Tests added
- `billing.useBilling.unit.tests.js` (new): `isPlanActive` with active/trialing/canceled/null
- `billing.store.unit.tests.js`: subscriptionError lifecycle; 409 structured error; non-409 passthrough
- `billing.subscriptions.component.unit.tests.js`: error card renders; a11y attributes; retry button; polling success/timeout; extras bypass; 409 dialog state

## Node-A dependency
The 409 handler in `createCheckout()` is defensive — it only fires when Node-A is live and returns a 409 with `{ code: 'subscription_already_active', portalUrl }`. No behavior change until then.

## Test plan
- [ ] `npm run lint` → green
- [ ] `npm run test:unit` → 1359 passed
- [ ] CI green
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkout processing and timeout feedback states for subscription purchases
  * Introduced subscription fetch error card with retry functionality
  * Added "subscription already active" error dialog with customer portal link option

* **Bug Fixes**
  * Improved subscription activation polling with timed attempts and maximum attempt limits
  * Enhanced subscription status recognition to include trialing state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->