### PR TITLE
fix(billing): FA6 icons + meterError lifecycle + URL credentials check

### DIFF
--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -493,8 +493,8 @@ export default {
     subscriptionStatusIcon() {
       if (['active', 'trialing'].includes(this.subscriptionStatus)) return 'fa-solid fa-circle-check';
       if (this.subscriptionStatus === 'past_due') return 'fa-solid fa-triangle-exclamation';
-      if (this.subscriptionStatus === 'paused') return 'fa-solid fa-pause-circle';
-      if (this.subscriptionStatus === 'unpaid') return 'fa-solid fa-exclamation-triangle';
+      if (this.subscriptionStatus === 'paused') return 'fa-solid fa-circle-pause';
+      if (this.subscriptionStatus === 'unpaid') return 'fa-solid fa-triangle-exclamation';
       if (['canceled', 'incomplete', 'incomplete_expired'].includes(this.subscriptionStatus)) return 'fa-solid fa-circle-exclamation';
       return 'fa-solid fa-circle-info';
     },

--- a/src/modules/billing/composables/billing.useMeter.js
+++ b/src/modules/billing/composables/billing.useMeter.js
@@ -145,7 +145,6 @@ export function useMeter({ pollIntervalMs = 30000, refreshOnFocus = true } = {})
     });
   };
 
-  meterError.value = null;
   void fetchMissingMeterData(billingStore).catch((err) => {
     console.error('[billing.useMeter] initial fetch failed', err);
     meterError.value = err;

--- a/src/modules/billing/lib/stripeRedirect.js
+++ b/src/modules/billing/lib/stripeRedirect.js
@@ -29,6 +29,9 @@ export function validateStripeUrl(url) {
   if (parsed.protocol !== 'https:') {
     throw new Error('Stripe URL must use HTTPS');
   }
+  if (parsed.username || parsed.password) {
+    throw new Error('Stripe URL must not contain credentials');
+  }
   if (!ALLOWED_HOSTS.includes(parsed.hostname)) {
     throw new Error(`Stripe URL host not allowed: ${parsed.hostname}`);
   }

--- a/src/modules/billing/tests/billing.stripeRedirect.unit.tests.js
+++ b/src/modules/billing/tests/billing.stripeRedirect.unit.tests.js
@@ -82,4 +82,23 @@ describe('validateStripeUrl', () => {
       'Stripe URL host not allowed: evil.com',
     );
   });
+
+  // ── URL credentials (phishing display tricks) ─────────────────────────────
+
+  it('throws when the URL contains a username (userinfo)', () => {
+    expect(() => validateStripeUrl('https://attacker@checkout.stripe.com/foo')).toThrow(
+      'Stripe URL must not contain credentials',
+    );
+  });
+
+  it('throws when the URL contains username and password', () => {
+    expect(() => validateStripeUrl('https://attacker:pass@billing.stripe.com/portal')).toThrow(
+      'Stripe URL must not contain credentials',
+    );
+  });
+
+  it('still accepts a credential-free URL on a whitelisted host', () => {
+    const url = 'https://checkout.stripe.com/pay/cs_test_clean';
+    expect(validateStripeUrl(url)).toBe(url);
+  });
 });

--- a/src/modules/billing/tests/billing.useMeter.unit.tests.js
+++ b/src/modules/billing/tests/billing.useMeter.unit.tests.js
@@ -549,4 +549,23 @@ describe('useMeter composable', () => {
     const { result } = mountMeter({ pollIntervalMs: 0 });
     expect('meterError' in result).toBe(true);
   });
+
+  it('preserves an existing meterError when a new consumer mounts (no unconditional reset)', async () => {
+    // First consumer establishes a baseline; we then simulate an error set by an
+    // earlier failed refresh and assert that mounting a second consumer does NOT
+    // wipe the shared error ref. safeRefresh is the only allowed lifecycle reset.
+    const { result: first } = mountMeter({ pollIntervalMs: 0 });
+    const earlierError = new Error('first consumer error');
+    first.meterError.value = earlierError;
+
+    const { result: second } = mountMeter({ pollIntervalMs: 0 });
+    // Allow microtasks from the second mount's initial fetch to settle
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Both refs are the shared sharedMeterError — second consumer's ref must still
+    // reflect the earlier error, not be reset to null.
+    expect(second.meterError.value).toBe(earlierError);
+    expect(first.meterError.value).toBe(earlierError);
+  });
 });


### PR DESCRIPTION
## Summary

Three small follow-up fixes flagged by CodeRabbit on the billing module after PR #4081 (meterError surfacing). All surgical, scoped to the billing module + its tests.

- **FA6 canonical icons** (`billing.subscriptions.component.vue`): `fa-pause-circle` -> `fa-circle-pause`, `fa-exclamation-triangle` -> `fa-triangle-exclamation`. Aligns with sibling icons already in canonical FA6 form (`fa-circle-check`, `fa-circle-exclamation`). Old FA5 names render as missing glyphs in Vuetify's FA iconset on FA6+.
- **`useMeter` shared error lifecycle** (`composables/billing.useMeter.js`): drop the unconditional `meterError.value = null` on each consumer mount. With the shared `sharedMeterError` ref introduced by #4081, that line wiped errors set by other consumers when a new one mounted. `safeRefresh` (per-attempt clear) and the initial-fetch catch handle the lifecycle correctly.
- **Reject URL credentials in `validateStripeUrl`** (`lib/stripeRedirect.js`): URLs like `https://attacker@checkout.stripe.com/...` passed the protocol + hostname-allowlist checks. The userinfo field could be used for phishing display tricks. Reject any URL with non-empty `parsed.username` or `parsed.password`, between protocol and hostname checks.

## Test plan

- [x] `npm run lint` — 0 issues
- [x] `npm run test:unit` — 1457 tests pass (88 files), incl. 1 new test in `billing.useMeter.unit.tests.js` (preserves existing meterError when a new consumer mounts) and 3 new tests in `billing.stripeRedirect.unit.tests.js` (username-only rejection, username+password rejection, credential-free still passes)
- [x] `npm run build` — succeeds (existing chunk-size + lightningcss `:deep` warnings unrelated)
- [ ] Vuetify renders the new icon names in subscription status badges (visual smoke on a downstream consumer)
- [ ] `validateStripeUrl` rejects credential-laden URLs in prod redirect flow (covered by added unit tests)

CodeRabbit follow-up findings from PR #4081 review on stale commit.