### PR TITLE
fix(billing): clear intentId on Stripe cancel-redirect

### DIFF
--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -78,8 +78,9 @@ const resolveExtrasIntentId = (packId) => {
 /**
  * @desc Clear every persisted extras intentId from sessionStorage.
  * Called after a successful extras purchase so subsequent purchases of the
- * same pack get a fresh UUID. Cancelled flows intentionally do NOT clear,
- * allowing the user to retry with the same idempotency key.
+ * same pack get a fresh UUID. Also called when the user returns from a
+ * cancelled Stripe checkout — Stripe's 24h idempotency cache otherwise
+ * replays the previous (potentially expired or stale) session URL on retry.
  * @returns {void}
  */
 export const clearExtrasIntentIds = () => {
@@ -95,6 +96,24 @@ export const clearExtrasIntentIds = () => {
     for (const key of keys) {
       sessionStorage.removeItem(key);
     }
+  } catch {
+    // sessionStorage unavailable — nothing to clean up
+  }
+};
+
+/**
+ * @desc Clear the persisted intentId for a single pack from sessionStorage.
+ * Used on the Stripe cancel-redirect path so a retry of that specific pack
+ * generates a fresh UUID — without touching intent IDs of other packs the
+ * user may have started purchasing in parallel tabs.
+ * @param {string} packId
+ * @returns {void}
+ */
+export const clearExtrasIntentId = (packId) => {
+  if (!packId) return;
+  try {
+    if (typeof sessionStorage === 'undefined') return;
+    sessionStorage.removeItem(extrasIntentKey(packId));
   } catch {
     // sessionStorage unavailable — nothing to clean up
   }
@@ -325,7 +344,11 @@ export const useBillingStore = defineStore('billing', {
       try {
         const api = apiBase();
         const successUrl = `${window.location.origin}/users?tab=subscriptions&success=true&type=extras`;
-        const cancelUrl = `${window.location.origin}/pricing?canceled=true#units`;
+        // type=extras + pack={packId} let the pricing view drop the persisted
+        // intentId on cancel-redirect so the next attempt generates a fresh
+        // UUID — Stripe's 24h idempotency cache would otherwise replay the
+        // previous (possibly expired) session URL.
+        const cancelUrl = `${window.location.origin}/pricing?canceled=true&type=extras&pack=${encodeURIComponent(packId)}#units`;
         const intentId = resolveExtrasIntentId(packId);
         const res = await axios.post(`${api}/${config.api.endPoints.billing}/extras/checkout`, {
           packId,

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+
+// ─── Prevent real HTTP calls ────────────────────────────────────────────────
+
+vi.mock('../../../lib/services/axios', () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock('../../../lib/helpers/analytics', () => ({
+  capture: vi.fn(),
+}));
+
+// ─── Mutable auth store state ───────────────────────────────────────────────
+
+const authState = vi.hoisted(() => ({
+  isLoggedIn: true,
+  user: null,
+  serverConfig: null,
+}));
+
+vi.mock('../../auth/stores/auth.store', () => ({
+  useAuthStore: () => authState,
+}));
+
+// ─── Imports (after mocks) ──────────────────────────────────────────────────
+
+import { createI18n } from 'vue-i18n';
+import { useBillingStore } from '../stores/billing.store';
+import BillingPricingView from '../views/billing.pricing.view.vue';
+import { billingEn } from '../lang/en.js';
+
+const i18n = createI18n({ legacy: false, globalInjection: true, locale: 'en', fallbackLocale: 'en', messages: { en: { ...billingEn } } });
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const mockConfig = {
+  api: {
+    protocol: 'http',
+    host: 'localhost',
+    port: '3000',
+    base: 'api',
+    endPoints: { billing: 'billing' },
+  },
+  vuetify: { theme: { rounded: '', flat: true, maxWidth: '1200px' } },
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const vuetify = createVuetify();
+
+const componentStubs = {
+  RouterLink: true,
+  BillingPricingToggleComponent: true,
+  BillingPricingCardComponent: true,
+  BillingPacksComponent: true,
+  HomeTabsComponent: true,
+};
+
+/**
+ * @desc Mount BillingPricingView with Vuetify + Pinia + custom $route.
+ * @param {Object} [opts]
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+function mountPricing({
+  serverConfig = { billing: { meterMode: true } },
+  isLoggedIn = true,
+  routeQuery = {},
+  routeHash = '',
+  router = { replace: vi.fn(), push: vi.fn() },
+} = {}) {
+  authState.serverConfig = serverConfig;
+  authState.isLoggedIn = isLoggedIn;
+  return mount(BillingPricingView, {
+    global: {
+      plugins: [vuetify, i18n],
+      mocks: {
+        config: mockConfig,
+        $route: { path: '/pricing', hash: routeHash, query: routeQuery },
+        $router: router,
+      },
+      stubs: componentStubs,
+    },
+  });
+}
+
+function seedStore(store) {
+  vi.spyOn(store, 'fetchPlans').mockResolvedValue([]);
+  vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+}
+
+// ─── Suite: Stripe cancel-redirect — intentId cleanup ───────────────────────
+
+describe('BillingPricingView — Stripe cancel-redirect intentId cleanup', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    store = useBillingStore();
+    seedStore(store);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    sessionStorage.clear();
+  });
+
+  it('clears the per-pack intentId when ?canceled=true&type=extras&pack=pack_500', async () => {
+    sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-stale');
+    sessionStorage.setItem('billing.extras.intentId.pack_2000', 'uuid-other');
+    const router = { replace: vi.fn(), push: vi.fn() };
+
+    wrapper = mountPricing({
+      routeQuery: { canceled: 'true', type: 'extras', pack: 'pack_500' },
+      routeHash: '#units',
+      router,
+    });
+    await flushPromises();
+
+    // Targeted pack key cleared, sibling preserved
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBeNull();
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_2000')).toBe('uuid-other');
+    // Cancel alert still shown
+    expect(wrapper.vm.checkoutCanceled).toBe(true);
+    // URL stripped of type/pack, canceled + hash preserved
+    expect(router.replace).toHaveBeenCalledWith({
+      path: '/pricing',
+      hash: '#units',
+      query: { canceled: 'true' },
+    });
+  });
+
+  it('falls back to clearing all extras intentIds when pack is missing', async () => {
+    sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+    sessionStorage.setItem('billing.extras.intentId.pack_2000', 'uuid-b');
+    sessionStorage.setItem('unrelated', 'keep-me');
+    const router = { replace: vi.fn(), push: vi.fn() };
+
+    wrapper = mountPricing({
+      routeQuery: { canceled: 'true', type: 'extras' },
+      routeHash: '#units',
+      router,
+    });
+    await flushPromises();
+
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBeNull();
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_2000')).toBeNull();
+    expect(sessionStorage.getItem('unrelated')).toBe('keep-me');
+    expect(wrapper.vm.checkoutCanceled).toBe(true);
+  });
+
+  it('does NOT clear intentIds when type is not extras (subscription cancel)', async () => {
+    sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+    const router = { replace: vi.fn(), push: vi.fn() };
+
+    wrapper = mountPricing({
+      routeQuery: { canceled: 'true' },
+      router,
+    });
+    await flushPromises();
+
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBe('uuid-a');
+    expect(wrapper.vm.checkoutCanceled).toBe(true);
+    // No URL rewrite for the subscription-cancel path (legacy behaviour preserved)
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('does NOT clear intentIds and does NOT show cancel banner when canceled is absent', async () => {
+    sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+    const router = { replace: vi.fn(), push: vi.fn() };
+
+    wrapper = mountPricing({ routeQuery: {}, router });
+    await flushPromises();
+
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBe('uuid-a');
+    expect(wrapper.vm.checkoutCanceled).toBe(false);
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('selects the units tab when hash is #units (regression check)', async () => {
+    wrapper = mountPricing({ routeQuery: {}, routeHash: '#units' });
+    await flushPromises();
+    expect(wrapper.vm.activeTab).toBe(1);
+  });
+});

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -86,6 +86,11 @@ function mountPricing({
   });
 }
 
+/**
+ * @desc Seed the billing store with no-op mocks so mounted views don't issue real fetches.
+ * @param {ReturnType<typeof useBillingStore>} store - Billing store instance from useBillingStore()
+ * @returns {void}
+ */
 function seedStore(store) {
   vi.spyOn(store, 'fetchPlans').mockResolvedValue([]);
   vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
@@ -152,6 +157,12 @@ describe('BillingPricingView — Stripe cancel-redirect intentId cleanup', () =>
     expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBeNull();
     expect(sessionStorage.getItem('billing.extras.intentId.pack_2000')).toBeNull();
     expect(sessionStorage.getItem('unrelated')).toBe('keep-me');
+    // URL stripped of type, canceled + hash preserved
+    expect(router.replace).toHaveBeenCalledWith({
+      path: '/pricing',
+      hash: '#units',
+      query: { canceled: 'true' },
+    });
     expect(wrapper.vm.checkoutCanceled).toBe(true);
   });
 

--- a/src/modules/billing/tests/billing.store.unit.tests.js
+++ b/src/modules/billing/tests/billing.store.unit.tests.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
-import { useBillingStore, clearExtrasIntentIds } from '../stores/billing.store';
+import { useBillingStore, clearExtrasIntentIds, clearExtrasIntentId } from '../stores/billing.store';
 import axios from '../../../lib/services/axios';
 
 // Mock axios
@@ -474,7 +474,7 @@ describe('Billing Store', () => {
         expect.objectContaining({
           packId: 'pack_500',
           successUrl: 'https://app.example.com/users?tab=subscriptions&success=true&type=extras',
-          cancelUrl: 'https://app.example.com/pricing?canceled=true#units',
+          cancelUrl: 'https://app.example.com/pricing?canceled=true&type=extras&pack=pack_500#units',
         }),
       );
       expect(window.location.assign).toHaveBeenCalledWith(checkoutUrl);
@@ -685,6 +685,43 @@ describe('Billing Store', () => {
       sessionStorage.setItem('unrelated', 'keep-me');
       expect(() => clearExtrasIntentIds()).not.toThrow();
       expect(sessionStorage.getItem('unrelated')).toBe('keep-me');
+    });
+  });
+
+  describe('clearExtrasIntentId (per-pack)', () => {
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+    afterEach(() => {
+      sessionStorage.clear();
+    });
+
+    it('removes only the targeted pack key, leaves siblings intact', () => {
+      sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+      sessionStorage.setItem('billing.extras.intentId.pack_2000', 'uuid-b');
+      sessionStorage.setItem('unrelated', 'keep-me');
+
+      clearExtrasIntentId('pack_500');
+
+      expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBeNull();
+      expect(sessionStorage.getItem('billing.extras.intentId.pack_2000')).toBe('uuid-b');
+      expect(sessionStorage.getItem('unrelated')).toBe('keep-me');
+    });
+
+    it('is a no-op when packId is empty / undefined', () => {
+      sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+      expect(() => clearExtrasIntentId(undefined)).not.toThrow();
+      expect(() => clearExtrasIntentId('')).not.toThrow();
+      expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBe('uuid-a');
+    });
+
+    it('does not throw when sessionStorage.removeItem throws', () => {
+      sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+      const removeSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+        throw new Error('SecurityError');
+      });
+      expect(() => clearExtrasIntentId('pack_500')).not.toThrow();
+      removeSpy.mockRestore();
     });
   });
 });

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -144,7 +144,7 @@
 /**
  * Module dependencies.
  */
-import { useBillingStore } from '../stores/billing.store';
+import { useBillingStore, clearExtrasIntentId, clearExtrasIntentIds } from '../stores/billing.store';
 import { useAuthStore } from '../../auth/stores/auth.store';
 import { plans as plansConfig } from '../config/billing.static-content';
 import { validateStripeUrl } from '../lib/stripeRedirect';
@@ -294,8 +294,22 @@ export default {
     }
 
     // Handle Stripe redirect query params — success always redirects to /users, never back here
-    const { canceled } = this.$route.query;
-    if (canceled === 'true') this.checkoutCanceled = true;
+    const { canceled, type, pack } = this.$route.query;
+    if (canceled === 'true') {
+      this.checkoutCanceled = true;
+      // Extras cancel-redirect: drop the persisted per-pack intentId so a retry
+      // generates a fresh UUID. Without this, Stripe's 24h idempotency cache
+      // replays the previous session URL — which may be expired or carry the
+      // stale successUrl/pack from the first attempt.
+      if (type === 'extras') {
+        if (pack) clearExtrasIntentId(pack);
+        else clearExtrasIntentIds();
+        // Strip the cancel-detection params from the URL so a refresh does not
+        // re-clear (no-op anyway) and so the address bar stays clean. Hash is
+        // preserved so the active tab (#units) is reflected.
+        this.$router.replace({ path: this.$route.path, hash: this.$route.hash, query: { canceled: 'true' } });
+      }
+    }
     if (this.$route.hash === '#units') this.activeTab = 1;
   },
   methods: {


### PR DESCRIPTION
## Summary

Day-1 UX bug from PR #4084: when a user clicks Buy → Stripe → cancels → returns → clicks Buy again, the same per-pack intentId was reused, causing Stripe's 24h idempotency cache to replay the previous session URL. That URL might be expired (\"Session expired\" page) or carry the stale \`successUrl\`/\`cancelUrl\`/\`pack\` from the first attempt.

The doc on \`clearExtrasIntentIds\` previously said \"Cancelled flows intentionally do NOT clear, allowing the user to retry with the same idempotency key.\" — that policy was wrong: idempotent retry only helps within the same minute against double-click, but it actively breaks the cancel-and-retry flow against Stripe's full-response replay.

## Changes

- **\`billing.store.js\`** — \`createExtrasCheckout\` cancelUrl now carries \`type=extras&pack={packId}\` so the landing pricing view can scope cleanup. Added \`clearExtrasIntentId(packId)\` helper for per-pack clearing (parallel pack purchases in separate tabs stay independent).
- **\`billing.pricing.view.vue\`** — \`created()\` already detected \`canceled === 'true'\`. Now also calls \`clearExtrasIntentId(pack)\` (or \`clearExtrasIntentIds()\` as fallback when the param is missing) when \`type === 'extras'\`. URL is cleaned of \`type\`/\`pack\` while keeping \`canceled\` + hash so the cancel banner still renders.
- **Tests** — new \`billing.pricing.view.unit.tests.js\` (5 cases: per-pack clear, fallback, type filter, no-canceled regression, hash tab regression). Extended \`billing.store.unit.tests.js\` with the new cancelUrl shape + \`clearExtrasIntentId\` describe block.

## Deviation from the original task brief

The brief asked to put cancel detection in \`billing.subscriptions.component.vue\`. Reading the existing code: \`cancelUrl\` lands on \`/pricing?canceled=true#units\`, **not** on the subscriptions page (that's only the \`successUrl\`). Putting cancel detection in the subscriptions component would be dead code. The pricing view was already doing \`if (canceled === 'true')\` in \`created()\` — the cleanup branch lives next to that, where the user actually lands.

## Test plan

- [x] \`npm run lint\` — 0 issues
- [x] \`npm run test:unit\` — 1473 passed (+ new pricing view suite)
- [x] \`npm run build\` — green
- [ ] Manual smoke: extras checkout → cancel on Stripe → verify sessionStorage \`billing.extras.intentId.{pack}\` is cleared on /pricing landing → click Buy again → fresh Stripe session URL (different intentId in network tab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Stripe checkout cancellation for add-ons. When users cancel an add-on purchase, the system now properly clears associated state, allowing seamless retry attempts without stale data interfering with new checkout sessions.

* **Tests**
  * Added comprehensive test coverage for billing cancellation workflows, including scenarios for add-on cancellations and state cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->