### PR TITLE
feat(feature): read ERRORS.md in Phase 0 before coding

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -16,6 +16,8 @@ description: >
 
 ### 1. Identify target module
 
+- Read `CLAUDE.md` for project conventions and stack patterns.
+- Read `ERRORS.md` for known bugs and non-obvious pitfalls to avoid before coding.
 - Which module? Default to **ONE** unless justified.
 - **If the module doesn't exist** → run `/create-module` to scaffold it first, then continue.
 


### PR DESCRIPTION
## Summary

- Adds explicit instruction in Phase 0 step 1 to read `CLAUDE.md` for project conventions before coding
- Adds instruction to read `ERRORS.md` for known bugs and non-obvious pitfalls before coding
- Closes #4077

## Test plan

- [ ] Verify `.claude/skills/feature/SKILL.md` Phase 0 step 1 now includes both `CLAUDE.md` and `ERRORS.md` read instructions

## Notes

Backwards compatible: additive-only change. No existing instructions removed or modified.