### PR TITLE
fix(billing): V5 polish — F5 polling recovery + visibility refetch + i18n residual + locale null-guard

### DIFF
--- a/src/modules/billing/components/billing.extrasLedger.component.vue
+++ b/src/modules/billing/components/billing.extrasLedger.component.vue
@@ -30,7 +30,7 @@
       v-if="entries.length === 0"
       class="text-caption text-medium-emphasis text-center py-6"
     >
-      No ledger entries yet
+      {{ $t('billing.extrasLedger.empty.noEntries') }}
     </div>
 
     <template v-else>
@@ -155,19 +155,22 @@ export default {
 
   emits: ['update:page'],
 
-  data() {
-    return {
-      headers: [
-        { title: 'Date', key: 'at', sortable: false },
-        { title: 'Kind', key: 'kind', sortable: false },
-        { title: 'Amount', key: 'amount', sortable: false, align: 'end' },
-        { title: 'Ref / History', key: 'refId', sortable: false },
-        { title: 'Stripe session', key: 'stripeSessionId', sortable: false },
-      ],
-    };
-  },
-
   computed: {
+    /**
+     * @desc Reactive table headers using i18n for localised column titles.
+     * Defined as computed (not data) so $t is available and re-evaluates on locale change.
+     * @returns {Array<{title: string, key: string, sortable: boolean, align?: string}>}
+     */
+    headers() {
+      return [
+        { title: this.$t('billing.extrasLedger.headers.date'), key: 'at', sortable: false },
+        { title: this.$t('billing.extrasLedger.headers.kind'), key: 'kind', sortable: false },
+        { title: this.$t('billing.extrasLedger.headers.amount'), key: 'amount', sortable: false, align: 'end' },
+        { title: this.$t('billing.extrasLedger.headers.refHistory'), key: 'refId', sortable: false },
+        { title: this.$t('billing.extrasLedger.headers.stripeSession'), key: 'stripeSessionId', sortable: false },
+      ];
+    },
+
     /**
      * @desc Total number of pages.
      * @returns {number}
@@ -181,13 +184,14 @@ export default {
   methods: {
     /**
      * @desc Format an ISO date string to a human-readable local date+time.
+     * Uses the active i18n locale for locale-aware formatting.
      * @param {string} value - ISO 8601 date string
      * @returns {string}
      */
     formatDate(value) {
       if (!value) return '—';
       try {
-        return new Date(value).toLocaleString(undefined, {
+        return new Date(value).toLocaleString(this.$i18n.locale || undefined, {
           year: 'numeric',
           month: 'short',
           day: 'numeric',

--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -225,15 +225,25 @@ export default {
     },
 
     /**
-     * @desc Accessible ARIA label summarising the current meter state.
+     * @desc Accessible ARIA label summarising the current meter state (locale-aware).
      * @returns {string}
      */
     ariaLabel() {
       const base = this.label ? `${this.label}: ` : '';
       if (this.overage > 0) {
-        return `${base}${this.used} of ${this.quota} used, ${this.overage} over quota`;
+        return this.$t('billing.meterProgress.ariaOver', {
+          base,
+          used: this.used,
+          quota: this.quota,
+          overage: this.overage,
+        });
       }
-      return `${base}${this.used} of ${this.quota} used (${this.clampedProgress}%)`;
+      return this.$t('billing.meterProgress.ariaUsed', {
+        base,
+        used: this.used,
+        quota: this.quota,
+        percent: this.clampedProgress,
+      });
     },
   },
 

--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -57,7 +57,7 @@
         variant="tonal"
         prepend-icon="fa-solid fa-triangle-exclamation"
       >
-        +{{ overage }} over
+        {{ $t('billing.meterProgress.over', { count: overage }) }}
       </v-chip>
     </div>
 
@@ -93,10 +93,10 @@
     >
       <span>{{ used }} / {{ quota }}</span>
       <template v-if="overage > 0">
-        <span class="text-error"> ({{ computedNetRemainingRaw }} remaining)</span>
+        <span class="text-error"> {{ $t('billing.meterProgress.remaining', { count: computedNetRemainingRaw }) }}</span>
       </template>
       <template v-else>
-        <span v-if="extras > 0"> +{{ extras }} extras</span>
+        <span v-if="extras > 0"> {{ $t('billing.meterProgress.extras', { count: extras }) }}</span>
       </template>
     </div>
   </div>

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -553,6 +553,7 @@ export default {
         // Normal load: fetch once and surface errors
         try {
           await this.billingStore.fetchSubscription();
+          this.subscriptionLastFetchedAt = Date.now();
         } catch {
           // subscriptionError is already set in the store; component shows error card
         }
@@ -647,7 +648,12 @@ export default {
       this.checkoutPollSnapshotId = this.billingStore.subscription?.stripeSubscriptionId ?? null;
       this.checkoutPollSnapshotStatus = this.billingStore.subscription?.status ?? null;
       this.checkoutPollSnapshotPlan = this.billingStore.subscription?.plan ?? null;
-      this.persistCheckoutPollingSession({ startedAt: Date.now() });
+      this.persistCheckoutPollingSession({
+        startedAt: Date.now(),
+        snapshotId: this.checkoutPollSnapshotId,
+        snapshotStatus: this.checkoutPollSnapshotStatus,
+        snapshotPlan: this.checkoutPollSnapshotPlan,
+      });
       this.scheduleQueryCleanup();
       this.pollSubscription();
       return true;
@@ -656,7 +662,8 @@ export default {
     /**
      * @desc Attempt to resume an interrupted checkout polling session after F5 reload.
      * Reads from sessionStorage — clears stale entry when the polling window has expired.
-     * When resumed, the component enters processing state and polls for remaining window time.
+     * When resumed, restores the pre-checkout snapshots from storage so that polling
+     * detects state changes against the original baseline (not the null store state after reload).
      * @returns {boolean} True when polling was successfully resumed
      */
     resumeCheckoutPollingFromSession() {
@@ -670,7 +677,14 @@ export default {
         return false;
       }
 
-      const { startedAt } = stored;
+      const { startedAt, snapshotId, snapshotStatus, snapshotPlan } = stored;
+
+      // Validate startedAt to guard against malformed storage data
+      if (typeof startedAt !== 'number' || Number.isNaN(startedAt)) {
+        sessionStorage.removeItem(CHECKOUT_POLL_SESSION_KEY);
+        return false;
+      }
+
       const elapsed = Date.now() - startedAt;
       const remaining = CHECKOUT_POLL_WINDOW_MS - elapsed;
 
@@ -679,13 +693,15 @@ export default {
         return false;
       }
 
-      // Resume: show processing banner and poll for remaining time
+      // Resume: restore baseline snapshots from storage and poll for remaining time.
+      // Using persisted snapshots (not null store state) prevents a false-positive
+      // activation on the first fetch after F5.
       this.checkoutProcessing = true;
       this.checkoutTimeout = false;
       this.checkoutPollCount = Math.floor(elapsed / CHECKOUT_POLL_INTERVAL_MS);
-      this.checkoutPollSnapshotId = this.billingStore.subscription?.stripeSubscriptionId ?? null;
-      this.checkoutPollSnapshotStatus = this.billingStore.subscription?.status ?? null;
-      this.checkoutPollSnapshotPlan = this.billingStore.subscription?.plan ?? null;
+      this.checkoutPollSnapshotId = snapshotId ?? null;
+      this.checkoutPollSnapshotStatus = snapshotStatus ?? null;
+      this.checkoutPollSnapshotPlan = snapshotPlan ?? null;
       this.pollSubscription();
       return true;
     },

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -317,6 +317,10 @@ import BillingExtrasCheckoutModalComponent from './billing.extrasCheckoutModal.c
 const CHECKOUT_POLL_MAX = 8;
 /** Interval between polling attempts in milliseconds. */
 const CHECKOUT_POLL_INTERVAL_MS = 2000;
+/** Total polling window in milliseconds (POLL_MAX × POLL_INTERVAL). */
+const CHECKOUT_POLL_WINDOW_MS = CHECKOUT_POLL_MAX * CHECKOUT_POLL_INTERVAL_MS;
+/** sessionStorage key used to persist polling state across F5 reloads. */
+const CHECKOUT_POLL_SESSION_KEY = 'billing.checkout.polling';
 
 /**
  * Component definition.
@@ -392,6 +396,8 @@ export default {
       checkoutPollSnapshotId: null,
       checkoutPollSnapshotStatus: null,
       checkoutPollSnapshotPlan: null,
+      // V5 P2: visibility-change subscription refresh debounce (timestamp of last fetch)
+      subscriptionLastFetchedAt: 0,
       // Bonus: 409 already-active dialog
       alreadyActiveDialog: false,
       alreadyActivePortalUrl: null,
@@ -509,13 +515,13 @@ export default {
       return null;
     },
     /**
-     * @desc Format the next billing date for display.
+     * @desc Format the next billing date for display using the active i18n locale.
      * @returns {string|null}
      */
     nextBillingDate() {
       const date = this.subscription?.currentPeriodEnd;
       if (!date) return null;
-      return new Date(date).toLocaleDateString(undefined, {
+      return new Date(date).toLocaleDateString(this.$i18n.locale || undefined, {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
@@ -526,6 +532,10 @@ export default {
    * @desc Fetch subscription data on mount and handle Stripe redirect query params.
    * The legacy /billing page is retired; this component is now the landing point for
    * Stripe redirects (success, cancel, packPurchased).
+   *
+   * F5 recovery (V5 P1): if sessionStorage contains a stale in-progress polling entry
+   * from a previous render and it's still within the polling window, polling is resumed
+   * for the remaining time without requiring the ?success query param to still be present.
    * @returns {Promise<void>}
    */
   async mounted() {
@@ -536,19 +546,36 @@ export default {
     const isCheckoutSuccess = this.handleCheckoutSuccessQuery();
 
     if (!isCheckoutSuccess) {
-      // Normal load: fetch once and surface errors
-      try {
-        await this.billingStore.fetchSubscription();
-      } catch {
-        // subscriptionError is already set in the store; component shows error card
+      // Check for interrupted polling session (F5 during checkout processing)
+      const resumed = this.resumeCheckoutPollingFromSession();
+
+      if (!resumed) {
+        // Normal load: fetch once and surface errors
+        try {
+          await this.billingStore.fetchSubscription();
+        } catch {
+          // subscriptionError is already set in the store; component shows error card
+        }
       }
     }
 
     // Note: fetchExtrasLedger is handled by the immediate watcher in setup(),
     // no duplicate call needed here.
+
+    // V5 P2: refresh subscription when tab regains visibility (multi-tab stale state)
+    // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Options API method, not a Qwik component
+    this._handleSubscriptionVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      const DEBOUNCE_MS = 500;
+      if (Date.now() - this.subscriptionLastFetchedAt < DEBOUNCE_MS) return;
+      if (this.checkoutProcessing) return; // Don't interrupt active polling
+      this.subscriptionLastFetchedAt = Date.now();
+      this.billingStore.fetchSubscription().catch(() => {});
+    };
+    document.addEventListener('visibilitychange', this._handleSubscriptionVisibilityChange);
   },
   /**
-   * @desc Clear pending timers on component teardown.
+   * @desc Clear pending timers and remove event listeners on component teardown.
    * @returns {void}
    */
   beforeUnmount() {
@@ -561,6 +588,7 @@ export default {
     if (this.checkoutPollTimer) {
       clearTimeout(this.checkoutPollTimer);
     }
+    document.removeEventListener('visibilitychange', this._handleSubscriptionVisibilityChange);
   },
   methods: {
     /**
@@ -619,9 +647,73 @@ export default {
       this.checkoutPollSnapshotId = this.billingStore.subscription?.stripeSubscriptionId ?? null;
       this.checkoutPollSnapshotStatus = this.billingStore.subscription?.status ?? null;
       this.checkoutPollSnapshotPlan = this.billingStore.subscription?.plan ?? null;
+      this.persistCheckoutPollingSession({ startedAt: Date.now() });
       this.scheduleQueryCleanup();
       this.pollSubscription();
       return true;
+    },
+
+    /**
+     * @desc Attempt to resume an interrupted checkout polling session after F5 reload.
+     * Reads from sessionStorage — clears stale entry when the polling window has expired.
+     * When resumed, the component enters processing state and polls for remaining window time.
+     * @returns {boolean} True when polling was successfully resumed
+     */
+    resumeCheckoutPollingFromSession() {
+      let stored;
+      try {
+        const raw = sessionStorage.getItem(CHECKOUT_POLL_SESSION_KEY);
+        if (!raw) return false;
+        stored = JSON.parse(raw);
+      } catch {
+        sessionStorage.removeItem(CHECKOUT_POLL_SESSION_KEY);
+        return false;
+      }
+
+      const { startedAt } = stored;
+      const elapsed = Date.now() - startedAt;
+      const remaining = CHECKOUT_POLL_WINDOW_MS - elapsed;
+
+      if (remaining <= 0) {
+        sessionStorage.removeItem(CHECKOUT_POLL_SESSION_KEY);
+        return false;
+      }
+
+      // Resume: show processing banner and poll for remaining time
+      this.checkoutProcessing = true;
+      this.checkoutTimeout = false;
+      this.checkoutPollCount = Math.floor(elapsed / CHECKOUT_POLL_INTERVAL_MS);
+      this.checkoutPollSnapshotId = this.billingStore.subscription?.stripeSubscriptionId ?? null;
+      this.checkoutPollSnapshotStatus = this.billingStore.subscription?.status ?? null;
+      this.checkoutPollSnapshotPlan = this.billingStore.subscription?.plan ?? null;
+      this.pollSubscription();
+      return true;
+    },
+
+    /**
+     * @desc Persist checkout polling session to sessionStorage for F5 recovery.
+     * @param {{ startedAt: number }} payload - Session data to persist
+     * @returns {void}
+     */
+    persistCheckoutPollingSession(payload) {
+      try {
+        sessionStorage.setItem(CHECKOUT_POLL_SESSION_KEY, JSON.stringify(payload));
+      } catch {
+        // sessionStorage unavailable (private mode / quota exceeded) — polling continues without persistence
+      }
+    },
+
+    /**
+     * @desc Clear the checkout polling session from sessionStorage.
+     * Called on successful activation or timeout to prevent stale resumption.
+     * @returns {void}
+     */
+    clearCheckoutPollingSession() {
+      try {
+        sessionStorage.removeItem(CHECKOUT_POLL_SESSION_KEY);
+      } catch {
+        // sessionStorage unavailable — nothing to clean up
+      }
     },
 
     /**
@@ -651,6 +743,7 @@ export default {
         if (activated) {
           this.checkoutProcessing = false;
           this.checkoutTimeout = false;
+          this.clearCheckoutPollingSession();
           this.paymentSuccessMessage = this.$t('billing.checkout.success.synced');
           return;
         }
@@ -659,6 +752,7 @@ export default {
         if (this.checkoutPollCount >= CHECKOUT_POLL_MAX) {
           this.checkoutProcessing = false;
           this.checkoutTimeout = true;
+          this.clearCheckoutPollingSession();
           return;
         }
 

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -643,12 +643,14 @@ export default {
 
       if (query.type === 'extras' || packPurchased) {
         // Extras purchase: no subscription state to poll — show success directly.
-        // Clear any leftover subscription polling session to prevent the resume
-        // path from overriding the extras success banner on next render.
+        // Clear any leftover subscription polling session and return true so that
+        // mounted() skips both resumeCheckoutPollingFromSession() and the normal
+        // fetchSubscription() call, preventing stale polling from overriding the
+        // extras success banner.
         this.clearCheckoutPollingSession();
         this.paymentSuccessMessage = this.$t('billing.extras.purchaseSuccess');
         this.scheduleQueryCleanup();
-        return false;
+        return true;
       }
 
       // Subscription checkout success: capture pre-poll snapshot and start polling

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -564,16 +564,7 @@ export default {
     // no duplicate call needed here.
 
     // V5 P2: refresh subscription when tab regains visibility (multi-tab stale state)
-    // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Options API method, not a Qwik component
-    this._handleSubscriptionVisibilityChange = () => {
-      if (document.visibilityState !== 'visible') return;
-      const DEBOUNCE_MS = 500;
-      if (Date.now() - this.subscriptionLastFetchedAt < DEBOUNCE_MS) return;
-      if (this.checkoutProcessing) return; // Don't interrupt active polling
-      this.subscriptionLastFetchedAt = Date.now();
-      this.billingStore.fetchSubscription().catch(() => {});
-    };
-    document.addEventListener('visibilitychange', this._handleSubscriptionVisibilityChange);
+    document.addEventListener('visibilitychange', this.handleSubscriptionVisibilityChange);
   },
   /**
    * @desc Clear pending timers and remove event listeners on component teardown.
@@ -589,9 +580,25 @@ export default {
     if (this.checkoutPollTimer) {
       clearTimeout(this.checkoutPollTimer);
     }
-    document.removeEventListener('visibilitychange', this._handleSubscriptionVisibilityChange);
+    document.removeEventListener('visibilitychange', this.handleSubscriptionVisibilityChange);
   },
   methods: {
+    /**
+     * @desc Handle tab visibility change — refresh subscription when tab becomes visible.
+     * Debounced 500ms to prevent a redundant fetch immediately after mount or a recent poll.
+     * Skipped while checkout polling is active to avoid concurrent fetch interference.
+     * @returns {void}
+     */
+    // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Options API method, not a Qwik component
+    handleSubscriptionVisibilityChange() {
+      if (document.visibilityState !== 'visible') return;
+      const DEBOUNCE_MS = 500;
+      if (Date.now() - this.subscriptionLastFetchedAt < DEBOUNCE_MS) return;
+      if (this.checkoutProcessing) return; // Don't interrupt active polling
+      this.subscriptionLastFetchedAt = Date.now();
+      this.billingStore.fetchSubscription().catch(() => {});
+    },
+
     /**
      * @desc Manually dismiss the payment success banner and clear its auto-dismiss timer.
      * @returns {void}
@@ -635,7 +642,10 @@ export default {
       if (!isSuccess) return false;
 
       if (query.type === 'extras' || packPurchased) {
-        // Extras purchase: no subscription state to poll — show success directly
+        // Extras purchase: no subscription state to poll — show success directly.
+        // Clear any leftover subscription polling session to prevent the resume
+        // path from overriding the extras success banner on next render.
+        this.clearCheckoutPollingSession();
         this.paymentSuccessMessage = this.$t('billing.extras.purchaseSuccess');
         this.scheduleQueryCleanup();
         return false;
@@ -679,13 +689,15 @@ export default {
 
       const { startedAt, snapshotId, snapshotStatus, snapshotPlan } = stored;
 
-      // Validate startedAt to guard against malformed storage data
-      if (typeof startedAt !== 'number' || Number.isNaN(startedAt)) {
+      // Validate startedAt to guard against malformed storage data.
+      // Number.isFinite rejects NaN, Infinity, null, strings, and future timestamps.
+      const now = Date.now();
+      if (!Number.isFinite(startedAt) || startedAt <= 0 || startedAt > now) {
         sessionStorage.removeItem(CHECKOUT_POLL_SESSION_KEY);
         return false;
       }
 
-      const elapsed = Date.now() - startedAt;
+      const elapsed = now - startedAt;
       const remaining = CHECKOUT_POLL_WINDOW_MS - elapsed;
 
       if (remaining <= 0) {

--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -33,7 +33,7 @@
         <span>{{ displayLabel || $t('billing.usage.weeklyUsage') }}</span>
         <span
           class="font-weight-medium billing-usage-bar__admin-label admin-rainbow admin-rainbow--text"
-        >{{ meterUsed != null ? meterUsed : '' }} ∞ Admin</span>
+        >{{ meterUsed != null ? meterUsed : '' }} ∞ {{ $t('billing.usageBar.adminLabel') }}</span>
       </div>
       <div
         class="billing-usage-bar__admin-track admin-rainbow"
@@ -58,7 +58,7 @@
     <template v-else-if="displayMode === 'free'">
       <div class="billing-usage-bar__summary d-flex justify-space-between text-body-medium text-medium-emphasis mb-1" aria-live="polite">
         <span>{{ displayLabel || $t('billing.usage.weeklyUsage') }}</span>
-        <span class="font-weight-medium">0 / {{ freeTierQuota }} compute</span>
+        <span class="font-weight-medium">0 / {{ freeTierQuota }} {{ $t('billing.usageBar.compute') }}</span>
       </div>
       <v-progress-linear
         :model-value="0"
@@ -253,7 +253,7 @@ export default {
      * @returns {string}
      */
     currentDisplay() {
-      if (!this.hasLimit) return 'Unlimited';
+      if (!this.hasLimit) return this.$t('billing.usageBar.unlimited');
       return `${this.current}/${this.limit}`;
     },
 
@@ -291,7 +291,7 @@ export default {
      */
     meterDisplay() {
       if (this.meterOverage > 0) {
-        return `${this.meterUsed} / ${this.meterQuota} (${this.meterNetRemainingRaw} remaining)`;
+        return `${this.meterUsed} / ${this.meterQuota} ${this.$t('billing.usageBar.remaining', { count: this.meterNetRemainingRaw })}`;
       }
       const base = `${this.meterUsed} / ${this.meterQuota}`;
       return this.meterExtras > 0 ? `${base} +${this.meterExtras}` : base;

--- a/src/modules/billing/composables/billing.useCurrencyFormat.js
+++ b/src/modules/billing/composables/billing.useCurrencyFormat.js
@@ -24,11 +24,13 @@ export function useCurrencyFormat() {
 
   /**
    * @desc Format a price amount as USD currency string using locale-aware Intl.NumberFormat.
+   * Falls back to 'en-US' when locale is null, undefined, or empty string.
    * @param {number} amount - Price in dollars (major units)
    * @returns {string} Formatted price string (e.g. '$1,299.00')
    */
   function formatPrice(amount) {
-    return new Intl.NumberFormat(locale.value, { style: 'currency', currency: 'USD' }).format(amount);
+    const localeStr = locale.value || 'en-US';
+    return new Intl.NumberFormat(localeStr, { style: 'currency', currency: 'USD' }).format(amount);
   }
 
   return { formatPrice };

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -95,6 +95,10 @@ export const billingEn = {
       remaining: '({count} remaining)',
       /** i18n key: billing.meterProgress.extras — interpolate {count} */
       extras: '+{count} extras',
+      /** i18n key: billing.meterProgress.ariaOver — interpolate {base}, {used}, {quota}, {overage} */
+      ariaOver: '{base}{used} of {quota} used, {overage} over quota',
+      /** i18n key: billing.meterProgress.ariaUsed — interpolate {base}, {used}, {quota}, {percent} */
+      ariaUsed: '{base}{used} of {quota} used ({percent}%)',
     },
     usageBar: {
       /** i18n key: billing.usageBar.adminLabel — used next to ∞ Admin display */

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -70,6 +70,42 @@ export const billingEn = {
       /** i18n key: billing.equivalences.scrapRun */
       scrapRun: 'operations / week',
     },
+    extrasLedger: {
+      empty: {
+        /** i18n key: billing.extrasLedger.empty.noEntries */
+        noEntries: 'No ledger entries yet',
+      },
+      headers: {
+        /** i18n key: billing.extrasLedger.headers.date */
+        date: 'Date',
+        /** i18n key: billing.extrasLedger.headers.kind */
+        kind: 'Kind',
+        /** i18n key: billing.extrasLedger.headers.amount */
+        amount: 'Amount',
+        /** i18n key: billing.extrasLedger.headers.refHistory */
+        refHistory: 'Ref / History',
+        /** i18n key: billing.extrasLedger.headers.stripeSession */
+        stripeSession: 'Stripe session',
+      },
+    },
+    meterProgress: {
+      /** i18n key: billing.meterProgress.over — interpolate {count} */
+      over: '+{count} over',
+      /** i18n key: billing.meterProgress.remaining — interpolate {count} */
+      remaining: '({count} remaining)',
+      /** i18n key: billing.meterProgress.extras — interpolate {count} */
+      extras: '+{count} extras',
+    },
+    usageBar: {
+      /** i18n key: billing.usageBar.adminLabel — used next to ∞ Admin display */
+      adminLabel: 'Admin',
+      /** i18n key: billing.usageBar.compute — unit label for free-tier display */
+      compute: 'compute',
+      /** i18n key: billing.usageBar.unlimited — legacy mode unlimited label */
+      unlimited: 'Unlimited',
+      /** i18n key: billing.usageBar.remaining — interpolate {count} */
+      remaining: '({count} remaining)',
+    },
     subscriptions: {
       /** i18n key: billing.subscriptions.title */
       title: 'Subscriptions',

--- a/src/modules/billing/lang/fr.js
+++ b/src/modules/billing/lang/fr.js
@@ -95,6 +95,10 @@ export const billingFr = {
       remaining: '({count} restants)',
       /** i18n key: billing.meterProgress.extras — interpolate {count} */
       extras: '+{count} extras',
+      /** i18n key: billing.meterProgress.ariaOver — interpolate {base}, {used}, {quota}, {overage} */
+      ariaOver: '{base}{used} sur {quota} utilises, {overage} de depassement',
+      /** i18n key: billing.meterProgress.ariaUsed — interpolate {base}, {used}, {quota}, {percent} */
+      ariaUsed: '{base}{used} sur {quota} utilises ({percent}%)',
     },
     usageBar: {
       /** i18n key: billing.usageBar.adminLabel — used next to ∞ Admin display */

--- a/src/modules/billing/lang/fr.js
+++ b/src/modules/billing/lang/fr.js
@@ -70,6 +70,42 @@ export const billingFr = {
       /** i18n key: billing.equivalences.scrapRun */
       scrapRun: 'operations / semaine',
     },
+    extrasLedger: {
+      empty: {
+        /** i18n key: billing.extrasLedger.empty.noEntries */
+        noEntries: 'Aucune entree dans le journal',
+      },
+      headers: {
+        /** i18n key: billing.extrasLedger.headers.date */
+        date: 'Date',
+        /** i18n key: billing.extrasLedger.headers.kind */
+        kind: 'Type',
+        /** i18n key: billing.extrasLedger.headers.amount */
+        amount: 'Montant',
+        /** i18n key: billing.extrasLedger.headers.refHistory */
+        refHistory: 'Ref / Historique',
+        /** i18n key: billing.extrasLedger.headers.stripeSession */
+        stripeSession: 'Session Stripe',
+      },
+    },
+    meterProgress: {
+      /** i18n key: billing.meterProgress.over — interpolate {count} */
+      over: '+{count} depassement',
+      /** i18n key: billing.meterProgress.remaining — interpolate {count} */
+      remaining: '({count} restants)',
+      /** i18n key: billing.meterProgress.extras — interpolate {count} */
+      extras: '+{count} extras',
+    },
+    usageBar: {
+      /** i18n key: billing.usageBar.adminLabel — used next to ∞ Admin display */
+      adminLabel: 'Admin',
+      /** i18n key: billing.usageBar.compute — unit label for free-tier display */
+      compute: 'compute',
+      /** i18n key: billing.usageBar.unlimited — legacy mode unlimited label */
+      unlimited: 'Illimite',
+      /** i18n key: billing.usageBar.remaining — interpolate {count} */
+      remaining: '({count} restants)',
+    },
     subscriptions: {
       /** i18n key: billing.subscriptions.title */
       title: 'Abonnements',

--- a/src/modules/billing/tests/__snapshots__/billing.meterProgress.component.unit.tests.js.snap
+++ b/src/modules/billing/tests/__snapshots__/billing.meterProgress.component.unit.tests.js.snap
@@ -10,7 +10,7 @@ exports[`BillingMeterProgressComponent > matches the overage snapshot 1`] = `
     <div class="v-chip__prepend"><i class="fa-solid fa-triangle-exclamation mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--start" aria-hidden="true"></i>
       <!---->
     </div>
-    <div class="v-chip__content" data-no-activator=""> +20 over </div>
+    <div class="v-chip__content" data-no-activator="">+20 over</div>
     <!---->
     <!----></span>
   </div><!-- Bar variant -->
@@ -23,6 +23,6 @@ exports[`BillingMeterProgressComponent > matches the overage snapshot 1`] = `
     </transition-stub>
     <!---->
   </div><!-- Summary text -->
-  <div data-v-f7f25334="" class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1" aria-live="polite"><span data-v-f7f25334="">120 / 100</span><span data-v-f7f25334="" class="text-error"> (-20 remaining)</span></div>
+  <div data-v-f7f25334="" class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1" aria-live="polite"><span data-v-f7f25334="">120 / 100</span><span data-v-f7f25334="" class="text-error">(-20 remaining)</span></div>
 </div>"
 `;

--- a/src/modules/billing/tests/__snapshots__/billing.usageBar.component.unit.tests.js.snap
+++ b/src/modules/billing/tests/__snapshots__/billing.usageBar.component.unit.tests.js.snap
@@ -14,7 +14,7 @@ exports[`BillingUsageBarComponent > matches the meter overage snapshot 1`] = `
       <div class="v-chip__prepend"><i class="fa-solid fa-triangle-exclamation mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--start" aria-hidden="true"></i>
         <!---->
       </div>
-      <div class="v-chip__content" data-no-activator=""> +100 over </div>
+      <div class="v-chip__content" data-no-activator="">+100 over</div>
       <!---->
       <!----></span>
     </div><!-- Bar variant -->
@@ -27,7 +27,7 @@ exports[`BillingUsageBarComponent > matches the meter overage snapshot 1`] = `
       </transition-stub>
       <!---->
     </div><!-- Summary text -->
-    <div data-v-f7f25334="" class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1" aria-live="polite"><span data-v-f7f25334="">1100 / 1000</span><span data-v-f7f25334="" class="text-error"> (-100 remaining)</span></div>
+    <div data-v-f7f25334="" class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1" aria-live="polite"><span data-v-f7f25334="">1100 / 1000</span><span data-v-f7f25334="" class="text-error">(-100 remaining)</span></div>
   </div>
 </div>"
 `;

--- a/src/modules/billing/tests/billing.extrasLedger.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.extrasLedger.component.unit.tests.js
@@ -2,9 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
+import { createI18n } from 'vue-i18n';
 import BillingExtrasLedgerComponent from '../components/billing.extrasLedger.component.vue';
+import { billingEn } from '../lang/en.js';
 
 const vuetify = createVuetify();
+const i18n = createI18n({ legacy: false, globalInjection: true, locale: 'en', fallbackLocale: 'en', messages: { en: { ...billingEn } } });
 
 /** Sample ledger entries covering all entry kinds. */
 const SAMPLE_ENTRIES = [
@@ -53,7 +56,7 @@ const SAMPLE_ENTRIES = [
 const mountComponent = (props) =>
   mount(BillingExtrasLedgerComponent, {
     props,
-    global: { plugins: [vuetify] },
+    global: { plugins: [vuetify, i18n] },
     attachTo: document.body,
   });
 

--- a/src/modules/billing/tests/billing.extrasLedger.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.extrasLedger.component.unit.tests.js
@@ -49,7 +49,8 @@ const SAMPLE_ENTRIES = [
 ];
 
 /**
- * Mount BillingExtrasLedgerComponent with Vuetify and Pinia installed.
+ * Mount BillingExtrasLedgerComponent with Vuetify and i18n installed.
+ * Pinia is activated separately via setActivePinia in beforeEach (not as a plugin).
  * @param {Object} props - Component props
  * @returns {import('@vue/test-utils').VueWrapper}
  */

--- a/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
@@ -2,12 +2,15 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
+import { createI18n } from 'vue-i18n';
 import BillingMeterProgressComponent from '../components/billing.meterProgress.component.vue';
+import { billingEn } from '../lang/en.js';
 
 const vuetify = createVuetify();
+const i18n = createI18n({ legacy: false, globalInjection: true, locale: 'en', fallbackLocale: 'en', messages: { en: { ...billingEn } } });
 
 /**
- * Mount BillingMeterProgressComponent with Vuetify and Pinia installed.
+ * Mount BillingMeterProgressComponent with Vuetify, Pinia, and i18n installed.
  * @param {Object} props - Component props
  * @param {Object} [attrs] Component listeners/attrs.
  * @returns {import('@vue/test-utils').VueWrapper}
@@ -16,7 +19,7 @@ const mountComponent = (props, attrs = {}) =>
   mount(BillingMeterProgressComponent, {
     props,
     attrs,
-    global: { plugins: [vuetify] },
+    global: { plugins: [vuetify, i18n] },
   });
 
 describe('BillingMeterProgressComponent', () => {

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -1041,3 +1041,64 @@ describe('BillingSubscriptionsComponent — visibilitychange subscription refetc
     expect(calls.length).toBeGreaterThan(0);
   });
 });
+
+// ─── Suite 12: V5 edge cases — i18n date formatting + extras/session collision ─
+
+describe('BillingSubscriptionsComponent — V5 edge cases', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    store = useBillingStore();
+    seedMeterStore(store);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    vi.useRealTimers();
+    sessionStorage.clear();
+  });
+
+  it('nextBillingDate uses $i18n.locale for locale-aware date formatting', async () => {
+    store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: '2026-06-15T00:00:00.000Z' };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    // nextBillingDate should be a non-empty formatted date string
+    const dateText = wrapper.vm.nextBillingDate;
+    expect(dateText).not.toBeNull();
+    expect(typeof dateText).toBe('string');
+    expect(dateText.length).toBeGreaterThan(0);
+    // Should include 2026 (the year) and some representation of the date
+    expect(dateText).toContain('2026');
+  });
+
+  it('extras purchase clears any stale sessionStorage polling session', async () => {
+    // Simulate a leftover subscription polling session from a previous navigation
+    sessionStorage.setItem('billing.checkout.polling', JSON.stringify({
+      startedAt: Date.now() - 2000,
+      snapshotId: null,
+      snapshotStatus: null,
+      snapshotPlan: null,
+    }));
+
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: true } },
+      routeQuery: { success: 'true', type: 'extras' },
+    });
+    await flushPromises();
+
+    // Session should be cleared — extras purchase must NOT resume subscription polling
+    expect(sessionStorage.getItem('billing.checkout.polling')).toBeNull();
+    // Extras success message displayed (not processing banner)
+    expect(wrapper.vm.checkoutProcessing).toBe(false);
+    expect(wrapper.text()).toContain('Pack credited to your balance');
+  });
+});

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -803,7 +803,8 @@ describe('BillingSubscriptionsComponent — F5 polling recovery (V5 P1)', () => 
     sessionStorage.clear();
   });
 
-  it('persists polling session to sessionStorage when ?success=true starts polling', async () => {
+  it('persists polling session to sessionStorage with snapshot fields when ?success=true starts polling', async () => {
+    store.subscription = { status: 'active', plan: 'starter', stripeSubscriptionId: 'sub_before' };
     wrapper = mountSubscriptions({
       serverConfig: { billing: { meterMode: false } },
       routeQuery: { success: 'true' },
@@ -815,11 +816,21 @@ describe('BillingSubscriptionsComponent — F5 polling recovery (V5 P1)', () => 
     const parsed = JSON.parse(raw);
     expect(parsed).toHaveProperty('startedAt');
     expect(typeof parsed.startedAt).toBe('number');
+    // Snapshot fields should be persisted for reliable F5 recovery
+    expect(parsed).toHaveProperty('snapshotId', 'sub_before');
+    expect(parsed).toHaveProperty('snapshotStatus', 'active');
+    expect(parsed).toHaveProperty('snapshotPlan', 'starter');
   });
 
-  it('resumes polling when sessionStorage has a valid recent entry (F5 mid-polling)', async () => {
+  it('resumes polling and restores snapshots from sessionStorage (F5 mid-polling)', async () => {
     // Simulate 4 seconds elapsed — still within the 16s window
-    sessionStorage.setItem(SESSION_KEY, JSON.stringify({ startedAt: Date.now() - 4000 }));
+    // Include snapshot fields so baseline is correctly restored
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify({
+      startedAt: Date.now() - 4000,
+      snapshotId: 'sub_before_f5',
+      snapshotStatus: 'active',
+      snapshotPlan: 'starter',
+    }));
     vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
 
     // Mount without ?success query — simulates F5
@@ -833,6 +844,10 @@ describe('BillingSubscriptionsComponent — F5 polling recovery (V5 P1)', () => 
     expect(wrapper.vm.checkoutProcessing).toBe(true);
     // Poll count should start at 2 (4000ms / 2000ms per poll)
     expect(wrapper.vm.checkoutPollCount).toBe(2);
+    // Snapshots restored from storage — not from null store state
+    expect(wrapper.vm.checkoutPollSnapshotId).toBe('sub_before_f5');
+    expect(wrapper.vm.checkoutPollSnapshotStatus).toBe('active');
+    expect(wrapper.vm.checkoutPollSnapshotPlan).toBe('starter');
   });
 
   it('shows processing banner when polling is resumed after F5', async () => {
@@ -846,6 +861,21 @@ describe('BillingSubscriptionsComponent — F5 polling recovery (V5 P1)', () => 
     await flushPromises();
 
     expect(wrapper.text()).toContain('Processing your payment');
+  });
+
+  it('does NOT resume polling when sessionStorage contains malformed startedAt', async () => {
+    // Store malformed data with invalid startedAt
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify({ startedAt: 'not-a-number' }));
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: {},
+    });
+    await flushPromises();
+
+    expect(wrapper.vm.checkoutProcessing).toBe(false);
+    // Session key should be cleared after invalid data detected
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
   });
 
   it('does NOT resume polling when sessionStorage entry is expired (F5 after timeout)', async () => {
@@ -864,7 +894,12 @@ describe('BillingSubscriptionsComponent — F5 polling recovery (V5 P1)', () => 
   });
 
   it('clears sessionStorage on successful subscription activation', async () => {
-    sessionStorage.setItem(SESSION_KEY, JSON.stringify({ startedAt: Date.now() }));
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify({
+      startedAt: Date.now(),
+      snapshotId: null,
+      snapshotStatus: null,
+      snapshotPlan: null,
+    }));
     let callCount = 0;
     vi.spyOn(store, 'fetchSubscription').mockImplementation(async () => {
       callCount += 1;
@@ -929,6 +964,9 @@ describe('BillingSubscriptionsComponent — visibilitychange subscription refetc
     await flushPromises();
 
     const initialCallCount = fetchSpy.mock.calls.length;
+
+    // Advance time past the 500ms debounce window to ensure the visibility refetch is not blocked
+    await vi.advanceTimersByTimeAsync(600);
 
     // Simulate tab becoming visible
     Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -377,6 +377,7 @@ describe('BillingSubscriptionsComponent — checkout success query flow', () => 
     setActivePinia(createPinia());
     vi.useFakeTimers();
     vi.clearAllMocks();
+    sessionStorage.clear();
     store = useBillingStore();
     seedMeterStore(store);
     store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
@@ -386,6 +387,7 @@ describe('BillingSubscriptionsComponent — checkout success query flow', () => 
     wrapper?.unmount();
     wrapper = null;
     vi.useRealTimers();
+    sessionStorage.clear();
   });
 
   it('shows processing state and cleans the URL query on ?success=true (P1-2 polling flow)', async () => {
@@ -490,6 +492,7 @@ describe('BillingSubscriptionsComponent — subscription fetch error (P1-1)', ()
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    sessionStorage.clear();
     store = useBillingStore();
     seedMeterStore(store);
     // Simulate a failed fetchSubscription: error set, subscription remains null
@@ -501,6 +504,7 @@ describe('BillingSubscriptionsComponent — subscription fetch error (P1-1)', ()
   afterEach(() => {
     wrapper?.unmount();
     wrapper = null;
+    sessionStorage.clear();
   });
 
   it('shows error card instead of free-plan fallback when subscriptionError is set', async () => {
@@ -563,6 +567,7 @@ describe('BillingSubscriptionsComponent — checkout success polling (P1-2)', ()
     setActivePinia(createPinia());
     vi.useFakeTimers();
     vi.clearAllMocks();
+    sessionStorage.clear();
     store = useBillingStore();
     seedMeterStore(store);
     store.subscription = null;
@@ -572,6 +577,7 @@ describe('BillingSubscriptionsComponent — checkout success polling (P1-2)', ()
     wrapper?.unmount();
     wrapper = null;
     vi.useRealTimers();
+    sessionStorage.clear();
   });
 
   it('shows processing spinner when ?success=true (non-extras)', async () => {
@@ -719,6 +725,7 @@ describe('BillingSubscriptionsComponent — 409 already-active dialog (Bonus)', 
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    sessionStorage.clear();
     store = useBillingStore();
     seedMeterStore(store);
     store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
@@ -769,5 +776,230 @@ describe('BillingSubscriptionsComponent — 409 already-active dialog (Bonus)', 
     wrapper.vm.showAlreadyActiveDialog(null);
     expect(wrapper.vm.alreadyActiveDialog).toBe(true);
     expect(wrapper.vm.alreadyActivePortalUrl).toBeNull();
+  });
+});
+
+// ─── Suite 10: V5 P1 — F5 mid-polling sessionStorage recovery ────────────────
+
+describe('BillingSubscriptionsComponent — F5 polling recovery (V5 P1)', () => {
+  let wrapper;
+  let store;
+  const SESSION_KEY = 'billing.checkout.polling';
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    store = useBillingStore();
+    seedMeterStore(store);
+    store.subscription = null;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    vi.useRealTimers();
+    sessionStorage.clear();
+  });
+
+  it('persists polling session to sessionStorage when ?success=true starts polling', async () => {
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: { success: 'true' },
+    });
+    await flushPromises();
+
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw);
+    expect(parsed).toHaveProperty('startedAt');
+    expect(typeof parsed.startedAt).toBe('number');
+  });
+
+  it('resumes polling when sessionStorage has a valid recent entry (F5 mid-polling)', async () => {
+    // Simulate 4 seconds elapsed — still within the 16s window
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify({ startedAt: Date.now() - 4000 }));
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+
+    // Mount without ?success query — simulates F5
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: {},
+    });
+    await flushPromises();
+
+    // Should resume processing state
+    expect(wrapper.vm.checkoutProcessing).toBe(true);
+    // Poll count should start at 2 (4000ms / 2000ms per poll)
+    expect(wrapper.vm.checkoutPollCount).toBe(2);
+  });
+
+  it('shows processing banner when polling is resumed after F5', async () => {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify({ startedAt: Date.now() - 2000 }));
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: {},
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Processing your payment');
+  });
+
+  it('does NOT resume polling when sessionStorage entry is expired (F5 after timeout)', async () => {
+    // Simulate 20 seconds elapsed — beyond the 16s window
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify({ startedAt: Date.now() - 20000 }));
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: {},
+    });
+    await flushPromises();
+
+    expect(wrapper.vm.checkoutProcessing).toBe(false);
+    // Session key should be cleared
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it('clears sessionStorage on successful subscription activation', async () => {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify({ startedAt: Date.now() }));
+    let callCount = 0;
+    vi.spyOn(store, 'fetchSubscription').mockImplementation(async () => {
+      callCount += 1;
+      if (callCount >= 1) {
+        store.subscription = { plan: 'starter', status: 'active', stripeSubscriptionId: 'sub_new' };
+      }
+    });
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: {},
+    });
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushPromises();
+
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it('clears sessionStorage on polling timeout', async () => {
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+
+    wrapper = mountSubscriptions({
+      serverConfig: { billing: { meterMode: false } },
+      routeQuery: { success: 'true' },
+    });
+    await flushPromises();
+
+    // Advance 8 × 2s to exhaust polls
+    await vi.advanceTimersByTimeAsync(16000);
+    await flushPromises();
+
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+    expect(wrapper.vm.checkoutTimeout).toBe(true);
+  });
+});
+
+// ─── Suite 11: V5 P2 — subscription store visibility change refetch ───────────
+
+describe('BillingSubscriptionsComponent — visibilitychange subscription refetch (V5 P2)', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    store = useBillingStore();
+    seedMeterStore(store);
+    store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    vi.useRealTimers();
+  });
+
+  it('calls fetchSubscription when tab becomes visible', async () => {
+    const fetchSpy = vi.spyOn(store, 'fetchSubscription').mockResolvedValue(store.subscription);
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    const initialCallCount = fetchSpy.mock.calls.length;
+
+    // Simulate tab becoming visible
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flushPromises();
+
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(initialCallCount);
+  });
+
+  it('does NOT call fetchSubscription when tab becomes hidden', async () => {
+    const fetchSpy = vi.spyOn(store, 'fetchSubscription').mockResolvedValue(store.subscription);
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    const initialCallCount = fetchSpy.mock.calls.length;
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flushPromises();
+
+    expect(fetchSpy.mock.calls.length).toBe(initialCallCount);
+  });
+
+  it('does NOT refetch if already fetched within 500ms debounce', async () => {
+    const fetchSpy = vi.spyOn(store, 'fetchSubscription').mockResolvedValue(store.subscription);
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    // Set subscriptionLastFetchedAt to now (simulating fresh fetch)
+    wrapper.vm.subscriptionLastFetchedAt = Date.now();
+
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flushPromises();
+
+    // Should not have called again within debounce window
+    const callsAfterDebounce = fetchSpy.mock.calls.length;
+    // Advance past debounce
+    await vi.advanceTimersByTimeAsync(600);
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flushPromises();
+
+    // Now it should call
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsAfterDebounce);
+  });
+
+  it('does NOT refetch when checkout polling is active', async () => {
+    const fetchSpy = vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    // Simulate active polling
+    wrapper.vm.checkoutProcessing = true;
+
+    const callCount = fetchSpy.mock.calls.length;
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flushPromises();
+
+    expect(fetchSpy.mock.calls.length).toBe(callCount);
+  });
+
+  it('removes visibilitychange listener on beforeUnmount', async () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    wrapper.unmount();
+    wrapper = null;
+
+    const calls = removeSpy.mock.calls.filter(([evt]) => evt === 'visibilitychange');
+    expect(calls.length).toBeGreaterThan(0);
   });
 });

--- a/src/modules/billing/tests/billing.useCurrencyFormat.unit.tests.js
+++ b/src/modules/billing/tests/billing.useCurrencyFormat.unit.tests.js
@@ -96,4 +96,59 @@ describe('useCurrencyFormat', () => {
     const normalized = frFormatted.replace(/\s/g, ' ');
     expect(normalized).toMatch(/1.299,00/);
   });
+
+  // ── V5 P3: null-guard for locale (avoids Intl.NumberFormat throw) ────────
+
+  it('formatPrice falls back to en-US when locale is empty string', () => {
+    const i18n = createI18n({
+      legacy: false,
+      globalInjection: true,
+      locale: 'en',
+      fallbackLocale: 'en',
+      messages: { en: {}, fr: {} },
+    });
+
+    let result;
+    const Wrapper = defineComponent({
+      setup() {
+        result = useCurrencyFormat();
+        return {};
+      },
+      template: '<div />',
+    });
+
+    mount(Wrapper, { global: { plugins: [i18n] } });
+
+    // Force locale to empty string
+    i18n.global.locale.value = '';
+    // Should not throw and should produce a valid USD-formatted string
+    expect(() => result.formatPrice(100)).not.toThrow();
+    expect(result.formatPrice(100)).toContain('$');
+  });
+
+  it('formatPrice falls back to en-US when locale is null-like', () => {
+    const i18n = createI18n({
+      legacy: false,
+      globalInjection: true,
+      locale: 'en',
+      fallbackLocale: 'en',
+      messages: { en: {}, fr: {} },
+    });
+
+    let result;
+    const Wrapper = defineComponent({
+      setup() {
+        result = useCurrencyFormat();
+        return {};
+      },
+      template: '<div />',
+    });
+
+    mount(Wrapper, { global: { plugins: [i18n] } });
+
+    // Simulate null-like locale (type-coerced via || fallback)
+    i18n.global.locale.value = null;
+    expect(() => result.formatPrice(50)).not.toThrow();
+    expect(result.formatPrice(50)).toContain('$');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes 4 findings from the Codex V5 audit on Vue billing (1 P1 + 2 P2 + 1 P3).

- **P1 (F5 polling recovery)**: persist checkout polling state in `sessionStorage` (`billing.checkout.polling`) so that an F5 reload within the 16s polling window resumes processing instead of silently showing stale data. Cleared on success or timeout. Visibility-change refetch skipped during active polling.
- **P2 (visibility refetch)**: register `visibilitychange` listener in `BillingSubscriptionsComponent.mounted()` — calls `fetchSubscription()` when the tab becomes visible, debounced 500ms. Mirrors the pattern from `useMeter`. Cleaned up in `beforeUnmount`.
- **P2 (i18n residual)**: migrate all remaining hardcoded strings across 4 billing components to `$t()` keys. Headers in `extrasLedger` moved to computed (from `data()`) so `$t` is available reactively. `toLocaleDateString(undefined)` → `this.$i18n.locale`. Added 16 new keys in `en.js` + `fr.js` under `billing.extrasLedger.*`, `billing.meterProgress.*`, `billing.usageBar.*`.
- **P3 (locale null-guard)**: `useCurrencyFormat.formatPrice` falls back to `'en-US'` when `locale.value` is null, undefined, or empty string — prevents `Intl.NumberFormat` from throwing on uninitialised i18n.

## Test plan

- [ ] All 1411 unit tests pass (`npm run test:unit`)
- [ ] Lint clean (`npm run lint`)
- [ ] F5 mid-polling → processing banner visible, polling resumes
- [ ] F5 after 16s timeout → no stale polling resumed
- [ ] Tab switch → `fetchSubscription` called on visibility restore
- [ ] `formatPrice(100)` with `locale.value = null` → no throw, returns `$100.00`
- [ ] Billing components render in FR locale with correct strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-language support (English and French) for billing components including extras ledger, meter progress, and usage displays.
  * Checkout polling now persists across page reloads for improved recovery when resuming interrupted processes.
  * Subscription data automatically refreshes when switching between browser tabs.

* **Bug Fixes**
  * Improved locale handling for date and currency formatting to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->