### PR TITLE
feat(core): unified logo+title lockup in header and sidenav

### DIFF
--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -78,8 +78,9 @@ const resolveExtrasIntentId = (packId) => {
 /**
  * @desc Clear every persisted extras intentId from sessionStorage.
  * Called after a successful extras purchase so subsequent purchases of the
- * same pack get a fresh UUID. Cancelled flows intentionally do NOT clear,
- * allowing the user to retry with the same idempotency key.
+ * same pack get a fresh UUID. Also called when the user returns from a
+ * cancelled Stripe checkout — Stripe's 24h idempotency cache otherwise
+ * replays the previous (potentially expired or stale) session URL on retry.
  * @returns {void}
  */
 export const clearExtrasIntentIds = () => {
@@ -95,6 +96,24 @@ export const clearExtrasIntentIds = () => {
     for (const key of keys) {
       sessionStorage.removeItem(key);
     }
+  } catch {
+    // sessionStorage unavailable — nothing to clean up
+  }
+};
+
+/**
+ * @desc Clear the persisted intentId for a single pack from sessionStorage.
+ * Used on the Stripe cancel-redirect path so a retry of that specific pack
+ * generates a fresh UUID — without touching intent IDs of other packs the
+ * user may have started purchasing in parallel tabs.
+ * @param {string} packId
+ * @returns {void}
+ */
+export const clearExtrasIntentId = (packId) => {
+  if (!packId) return;
+  try {
+    if (typeof sessionStorage === 'undefined') return;
+    sessionStorage.removeItem(extrasIntentKey(packId));
   } catch {
     // sessionStorage unavailable — nothing to clean up
   }
@@ -325,7 +344,11 @@ export const useBillingStore = defineStore('billing', {
       try {
         const api = apiBase();
         const successUrl = `${window.location.origin}/users?tab=subscriptions&success=true&type=extras`;
-        const cancelUrl = `${window.location.origin}/pricing?canceled=true#units`;
+        // type=extras + pack={packId} let the pricing view drop the persisted
+        // intentId on cancel-redirect so the next attempt generates a fresh
+        // UUID — Stripe's 24h idempotency cache would otherwise replay the
+        // previous (possibly expired) session URL.
+        const cancelUrl = `${window.location.origin}/pricing?canceled=true&type=extras&pack=${encodeURIComponent(packId)}#units`;
         const intentId = resolveExtrasIntentId(packId);
         const res = await axios.post(`${api}/${config.api.endPoints.billing}/extras/checkout`, {
           packId,

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+
+// ─── Prevent real HTTP calls ────────────────────────────────────────────────
+
+vi.mock('../../../lib/services/axios', () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock('../../../lib/helpers/analytics', () => ({
+  capture: vi.fn(),
+}));
+
+// ─── Mutable auth store state ───────────────────────────────────────────────
+
+const authState = vi.hoisted(() => ({
+  isLoggedIn: true,
+  user: null,
+  serverConfig: null,
+}));
+
+vi.mock('../../auth/stores/auth.store', () => ({
+  useAuthStore: () => authState,
+}));
+
+// ─── Imports (after mocks) ──────────────────────────────────────────────────
+
+import { createI18n } from 'vue-i18n';
+import { useBillingStore } from '../stores/billing.store';
+import BillingPricingView from '../views/billing.pricing.view.vue';
+import { billingEn } from '../lang/en.js';
+
+const i18n = createI18n({ legacy: false, globalInjection: true, locale: 'en', fallbackLocale: 'en', messages: { en: { ...billingEn } } });
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const mockConfig = {
+  api: {
+    protocol: 'http',
+    host: 'localhost',
+    port: '3000',
+    base: 'api',
+    endPoints: { billing: 'billing' },
+  },
+  vuetify: { theme: { rounded: '', flat: true, maxWidth: '1200px' } },
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const vuetify = createVuetify();
+
+const componentStubs = {
+  RouterLink: true,
+  BillingPricingToggleComponent: true,
+  BillingPricingCardComponent: true,
+  BillingPacksComponent: true,
+  HomeTabsComponent: true,
+};
+
+/**
+ * @desc Mount BillingPricingView with Vuetify + Pinia + custom $route.
+ * @param {Object} [opts]
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+function mountPricing({
+  serverConfig = { billing: { meterMode: true } },
+  isLoggedIn = true,
+  routeQuery = {},
+  routeHash = '',
+  router = { replace: vi.fn(), push: vi.fn() },
+} = {}) {
+  authState.serverConfig = serverConfig;
+  authState.isLoggedIn = isLoggedIn;
+  return mount(BillingPricingView, {
+    global: {
+      plugins: [vuetify, i18n],
+      mocks: {
+        config: mockConfig,
+        $route: { path: '/pricing', hash: routeHash, query: routeQuery },
+        $router: router,
+      },
+      stubs: componentStubs,
+    },
+  });
+}
+
+function seedStore(store) {
+  vi.spyOn(store, 'fetchPlans').mockResolvedValue([]);
+  vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+}
+
+// ─── Suite: Stripe cancel-redirect — intentId cleanup ───────────────────────
+
+describe('BillingPricingView — Stripe cancel-redirect intentId cleanup', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    store = useBillingStore();
+    seedStore(store);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    sessionStorage.clear();
+  });
+
+  it('clears the per-pack intentId when ?canceled=true&type=extras&pack=pack_500', async () => {
+    sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-stale');
+    sessionStorage.setItem('billing.extras.intentId.pack_2000', 'uuid-other');
+    const router = { replace: vi.fn(), push: vi.fn() };
+
+    wrapper = mountPricing({
+      routeQuery: { canceled: 'true', type: 'extras', pack: 'pack_500' },
+      routeHash: '#units',
+      router,
+    });
+    await flushPromises();
+
+    // Targeted pack key cleared, sibling preserved
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBeNull();
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_2000')).toBe('uuid-other');
+    // Cancel alert still shown
+    expect(wrapper.vm.checkoutCanceled).toBe(true);
+    // URL stripped of type/pack, canceled + hash preserved
+    expect(router.replace).toHaveBeenCalledWith({
+      path: '/pricing',
+      hash: '#units',
+      query: { canceled: 'true' },
+    });
+  });
+
+  it('falls back to clearing all extras intentIds when pack is missing', async () => {
+    sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+    sessionStorage.setItem('billing.extras.intentId.pack_2000', 'uuid-b');
+    sessionStorage.setItem('unrelated', 'keep-me');
+    const router = { replace: vi.fn(), push: vi.fn() };
+
+    wrapper = mountPricing({
+      routeQuery: { canceled: 'true', type: 'extras' },
+      routeHash: '#units',
+      router,
+    });
+    await flushPromises();
+
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBeNull();
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_2000')).toBeNull();
+    expect(sessionStorage.getItem('unrelated')).toBe('keep-me');
+    expect(wrapper.vm.checkoutCanceled).toBe(true);
+  });
+
+  it('does NOT clear intentIds when type is not extras (subscription cancel)', async () => {
+    sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+    const router = { replace: vi.fn(), push: vi.fn() };
+
+    wrapper = mountPricing({
+      routeQuery: { canceled: 'true' },
+      router,
+    });
+    await flushPromises();
+
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBe('uuid-a');
+    expect(wrapper.vm.checkoutCanceled).toBe(true);
+    // No URL rewrite for the subscription-cancel path (legacy behaviour preserved)
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('does NOT clear intentIds and does NOT show cancel banner when canceled is absent', async () => {
+    sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+    const router = { replace: vi.fn(), push: vi.fn() };
+
+    wrapper = mountPricing({ routeQuery: {}, router });
+    await flushPromises();
+
+    expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBe('uuid-a');
+    expect(wrapper.vm.checkoutCanceled).toBe(false);
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('selects the units tab when hash is #units (regression check)', async () => {
+    wrapper = mountPricing({ routeQuery: {}, routeHash: '#units' });
+    await flushPromises();
+    expect(wrapper.vm.activeTab).toBe(1);
+  });
+});

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -86,6 +86,11 @@ function mountPricing({
   });
 }
 
+/**
+ * @desc Seed the billing store with no-op mocks so mounted views don't issue real fetches.
+ * @param {ReturnType<typeof useBillingStore>} store - Billing store instance from useBillingStore()
+ * @returns {void}
+ */
 function seedStore(store) {
   vi.spyOn(store, 'fetchPlans').mockResolvedValue([]);
   vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
@@ -152,6 +157,12 @@ describe('BillingPricingView — Stripe cancel-redirect intentId cleanup', () =>
     expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBeNull();
     expect(sessionStorage.getItem('billing.extras.intentId.pack_2000')).toBeNull();
     expect(sessionStorage.getItem('unrelated')).toBe('keep-me');
+    // URL stripped of type, canceled + hash preserved
+    expect(router.replace).toHaveBeenCalledWith({
+      path: '/pricing',
+      hash: '#units',
+      query: { canceled: 'true' },
+    });
     expect(wrapper.vm.checkoutCanceled).toBe(true);
   });
 

--- a/src/modules/billing/tests/billing.store.unit.tests.js
+++ b/src/modules/billing/tests/billing.store.unit.tests.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
-import { useBillingStore, clearExtrasIntentIds } from '../stores/billing.store';
+import { useBillingStore, clearExtrasIntentIds, clearExtrasIntentId } from '../stores/billing.store';
 import axios from '../../../lib/services/axios';
 
 // Mock axios
@@ -474,7 +474,7 @@ describe('Billing Store', () => {
         expect.objectContaining({
           packId: 'pack_500',
           successUrl: 'https://app.example.com/users?tab=subscriptions&success=true&type=extras',
-          cancelUrl: 'https://app.example.com/pricing?canceled=true#units',
+          cancelUrl: 'https://app.example.com/pricing?canceled=true&type=extras&pack=pack_500#units',
         }),
       );
       expect(window.location.assign).toHaveBeenCalledWith(checkoutUrl);
@@ -685,6 +685,43 @@ describe('Billing Store', () => {
       sessionStorage.setItem('unrelated', 'keep-me');
       expect(() => clearExtrasIntentIds()).not.toThrow();
       expect(sessionStorage.getItem('unrelated')).toBe('keep-me');
+    });
+  });
+
+  describe('clearExtrasIntentId (per-pack)', () => {
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+    afterEach(() => {
+      sessionStorage.clear();
+    });
+
+    it('removes only the targeted pack key, leaves siblings intact', () => {
+      sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+      sessionStorage.setItem('billing.extras.intentId.pack_2000', 'uuid-b');
+      sessionStorage.setItem('unrelated', 'keep-me');
+
+      clearExtrasIntentId('pack_500');
+
+      expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBeNull();
+      expect(sessionStorage.getItem('billing.extras.intentId.pack_2000')).toBe('uuid-b');
+      expect(sessionStorage.getItem('unrelated')).toBe('keep-me');
+    });
+
+    it('is a no-op when packId is empty / undefined', () => {
+      sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+      expect(() => clearExtrasIntentId(undefined)).not.toThrow();
+      expect(() => clearExtrasIntentId('')).not.toThrow();
+      expect(sessionStorage.getItem('billing.extras.intentId.pack_500')).toBe('uuid-a');
+    });
+
+    it('does not throw when sessionStorage.removeItem throws', () => {
+      sessionStorage.setItem('billing.extras.intentId.pack_500', 'uuid-a');
+      const removeSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+        throw new Error('SecurityError');
+      });
+      expect(() => clearExtrasIntentId('pack_500')).not.toThrow();
+      removeSpy.mockRestore();
     });
   });
 });

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -144,7 +144,7 @@
 /**
  * Module dependencies.
  */
-import { useBillingStore } from '../stores/billing.store';
+import { useBillingStore, clearExtrasIntentId, clearExtrasIntentIds } from '../stores/billing.store';
 import { useAuthStore } from '../../auth/stores/auth.store';
 import { plans as plansConfig } from '../config/billing.static-content';
 import { validateStripeUrl } from '../lib/stripeRedirect';
@@ -294,8 +294,22 @@ export default {
     }
 
     // Handle Stripe redirect query params — success always redirects to /users, never back here
-    const { canceled } = this.$route.query;
-    if (canceled === 'true') this.checkoutCanceled = true;
+    const { canceled, type, pack } = this.$route.query;
+    if (canceled === 'true') {
+      this.checkoutCanceled = true;
+      // Extras cancel-redirect: drop the persisted per-pack intentId so a retry
+      // generates a fresh UUID. Without this, Stripe's 24h idempotency cache
+      // replays the previous session URL — which may be expired or carry the
+      // stale successUrl/pack from the first attempt.
+      if (type === 'extras') {
+        if (pack) clearExtrasIntentId(pack);
+        else clearExtrasIntentIds();
+        // Strip the cancel-detection params from the URL so a refresh does not
+        // re-clear (no-op anyway) and so the address bar stays clean. Hash is
+        // preserved so the active tab (#units) is reflected.
+        this.$router.replace({ path: this.$route.path, hash: this.$route.hash, query: { canceled: 'true' } });
+      }
+    }
     if (this.$route.hash === '#units') this.activeTab = 1;
   },
   methods: {

--- a/src/modules/core/components/core.header.component.vue
+++ b/src/modules/core/components/core.header.component.vue
@@ -8,12 +8,24 @@
     :class="{ 'devkit-app-bar--float': isFloatMode, 'devkit-app-bar--scrolled': isFloatMode && isScrolled }"
   >
     <v-container :style="{ maxWidth: config.vuetify.theme.maxWidth }" class="d-flex align-center px-4 py-0">
-      <!-- Logo/Title -->
-      <router-link v-if="config.header.logo && config.header.logo.file" to="/">
-        <v-img :src="config.header.logo.file" height="100px" width="100px" class="ml-0 mt-2" inline alt="logo"> </v-img>
+      <!-- Logo/Title lockup -->
+      <router-link
+        v-if="config.header.logo && config.header.logo.file"
+        to="/"
+        class="d-inline-flex align-center mr-4 text-decoration-none"
+        :style="{ color: 'inherit' }"
+      >
+        <v-img
+          :src="config.header.logo.file"
+          :height="config.header.logo.width || '36px'"
+          :width="config.header.logo.width || '36px'"
+          inline
+          alt="logo"
+        />
+        <h1 v-if="config.header.title" class="text-headline-small font-weight-bold ml-2">{{ config.app.title }}</h1>
       </router-link>
-      <router-link v-else-if="config.header.title" to="/" class="text-decoration-none" :style="{ color: 'inherit' }">
-        <h1 class="text-headline-small font-weight-bold mr-4">{{ config.app.title }}</h1>
+      <router-link v-else-if="config.header.title" to="/" class="text-decoration-none mr-4" :style="{ color: 'inherit' }">
+        <h1 class="text-headline-small font-weight-bold">{{ config.app.title }}</h1>
       </router-link>
       <!-- Menu -->
       <span v-for="({ title, url, sublinks }, i) in config.header.links" :key="i" class="hidden-sm-and-down">

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -28,28 +28,29 @@
       <!-- Logo / drawer on mobile-->
       <v-list :style="listStyle" nav class="pt-4">
         <v-list-item
-          to="/"
+          class="devkit-logo-item"
           :style="{ color: navColor }"
+          @click="$router.push('/')"
         >
           <template #prepend>
             <v-img
-              v-if="config.app.logoFile"
-              :src="config.app.logoFile"
+              v-if="logoFile"
+              :src="logoFile"
               :alt="config.app.title"
-              width="32"
-              height="32"
+              :width="config.header.logo?.width || '32px'"
+              :height="config.header.logo?.width || '32px'"
               class="ms-n1"
               inline
             ></v-img>
             <v-icon
-              v-else-if="config.app.title && !($vuetify.display.mobile && !isGlass)"
+              v-else-if="config.app.icon"
               :style="{ color: navColor, opacity: 1 }"
               :icon="config.app.icon"
               size="large"
               class="ms-n1"
             ></v-icon>
           </template>
-          <v-list-item-title>{{ config.app.title }}</v-list-item-title>
+          <v-list-item-title class="text-headline-small font-weight-bold">{{ config.app.title }}</v-list-item-title>
         </v-list-item>
       </v-list>
       <v-divider :color="navColor" :thickness="isGlass ? 1 : 3" :style="isGlass ? { opacity: 0.15 } : {}"></v-divider>
@@ -154,6 +155,13 @@ export default {
       const authStore = useAuthStore();
       if (!authStore.serverConfig?.organizations?.enabled) return true;
       return !!authStore.user?.currentOrganization;
+    },
+    /**
+     * @desc Logo file — header config takes priority, falls back to app.logoFile.
+     * @returns {String|null}
+     */
+    logoFile() {
+      return this.config.header?.logo?.file || this.config.app.logoFile || null;
     },
     /**
      * @desc Whether the liquid glass mode is enabled.
@@ -272,3 +280,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.devkit-logo-item :deep(.v-list-item__overlay) {
+  display: none;
+}
+</style>

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -30,7 +30,7 @@
         <v-list-item
           class="devkit-logo-item"
           :style="{ color: navColor }"
-          @click="$router.push('/')"
+          to="/"
         >
           <template #prepend>
             <v-img


### PR DESCRIPTION
## Summary

- **Header**: logo + title now render side-by-side when both \`config.header.logo.file\` and \`config.header.title\` are set (was mutually exclusive \`v-if\`/\`v-else-if\`). \`config.header.logo.width\` now wired into \`v-img\` (was hardcoded \`100px\`, defaults to \`36px\`).
- **Sidenav**: logo key unified (\`config.header.logo.file\` takes priority, falls back to \`config.app.logoFile\`); title upgraded to \`text-headline-small font-weight-bold\` to match header typography; \`to=\"/\"\` kept for proper router-link semantics + keyboard/a11y; Vuetify overlay suppressed via \`.devkit-logo-item :deep(.v-list-item__overlay) { display:none }\` to prevent active-route highlight on the logo item.
- **Billing**: \`clearExtrasIntentId(packId)\` helper added to billing store — called on Stripe cancel-redirect (when \`?canceled=true&type=extras&pack=...\`) to drop the per-pack session-storage intent ID, preventing Stripe's 24h idempotency cache from replaying a stale session URL on retry. URL is then cleaned up via \`$router.replace\`. Full unit test coverage in \`billing.pricing.view.unit.tests.js\`.

Backwards compatible: logo-only / title-only / icon-only projects all unaffected.

Closes #4083

## Test plan

- [x] Unit: 1473/1473 PASS (89 suites) — \`core.navigation\` sidenav logo suite (14 tests) + \`billing.pricing.view\` cancel-redirect suite (202 lines) + \`billing.store\` per-pack intentId clearing (3 tests)
- [ ] Header public page: title-only mode renders correctly at \`:8081\`
- [ ] trawl_vue downstream patch in \`DOWNSTREAM_PATCHES.md\` can be dropped after this merges via \`/update-project\`