### PR TITLE
feat(legal): Add legal module + cookie consent (RGPD)

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -26,7 +26,7 @@ Disabled by default. Enable in `modules/legal/config/legal.{env}.config.js` (or 
 
 ### Action for downstream projects
 
-**Default consumers** (cookieConsent off, pages off): no action. The PostHog plugin change is a no-op until consent flow is enabled. If you ship PostHog in EU without enabling cookie consent, you are non-compliant by default — enable it.
+**Default consumers** (cookieConsent off, pages off): no action required. **Behavior change to be aware of:** PostHog now defaults to opt-out — events are not captured until the user opts in via the consent banner. If you ship PostHog targeting EU users, you must enable the cookie consent flow (see below) to be GDPR-compliant. If you don't enable consent, no events will be captured at all.
 
 **To enable cookie consent** (REQUIRED if you ship PostHog targeting EU users):
 1. Override `legal.cookieConsent.enabled: true`

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -17,6 +17,7 @@ Disabled by default. Enable in `modules/legal/config/legal.{env}.config.js` (or 
 - `legal.pages.enabled: true` → routes register at `/legal/{slug}`
 
 ### What changed in the stack
+
 - NEW: `src/modules/legal/` (composables, components, view, routes, assets/templates, config, lang)
 - MODIFIED: `src/lib/plugins/posthog.js` — added `opt_out_capturing_by_default: true` + `persistence: 'memory'`. PostHog now waits for explicit opt-in before storing cookies. Existing flag-based features (autocapture/replay/pageleave/etc.) unchanged.
 - MODIFIED: `src/modules/core/components/core.footer.component.vue` — auto-injects a "Legal" section when `legal.cookieConsent.enabled` or any `legal.pages.items[*].enabled` is true. Also fixes a pre-existing bug where the footer was hidden on hard-load (the `$route` watcher didn't fire on initial mount); a `created()` hook now initializes `enabled` from `$route.meta.footer`.
@@ -46,6 +47,7 @@ Disabled by default. Enable in `modules/legal/config/legal.{env}.config.js` (or 
 - Remove the local route entries
 
 ### Why
+
 Stripe KYC requires a legal compliance baseline (ToS, Privacy, Refund, Legal Notice, DPA) + cookie consent for EU. Centralizing in devkit avoids duplicating across downstream projects and gives every new project a working baseline out of the box.
 
 ---

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,52 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## Legal module + cookie consent banner (2026-05-07)
+
+**Non-breaking for default consumers.** New `modules/legal/` ships:
+- Cookie consent banner gating PostHog opt-in (RGPD-compliant)
+- Markdown-driven legal pages renderer (terms, privacy, refund, legal-notice, dpa, aup)
+- 6 baseline templates with `{{entity.*}}` placeholders
+- Footer "Legal" section + "Cookie settings" link (conditional)
+
+Disabled by default. Enable in `modules/legal/config/legal.{env}.config.js` (or downstream override):
+- `legal.cookieConsent.enabled: true` → banner mounts on every public route
+- `legal.pages.enabled: true` → routes register at `/legal/{slug}`
+
+### What changed in the stack
+- NEW: `src/modules/legal/` (composables, components, view, routes, assets/templates, config, lang)
+- MODIFIED: `src/lib/plugins/posthog.js` — added `opt_out_capturing_by_default: true` + `persistence: 'memory'`. PostHog now waits for explicit opt-in before storing cookies. Existing flag-based features (autocapture/replay/pageleave/etc.) unchanged.
+- MODIFIED: `src/modules/core/components/core.footer.component.vue` — auto-injects a "Legal" section when `legal.cookieConsent.enabled` or any `legal.pages.items[*].enabled` is true. Also fixes a pre-existing bug where the footer was hidden on hard-load (the `$route` watcher didn't fire on initial mount); a `created()` hook now initializes `enabled` from `$route.meta.footer`.
+- MODIFIED: `src/modules/app/app.vue` — global mount of `<legalCookieBanner />`.
+- MODIFIED: `src/modules/app/app.router.js` — concatenates legal routes (returns empty when `pages.enabled: false`).
+- MODIFIED: `src/lib/plugins/i18n.js` — imports `legalEn` / `legalFr`.
+
+### Action for downstream projects
+
+**Default consumers** (cookieConsent off, pages off): no action. The PostHog plugin change is a no-op until consent flow is enabled. If you ship PostHog in EU without enabling cookie consent, you are non-compliant by default — enable it.
+
+**To enable cookie consent** (REQUIRED if you ship PostHog targeting EU users):
+1. Override `legal.cookieConsent.enabled: true`
+2. Set `legal.cookieConsent.privacyPolicyPath` to your privacy URL
+3. Verify banner appears on landing, accept-all sets posthog cookies, reject keeps them clear
+
+**To enable legal pages**:
+1. Either fill `legal.pages.entity.*` (templates substitute placeholders), or
+2. Override `markdownPath` per item to point at your own `.md` (full rewrite — your file under `/src/` anywhere)
+3. Set `legal.pages.enabled: true`
+4. Pages auto-route at `/legal/{slug}` (configurable via `routePrefix`)
+
+**If you have an existing legal pages implementation** (e.g., trawl_vue's `modules/trawl/views/trawl.legal.view.vue`):
+- At next `/update-project`, retire your local view + tests + routes
+- Move (or keep) your `.md` files under `/src/` (any path)
+- Override `markdownPath` per item in your config to point at them
+- Remove the local route entries
+
+### Why
+Stripe KYC requires a legal compliance baseline (ToS, Privacy, Refund, Legal Notice, DPA) + cookie consent for EU. Centralizing in devkit avoids duplicating across downstream projects and gives every new project a working baseline out of the box.
+
+---
+
 ## core.pageHeader — breadcrumb slot + canonical 56px height + overflow fix (2026-04-26)
 
 **Non-breaking for default consumers.** The shared

--- a/src/config/defaults/development.config.js
+++ b/src/config/defaults/development.config.js
@@ -78,6 +78,7 @@ export default {
     organizations: { activated: true }, // multi-org membership
     analytics: { activated: true }, // usage analytics
     admin: { activated: true }, // admin panel
+    legal: { activated: true }, // legal pages + cookie consent (routes gated by legal.pages.enabled)
   },
   analytics: {
     posthog: { // PostHog analytics — uncomment host + key to enable

--- a/src/config/defaults/test.config.js
+++ b/src/config/defaults/test.config.js
@@ -70,6 +70,7 @@ export default {
     organizations: { activated: true },
     analytics: { activated: true },
     admin: { activated: true },
+    legal: { activated: true },
   },
   cookie: { prefix: 'devkit' },
   sign: { route: '/', in: true, up: true },

--- a/src/lib/composables/useFooterExtras.js
+++ b/src/lib/composables/useFooterExtras.js
@@ -1,0 +1,44 @@
+import { ref } from 'vue';
+
+/**
+ * Module-scope singleton store for footer extra sections.
+ * Core footer reads `extras` and renders them after `config.footer.links`.
+ * @type {import('vue').Ref<Array<{_id: string, title: string, items: Array}>>}
+ */
+const extras = ref([]);
+
+/**
+ * Module-agnostic registry for footer sections.
+ * Modules call `register` on mount and `unregister` on unmount to inject
+ * their content into the core footer without creating a hard import dependency.
+ *
+ * @returns {{
+ *   extras: import('vue').Ref<Array<{_id: string, title: string, items: Array}>>,
+ *   register: (id: string, section: {title: string, items: Array}) => void,
+ *   unregister: (id: string) => void
+ * }}
+ */
+export function useFooterExtras() {
+  /**
+   * Register (or replace) a footer section by id.
+   * @param {string} id - Unique section identifier (e.g. 'legal')
+   * @param {{title: string, items: Array}} section - Section data
+   * @returns {void}
+   */
+  const register = (id, section) => {
+    const idx = extras.value.findIndex((s) => s._id === id);
+    if (idx >= 0) extras.value.splice(idx, 1, { ...section, _id: id });
+    else extras.value.push({ ...section, _id: id });
+  };
+
+  /**
+   * Unregister a footer section by id.
+   * @param {string} id - Unique section identifier to remove
+   * @returns {void}
+   */
+  const unregister = (id) => {
+    extras.value = extras.value.filter((s) => s._id !== id);
+  };
+
+  return { extras, register, unregister };
+}

--- a/src/lib/plugins/i18n.js
+++ b/src/lib/plugins/i18n.js
@@ -18,6 +18,8 @@ import { billingEn } from '../../modules/billing/lang/en.js';
 import { billingFr } from '../../modules/billing/lang/fr.js';
 import { usersEn } from '../../modules/users/lang/en.js';
 import { usersFr } from '../../modules/users/lang/fr.js';
+import { legalEn } from '../../modules/legal/lang/en.js';
+import { legalFr } from '../../modules/legal/lang/fr.js';
 
 /**
  * i18n instance — Composition API mode (legacy: false) so both
@@ -30,8 +32,8 @@ const i18n = createI18n({
   locale: 'en',
   fallbackLocale: 'en',
   messages: {
-    en: { ...billingEn, ...usersEn },
-    fr: { ...billingFr, ...usersFr },
+    en: { ...billingEn, ...usersEn, ...legalEn },
+    fr: { ...billingFr, ...usersFr, ...legalFr },
   },
 });
 

--- a/src/lib/plugins/posthog.js
+++ b/src/lib/plugins/posthog.js
@@ -39,6 +39,9 @@ export default {
     posthog.init(phConfig.key, {
       api_host: phConfig.host || 'https://us.i.posthog.com',
 
+      opt_out_capturing_by_default: true,
+      persistence: 'memory',
+
       autocapture: isEnabled(phConfig.autoCapture),
       capture_pageleave: isEnabled(phConfig.capturePageleave),
 

--- a/src/lib/plugins/tests/posthog.unit.tests.js
+++ b/src/lib/plugins/tests/posthog.unit.tests.js
@@ -240,4 +240,22 @@ describe('posthog plugin', () => {
       );
     });
   });
+
+  it('initializes posthog with opt_out_capturing_by_default: true (RGPD gating)', () => {
+    const app = makeApp({ key: 'phc_testkey' });
+    posthogPlugin.install(app);
+    expect(posthog.init).toHaveBeenCalledWith(
+      'phc_testkey',
+      expect.objectContaining({ opt_out_capturing_by_default: true }),
+    );
+  });
+
+  it('initializes posthog with persistence: memory (no cookie/LS until consent)', () => {
+    const app = makeApp({ key: 'phc_testkey' });
+    posthogPlugin.install(app);
+    expect(posthog.init).toHaveBeenCalledWith(
+      'phc_testkey',
+      expect.objectContaining({ persistence: 'memory' }),
+    );
+  });
 });

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -19,7 +19,7 @@ import billing from '../billing/router/billing.router';
 import legal from '../legal/router/legal.router';
 
 // Core modules — always mounted
-const coreRoutes = [].concat(home, auth, users, legal);
+const coreRoutes = [].concat(home, auth, users);
 
 /**
  * Admin child modules — routes injected as children of the `/admin` parent
@@ -45,6 +45,7 @@ const optionalModules = [
   { name: 'admin', routes: admin },
   { name: 'tasks', routes: tasks },
   { name: 'billing', routes: billing },
+  { name: 'legal', routes: legal },
 ];
 
 const routes = optionalModules.reduce(

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -16,9 +16,10 @@ import admin from '../admin/router/admin.router';
 import users from '../users/router/users.router';
 import tasks from '../tasks/router/tasks.router';
 import billing from '../billing/router/billing.router';
+import legal from '../legal/router/legal.router';
 
 // Core modules — always mounted
-const coreRoutes = [].concat(home, auth, users);
+const coreRoutes = [].concat(home, auth, users, legal);
 
 /**
  * Admin child modules — routes injected as children of the `/admin` parent

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -36,6 +36,7 @@
     <authPendingRequestBanner />
 
     <organizationsAdminPendingBanner />
+    <legalCookieBanner />
     <v-main class="pb-0" :style="mainStyle">
       <appErrorBoundary>
         <router-view />
@@ -61,6 +62,7 @@ import authEmailBanner from '../auth/components/emailBanner.component.vue';
 import authPendingRequestBanner from '../auth/components/pendingRequestBanner.component.vue';
 
 import organizationsAdminPendingBanner from '../organizations/components/organizations.adminPendingBanner.component.vue';
+import legalCookieBanner from '../legal/components/legal.cookieBanner.component.vue';
 import appErrorBoundary from './components/app.errorBoundary.component.vue';
 
 /**
@@ -76,6 +78,7 @@ export default {
     authPendingRequestBanner,
 
     organizationsAdminPendingBanner,
+    legalCookieBanner,
     appErrorBoundary,
   },
   /**

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -37,6 +37,7 @@
 
     <organizationsAdminPendingBanner />
     <legalCookieBanner />
+    <legalFooterSection />
     <v-main class="pb-0" :style="mainStyle">
       <appErrorBoundary>
         <router-view />
@@ -63,6 +64,7 @@ import authPendingRequestBanner from '../auth/components/pendingRequestBanner.co
 
 import organizationsAdminPendingBanner from '../organizations/components/organizations.adminPendingBanner.component.vue';
 import legalCookieBanner from '../legal/components/legal.cookieBanner.component.vue';
+import legalFooterSection from '../legal/components/legal.footerSection.component.vue';
 import appErrorBoundary from './components/app.errorBoundary.component.vue';
 
 /**
@@ -79,6 +81,7 @@ export default {
 
     organizationsAdminPendingBanner,
     legalCookieBanner,
+    legalFooterSection,
     appErrorBoundary,
   },
   /**

--- a/src/modules/core/components/core.footer.component.vue
+++ b/src/modules/core/components/core.footer.component.vue
@@ -31,7 +31,7 @@
  * Module dependencies.
  */
 import { useTheme } from 'vuetify';
-import { useCookieConsent } from '@/modules/legal/composables/useCookieConsent';
+import { useFooterExtras } from '@/lib/composables/useFooterExtras';
 /**
  * Component definition.
  */
@@ -52,9 +52,14 @@ export default {
       default: null,
     },
   },
+  /**
+   * @desc Initialise the footer extras registry so the footer can render
+   * sections injected by optional modules (e.g. legal) without hard-importing them.
+   * @returns {{ extras: import('vue').Ref<Array> }}
+   */
   setup() {
-    const { reopenSettings } = useCookieConsent();
-    return { reopenSettings };
+    const { extras } = useFooterExtras();
+    return { extras };
   },
   data() {
     const theme = useTheme();
@@ -84,42 +89,14 @@ export default {
       };
     },
     /**
-     * @desc Build the Legal footer section from config.legal.
-     * Returns null when neither cookieConsent nor pages are enabled.
-     * @returns {{ title: string, items: Array }|null}
-     */
-    legalSection() {
-      const cc = this.config?.legal?.cookieConsent;
-      const pages = this.config?.legal?.pages;
-      const items = [];
-      if (pages?.enabled && pages.items) {
-        Object.values(pages.items)
-          .filter((it) => it.enabled)
-          .forEach((it) => {
-            items.push({
-              label: it.title,
-              icon: 'fa-solid fa-file-lines',
-              url: `${pages.routePrefix || '/legal'}/${it.slug}`,
-            });
-          });
-      }
-      if (cc?.enabled) {
-        items.push({
-          label: this.$t('legal.footer.cookieSettings'),
-          icon: 'fa-solid fa-cookie-bite',
-          action: 'cookieSettings',
-        });
-      }
-      if (items.length === 0) return null;
-      return { title: this.$t('legal.footer.sectionTitle'), items };
-    },
-    /**
-     * @desc Combines the prop-provided footer links with the auto-injected Legal section.
+     * @desc Combines the prop-provided footer links with sections registered by
+     * optional modules via `useFooterExtras`. Core has no knowledge of which
+     * modules injected the extras — they register/unregister via lifecycle hooks.
      * @returns {Array}
      */
     allLinks() {
       const base = this.links || [];
-      return this.legalSection ? [...base, this.legalSection] : base;
+      return [...base, ...this.extras];
     },
   },
   watch: {
@@ -141,12 +118,13 @@ export default {
       }
     },
     /**
-     * @desc Handle footer item click — branches on action type.
-     * @param {{ action?: string, url?: string }} item
+     * @desc Handle footer item click — dispatches `onClick` callback when present
+     * (injected by optional modules), otherwise navigates to `url`.
+     * @param {{ onClick?: Function, url?: string }} item
      */
     onItemClick(item) {
-      if (item.action === 'cookieSettings') {
-        this.reopenSettings();
+      if (typeof item.onClick === 'function') {
+        item.onClick();
       } else if (item.url) {
         this.navigate(item.url);
       }

--- a/src/modules/core/components/core.footer.component.vue
+++ b/src/modules/core/components/core.footer.component.vue
@@ -1,18 +1,18 @@
 <template>
   <v-footer v-if="enabled" class="footer pa-0 align-end" :style="footerStyle" app>
-    <v-container v-if="links.length > 0" class="px-0 py-4" :style="custom && custom.section ? custom.section : null">
+    <v-container v-if="allLinks.length > 0" class="px-0 py-4" :style="custom && custom.section ? custom.section : null">
       <v-row density="compact" align="center" justify="center">
         <v-col
-          v-for="({ items, title }, i) in links.filter((section) => section.items)"
+          v-for="({ items, title }, i) in allLinks.filter((section) => section.items)"
           :key="i"
           cols="12"
-          :md="12 / links.filter((section) => section.items).length"
+          :md="12 / allLinks.filter((section) => section.items).length"
           class="text-center"
         >
           <v-card color="transparent" :flat="config.vuetify.theme.flat" :style="custom && custom.section ? custom.section : null">
             <v-card-title class="text-center text-title-medium font-weight-bold text-medium-emphasis">{{ title }}</v-card-title>
             <v-list class="bg-transparent" :style="custom && custom.section ? custom.section : null" density="compact">
-              <v-list-item v-for="(item, idx) in items" :key="idx" class="justify-center" @click="navigate(item.url)">
+              <v-list-item v-for="(item, idx) in items" :key="idx" class="justify-center" @click="onItemClick(item)">
                 <v-list-item-title>
                   <v-icon size="14" class="mr-2 text-onSurface text-medium-emphasis">{{ item.icon }}</v-icon>
                   <span class="text-onSurface text-high-emphasis text-label-small"> {{ item.label }} </span>
@@ -31,6 +31,7 @@
  * Module dependencies.
  */
 import { useTheme } from 'vuetify';
+import { useCookieConsent } from '@/modules/legal/composables/useCookieConsent';
 /**
  * Component definition.
  */
@@ -50,6 +51,10 @@ export default {
       type: Object,
       default: null,
     },
+  },
+  setup() {
+    const { reopenSettings } = useCookieConsent();
+    return { reopenSettings };
   },
   data() {
     const theme = useTheme();
@@ -78,6 +83,44 @@ export default {
         background: bgColor,
       };
     },
+    /**
+     * @desc Build the Legal footer section from config.legal.
+     * Returns null when neither cookieConsent nor pages are enabled.
+     * @returns {{ title: string, items: Array }|null}
+     */
+    legalSection() {
+      const cc = this.config?.legal?.cookieConsent;
+      const pages = this.config?.legal?.pages;
+      const items = [];
+      if (pages?.enabled && pages.items) {
+        Object.values(pages.items)
+          .filter((it) => it.enabled)
+          .forEach((it) => {
+            items.push({
+              label: it.title,
+              icon: 'fa-solid fa-file-lines',
+              url: `${pages.routePrefix || '/legal'}/${it.slug}`,
+            });
+          });
+      }
+      if (cc?.enabled) {
+        items.push({
+          label: this.$t('legal.footer.cookieSettings'),
+          icon: 'fa-solid fa-cookie-bite',
+          action: 'cookieSettings',
+        });
+      }
+      if (items.length === 0) return null;
+      return { title: this.$t('legal.footer.sectionTitle'), items };
+    },
+    /**
+     * @desc Combines the prop-provided footer links with the auto-injected Legal section.
+     * @returns {Array}
+     */
+    allLinks() {
+      const base = this.links || [];
+      return this.legalSection ? [...base, this.legalSection] : base;
+    },
   },
   watch: {
     $route(route) {
@@ -85,12 +128,27 @@ export default {
       else this.enabled = false;
     },
   },
+  created() {
+    const route = this.$route;
+    if (route?.meta?.footer) this.enabled = true;
+  },
   methods: {
     navigate(link) {
       if (link.startsWith('http')) {
         window.open(link, '_blank');
       } else {
         this.$router.push(link);
+      }
+    },
+    /**
+     * @desc Handle footer item click — branches on action type.
+     * @param {{ action?: string, url?: string }} item
+     */
+    onItemClick(item) {
+      if (item.action === 'cookieSettings') {
+        this.reopenSettings();
+      } else if (item.url) {
+        this.navigate(item.url);
       }
     },
   },

--- a/src/modules/core/components/tests/core.footer.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.footer.component.unit.tests.js
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import { createI18n } from 'vue-i18n';
+import { useFooterExtras } from '@/lib/composables/useFooterExtras';
 
 vi.mock('vuetify', async (importOriginal) => {
   const actual = await importOriginal();
@@ -18,30 +19,33 @@ vi.mock('vuetify', async (importOriginal) => {
 
 import CoreFooter from '../core.footer.component.vue';
 
+/**
+ * Returns a fresh Vuetify instance for each test.
+ * @returns {import('vuetify').Vuetify}
+ */
 const vuetify = () => createVuetify({ components, directives });
+
+/**
+ * Returns a fresh vue-i18n instance with minimal keys.
+ * @returns {import('vue-i18n').I18n}
+ */
 const i18n = () =>
   createI18n({
     legacy: false,
     locale: 'en',
-    messages: {
-      en: {
-        legal: {
-          footer: { sectionTitle: 'Legal', cookieSettings: 'Cookie settings' },
-        },
-      },
-    },
+    messages: { en: {} },
   });
 
-const baseConfig = (overrides = {}) => ({
+const baseConfig = () => ({
   footer: { links: [{ title: 'Help', items: [{ label: 'Docs', icon: 'fa-solid fa-book', url: '/docs' }] }] },
   vuetify: { theme: { flat: false } },
-  legal: {
-    cookieConsent: { enabled: false, privacyPolicyPath: '/legal/privacy' },
-    pages: { enabled: false, routePrefix: '/legal', items: {} },
-    ...overrides,
-  },
 });
 
+/**
+ * Mounts CoreFooter with the given config, simulating an active footer route.
+ * @param {object} config
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
 const mountFooter = (config) =>
   mount(CoreFooter, {
     global: {
@@ -61,63 +65,64 @@ const mountFooter = (config) =>
     },
   });
 
-describe('core.footer.component — Legal section', () => {
+describe('core.footer.component — registry extras', () => {
   beforeEach(() => {
-    localStorage.clear();
+    // Clear any extras registered by previous tests
+    const { extras } = useFooterExtras();
+    extras.value = [];
   });
 
-  it('does not render Legal section when both legal flags are off', () => {
+  afterEach(() => {
+    const { extras } = useFooterExtras();
+    extras.value = [];
+  });
+
+  it('renders only prop links when extras registry is empty', () => {
     const wrapper = mountFooter(baseConfig());
-    expect(wrapper.text()).not.toContain('Legal');
+    expect(wrapper.text()).toContain('Help');
+    expect(wrapper.text()).toContain('Docs');
   });
 
-  it('renders Legal section with Cookie settings only when cookieConsent.enabled and pages.enabled=false', () => {
-    const wrapper = mountFooter(
-      baseConfig({
-        cookieConsent: { enabled: true, privacyPolicyPath: '/legal/privacy' },
-        pages: { enabled: false, routePrefix: '/legal', items: {} },
-      }),
-    );
-    expect(wrapper.text()).toContain('Legal');
-    expect(wrapper.text()).toContain('Cookie settings');
+  it('renders an extra section injected via useFooterExtras().register()', () => {
+    const { register } = useFooterExtras();
+    register('test-module', {
+      title: 'Test Section',
+      items: [{ label: 'Item One', icon: 'fa-solid fa-star', url: '/one' }],
+    });
+    const wrapper = mountFooter(baseConfig());
+    expect(wrapper.text()).toContain('Test Section');
+    expect(wrapper.text()).toContain('Item One');
   });
 
-  it('renders Legal section with enabled pages and no Cookie settings when cookieConsent.enabled=false', () => {
-    const wrapper = mountFooter(
-      baseConfig({
-        cookieConsent: { enabled: false, privacyPolicyPath: '/legal/privacy' },
-        pages: {
-          enabled: true,
-          routePrefix: '/legal',
-          items: {
-            terms:   { enabled: true,  slug: 'terms',   title: 'Terms',   markdownPath: '/p/terms.md' },
-            privacy: { enabled: true,  slug: 'privacy', title: 'Privacy', markdownPath: '/p/privacy.md' },
-            off:     { enabled: false, slug: 'off',     title: 'Off',     markdownPath: '/p/off.md' },
-          },
-        },
-      }),
-    );
-    expect(wrapper.text()).toContain('Legal');
-    expect(wrapper.text()).toContain('Terms');
-    expect(wrapper.text()).toContain('Privacy');
-    expect(wrapper.text()).not.toContain('Off');
-    expect(wrapper.text()).not.toContain('Cookie settings');
+  it('renders multiple extra sections in registration order', () => {
+    const { register } = useFooterExtras();
+    register('section-a', { title: 'Alpha', items: [{ label: 'A', icon: 'fa-solid fa-a', url: '/a' }] });
+    register('section-b', { title: 'Beta', items: [{ label: 'B', icon: 'fa-solid fa-b', url: '/b' }] });
+    const wrapper = mountFooter(baseConfig());
+    expect(wrapper.text()).toContain('Alpha');
+    expect(wrapper.text()).toContain('Beta');
   });
 
-  it('renders both Cookie settings and pages when both flags are on', () => {
-    const wrapper = mountFooter(
-      baseConfig({
-        cookieConsent: { enabled: true, privacyPolicyPath: '/legal/privacy' },
-        pages: {
-          enabled: true,
-          routePrefix: '/legal',
-          items: {
-            terms: { enabled: true, slug: 'terms', title: 'Terms', markdownPath: '/p/terms.md' },
-          },
-        },
-      }),
-    );
-    expect(wrapper.text()).toContain('Cookie settings');
-    expect(wrapper.text()).toContain('Terms');
+  it('does not render an extra section after unregister()', () => {
+    const { register, unregister } = useFooterExtras();
+    register('removable', { title: 'Removable', items: [{ label: 'Gone', icon: 'fa-solid fa-trash', url: '/gone' }] });
+    unregister('removable');
+    const wrapper = mountFooter(baseConfig());
+    expect(wrapper.text()).not.toContain('Removable');
+  });
+
+  it('calls item.onClick when item has an onClick callback', async () => {
+    const { register } = useFooterExtras();
+    const onClick = vi.fn();
+    register('clickable', {
+      title: 'Clickable',
+      items: [{ label: 'Action', icon: 'fa-solid fa-play', onClick }],
+    });
+    const wrapper = mountFooter(baseConfig());
+    const listItems = wrapper.findAllComponents({ name: 'VListItem' });
+    const actionItem = listItems.find((li) => li.text().includes('Action'));
+    expect(actionItem).toBeTruthy();
+    await actionItem.trigger('click');
+    expect(onClick).toHaveBeenCalledOnce();
   });
 });

--- a/src/modules/core/components/tests/core.footer.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.footer.component.unit.tests.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { createI18n } from 'vue-i18n';
+
+vi.mock('vuetify', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useTheme: () => ({
+      name: 'light',
+      current: { colors: { onSurface: '#111111', background: '#ffffff', surface: '#fafafa' } },
+    }),
+  };
+});
+
+import CoreFooter from '../core.footer.component.vue';
+
+const vuetify = () => createVuetify({ components, directives });
+const i18n = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en: {
+        legal: {
+          footer: { sectionTitle: 'Legal', cookieSettings: 'Cookie settings' },
+        },
+      },
+    },
+  });
+
+const baseConfig = (overrides = {}) => ({
+  footer: { links: [{ title: 'Help', items: [{ label: 'Docs', icon: 'fa-solid fa-book', url: '/docs' }] }] },
+  vuetify: { theme: { flat: false } },
+  legal: {
+    cookieConsent: { enabled: false, privacyPolicyPath: '/legal/privacy' },
+    pages: { enabled: false, routePrefix: '/legal', items: {} },
+    ...overrides,
+  },
+});
+
+const mountFooter = (config) =>
+  mount(CoreFooter, {
+    global: {
+      plugins: [vuetify(), i18n()],
+      mocks: {
+        config,
+        $route: { path: '/', meta: { footer: true } },
+        $router: { push: vi.fn() },
+      },
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>', props: ['to'] },
+        VFooter: { template: '<div class="v-footer-stub"><slot /></div>' },
+      },
+    },
+    props: {
+      links: config.footer?.links || [],
+    },
+  });
+
+describe('core.footer.component — Legal section', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not render Legal section when both legal flags are off', () => {
+    const wrapper = mountFooter(baseConfig());
+    expect(wrapper.text()).not.toContain('Legal');
+  });
+
+  it('renders Legal section with Cookie settings only when cookieConsent.enabled and pages.enabled=false', () => {
+    const wrapper = mountFooter(
+      baseConfig({
+        cookieConsent: { enabled: true, privacyPolicyPath: '/legal/privacy' },
+        pages: { enabled: false, routePrefix: '/legal', items: {} },
+      }),
+    );
+    expect(wrapper.text()).toContain('Legal');
+    expect(wrapper.text()).toContain('Cookie settings');
+  });
+
+  it('renders Legal section with enabled pages and no Cookie settings when cookieConsent.enabled=false', () => {
+    const wrapper = mountFooter(
+      baseConfig({
+        cookieConsent: { enabled: false, privacyPolicyPath: '/legal/privacy' },
+        pages: {
+          enabled: true,
+          routePrefix: '/legal',
+          items: {
+            terms:   { enabled: true,  slug: 'terms',   title: 'Terms',   markdownPath: '/p/terms.md' },
+            privacy: { enabled: true,  slug: 'privacy', title: 'Privacy', markdownPath: '/p/privacy.md' },
+            off:     { enabled: false, slug: 'off',     title: 'Off',     markdownPath: '/p/off.md' },
+          },
+        },
+      }),
+    );
+    expect(wrapper.text()).toContain('Legal');
+    expect(wrapper.text()).toContain('Terms');
+    expect(wrapper.text()).toContain('Privacy');
+    expect(wrapper.text()).not.toContain('Off');
+    expect(wrapper.text()).not.toContain('Cookie settings');
+  });
+
+  it('renders both Cookie settings and pages when both flags are on', () => {
+    const wrapper = mountFooter(
+      baseConfig({
+        cookieConsent: { enabled: true, privacyPolicyPath: '/legal/privacy' },
+        pages: {
+          enabled: true,
+          routePrefix: '/legal',
+          items: {
+            terms: { enabled: true, slug: 'terms', title: 'Terms', markdownPath: '/p/terms.md' },
+          },
+        },
+      }),
+    );
+    expect(wrapper.text()).toContain('Cookie settings');
+    expect(wrapper.text()).toContain('Terms');
+  });
+});

--- a/src/modules/legal/assets/templates/aup.template.md
+++ b/src/modules/legal/assets/templates/aup.template.md
@@ -1,0 +1,22 @@
+# Acceptable Use Policy
+
+_Last updated: {{entity.lastUpdated}}_
+
+By using **{{entity.name}}** services, you agree to comply with this Acceptable Use Policy ("AUP").
+
+## 1. Prohibited content
+- Illegal content
+- Infringing content
+- Malicious software
+
+## 2. Prohibited activities
+- Unauthorized access to systems
+- Disrupting service availability
+- Bypassing third-party protections in a manner that violates their Terms of Service
+- Mass automated scraping in violation of target sites' Terms
+
+## 3. Enforcement
+Violations may result in suspension or termination, with no refund. Severe violations may be reported to authorities.
+
+## 4. Reporting
+Report abuse: {{entity.contactEmail}}

--- a/src/modules/legal/assets/templates/aup.template.md
+++ b/src/modules/legal/assets/templates/aup.template.md
@@ -5,18 +5,22 @@ _Last updated: {{entity.lastUpdated}}_
 By using **{{entity.name}}** services, you agree to comply with this Acceptable Use Policy ("AUP").
 
 ## 1. Prohibited content
+
 - Illegal content
 - Infringing content
 - Malicious software
 
 ## 2. Prohibited activities
+
 - Unauthorized access to systems
 - Disrupting service availability
 - Bypassing third-party protections in a manner that violates their Terms of Service
 - Mass automated scraping in violation of target sites' Terms
 
 ## 3. Enforcement
+
 Violations may result in suspension or termination, with no refund. Severe violations may be reported to authorities.
 
 ## 4. Reporting
+
 Report abuse: {{entity.contactEmail}}

--- a/src/modules/legal/assets/templates/dpa.template.md
+++ b/src/modules/legal/assets/templates/dpa.template.md
@@ -5,29 +5,37 @@ _Last updated: {{entity.lastUpdated}}_
 This Data Processing Agreement ("DPA") forms part of the agreement between **{{entity.name}}** ("Processor") and the Customer ("Controller") under GDPR Article 28.
 
 ## 1. Subject matter
+
 The Processor processes personal data on behalf of the Controller solely to provide the contracted service.
 
 ## 2. Duration
+
 This DPA applies for the term of the underlying service agreement.
 
 ## 3. Categories of data
+
 - Identifiers (email, name)
 - Usage data
 - Optional analytics with explicit consent
 
 ## 4. Data subjects
+
 End users of the Controller's organization.
 
 ## 5. Sub-processors
+
 - Stripe (payments)
 - {{entity.hostingProvider}} (hosting)
 - PostHog (analytics, only if consent granted)
 
 ## 6. Security
+
 Encryption in transit (TLS), encryption at rest, access controls, regular backups.
 
 ## 7. Sub-processor changes
+
 Notice provided 30 days before adding a new sub-processor.
 
 ## 8. Contact
+
 {{entity.dpoEmail}}

--- a/src/modules/legal/assets/templates/dpa.template.md
+++ b/src/modules/legal/assets/templates/dpa.template.md
@@ -1,0 +1,33 @@
+# Data Processing Agreement
+
+_Last updated: {{entity.lastUpdated}}_
+
+This Data Processing Agreement ("DPA") forms part of the agreement between **{{entity.name}}** ("Processor") and the Customer ("Controller") under GDPR Article 28.
+
+## 1. Subject matter
+The Processor processes personal data on behalf of the Controller solely to provide the contracted service.
+
+## 2. Duration
+This DPA applies for the term of the underlying service agreement.
+
+## 3. Categories of data
+- Identifiers (email, name)
+- Usage data
+- Optional analytics with explicit consent
+
+## 4. Data subjects
+End users of the Controller's organization.
+
+## 5. Sub-processors
+- Stripe (payments)
+- {{entity.hostingProvider}} (hosting)
+- PostHog (analytics, only if consent granted)
+
+## 6. Security
+Encryption in transit (TLS), encryption at rest, access controls, regular backups.
+
+## 7. Sub-processor changes
+Notice provided 30 days before adding a new sub-processor.
+
+## 8. Contact
+{{entity.dpoEmail}}

--- a/src/modules/legal/assets/templates/legal-notice.template.md
+++ b/src/modules/legal/assets/templates/legal-notice.template.md
@@ -3,6 +3,7 @@
 _Last updated: {{entity.lastUpdated}}_
 
 ## Publisher
+
 **{{entity.name}}**
 {{entity.legalForm}}
 {{entity.address}}
@@ -12,11 +13,14 @@ Registration: {{entity.registrationId}}
 Contact: {{entity.contactEmail}}
 
 ## Hosting
+
 {{entity.hostingProvider}}
 {{entity.hostingAddress}}
 
 ## Director of publication
+
 {{entity.name}}
 
 ## Intellectual property
+
 All content on this site is the property of {{entity.name}} unless otherwise noted.

--- a/src/modules/legal/assets/templates/legal-notice.template.md
+++ b/src/modules/legal/assets/templates/legal-notice.template.md
@@ -1,0 +1,22 @@
+# Legal Notice
+
+_Last updated: {{entity.lastUpdated}}_
+
+## Publisher
+**{{entity.name}}**
+{{entity.legalForm}}
+{{entity.address}}
+{{entity.country}}
+
+Registration: {{entity.registrationId}}
+Contact: {{entity.contactEmail}}
+
+## Hosting
+{{entity.hostingProvider}}
+{{entity.hostingAddress}}
+
+## Director of publication
+{{entity.name}}
+
+## Intellectual property
+All content on this site is the property of {{entity.name}} unless otherwise noted.

--- a/src/modules/legal/assets/templates/privacy.template.md
+++ b/src/modules/legal/assets/templates/privacy.template.md
@@ -1,0 +1,27 @@
+# Privacy Policy
+
+_Last updated: {{entity.lastUpdated}}_
+
+This Privacy Policy describes how **{{entity.name}}** ({{entity.legalForm}}, {{entity.country}}) collects and uses your data.
+
+## 1. Data we collect
+- Account information (email, name)
+- Usage data (anonymized analytics, see Cookies & Consent below)
+- Payment data (processed by Stripe; we do not store card details)
+
+## 2. Legal basis (GDPR)
+- Contract performance (account, billing)
+- Legitimate interest (security, fraud prevention)
+- Consent (analytics)
+
+## 3. Cookies & Consent
+We use a cookie consent banner. Analytics cookies (PostHog) are only set after explicit opt-in. You can revoke at any time via the "Cookie settings" link in the footer.
+
+## 4. Your rights (GDPR)
+You may request access, correction, deletion, or portability of your personal data by contacting {{entity.dpoEmail}}.
+
+## 5. Hosting
+Data is hosted by {{entity.hostingProvider}} ({{entity.hostingAddress}}).
+
+## 6. Contact
+Data Protection contact: {{entity.dpoEmail}}

--- a/src/modules/legal/assets/templates/privacy.template.md
+++ b/src/modules/legal/assets/templates/privacy.template.md
@@ -15,7 +15,7 @@ This Privacy Policy describes how **{{entity.name}}** ({{entity.legalForm}}, {{e
 - Consent (analytics)
 
 ## 3. Cookies & Consent
-We use a cookie consent banner. Analytics cookies (PostHog) are only set after explicit opt-in. You can revoke at any time via the "Cookie settings" link in the footer.
+We use a cookie consent banner. Analytics cookies (PostHog) are only set after explicit opt-in. You can revoke your consent at any time. If a cookie consent banner is enabled on this site, look for a "Cookie settings" link in the footer; otherwise contact us at {{entity.dpoEmail}} to update your preferences.
 
 ## 4. Your rights (GDPR)
 You may request access, correction, deletion, or portability of your personal data by contacting {{entity.dpoEmail}}.

--- a/src/modules/legal/assets/templates/privacy.template.md
+++ b/src/modules/legal/assets/templates/privacy.template.md
@@ -5,23 +5,29 @@ _Last updated: {{entity.lastUpdated}}_
 This Privacy Policy describes how **{{entity.name}}** ({{entity.legalForm}}, {{entity.country}}) collects and uses your data.
 
 ## 1. Data we collect
+
 - Account information (email, name)
 - Usage data (anonymized analytics, see Cookies & Consent below)
 - Payment data (processed by Stripe; we do not store card details)
 
 ## 2. Legal basis (GDPR)
+
 - Contract performance (account, billing)
 - Legitimate interest (security, fraud prevention)
 - Consent (analytics)
 
 ## 3. Cookies & Consent
+
 We use a cookie consent banner. Analytics cookies (PostHog) are only set after explicit opt-in. You can revoke your consent at any time. If a cookie consent banner is enabled on this site, look for a "Cookie settings" link in the footer; otherwise contact us at {{entity.dpoEmail}} to update your preferences.
 
 ## 4. Your rights (GDPR)
+
 You may request access, correction, deletion, or portability of your personal data by contacting {{entity.dpoEmail}}.
 
 ## 5. Hosting
+
 Data is hosted by {{entity.hostingProvider}} ({{entity.hostingAddress}}).
 
 ## 6. Contact
+
 Data Protection contact: {{entity.dpoEmail}}

--- a/src/modules/legal/assets/templates/refund.template.md
+++ b/src/modules/legal/assets/templates/refund.template.md
@@ -5,15 +5,19 @@ _Last updated: {{entity.lastUpdated}}_
 **{{entity.name}}** offers refunds under the following conditions:
 
 ## 1. Free trial
+
 Free plans do not require a payment method and are not eligible for refunds.
 
 ## 2. Paid subscriptions
+
 - 14-day money-back guarantee on first paid subscription
 - Pro-rated refunds on cancellation are not provided; you keep access until the period ends
 - Compute packs (consumable credits) are non-refundable once activity has occurred
 
 ## 3. How to request
+
 Email {{entity.contactEmail}} with your account email and reason. We respond within 5 business days.
 
 ## 4. EU consumer rights
+
 EU consumers may benefit from a 14-day right of withdrawal under Directive 2011/83/EU, to the extent applicable.

--- a/src/modules/legal/assets/templates/refund.template.md
+++ b/src/modules/legal/assets/templates/refund.template.md
@@ -1,0 +1,19 @@
+# Refund Policy
+
+_Last updated: {{entity.lastUpdated}}_
+
+**{{entity.name}}** offers refunds under the following conditions:
+
+## 1. Free trial
+Free plans do not require a payment method and are not eligible for refunds.
+
+## 2. Paid subscriptions
+- 14-day money-back guarantee on first paid subscription
+- Pro-rated refunds on cancellation are not provided; you keep access until the period ends
+- Compute packs (consumable credits) are non-refundable once activity has occurred
+
+## 3. How to request
+Email {{entity.contactEmail}} with your account email and reason. We respond within 5 business days.
+
+## 4. EU consumer rights
+EU consumers may benefit from a 14-day right of withdrawal under Directive 2011/83/EU, to the extent applicable.

--- a/src/modules/legal/assets/templates/terms.template.md
+++ b/src/modules/legal/assets/templates/terms.template.md
@@ -1,0 +1,25 @@
+# Terms of Service
+
+_Last updated: {{entity.lastUpdated}}_
+
+These Terms of Service ("Terms") govern your use of services provided by **{{entity.name}}** ({{entity.legalForm}}), registered at {{entity.address}}, {{entity.country}} (registration: {{entity.registrationId}}).
+
+By accessing or using the service, you agree to be bound by these Terms.
+
+## 1. Account
+You are responsible for safeguarding your credentials and for all activities under your account.
+
+## 2. Acceptable use
+You agree not to misuse the service. Prohibited activities include but are not limited to: unauthorized access, scraping in violation of third-party terms, or any unlawful activity.
+
+## 3. Subscription and billing
+Paid plans are billed in advance. See the [Refund Policy](/legal/refund) for cancellation and refund terms.
+
+## 4. Termination
+We may suspend or terminate your account for breach of these Terms.
+
+## 5. Liability
+The service is provided "as is". To the fullest extent permitted by law, our liability is limited.
+
+## 6. Contact
+Questions about these Terms: {{entity.contactEmail}}

--- a/src/modules/legal/assets/templates/terms.template.md
+++ b/src/modules/legal/assets/templates/terms.template.md
@@ -13,7 +13,7 @@ You are responsible for safeguarding your credentials and for all activities und
 You agree not to misuse the service. Prohibited activities include but are not limited to: unauthorized access, scraping in violation of third-party terms, or any unlawful activity.
 
 ## 3. Subscription and billing
-Paid plans are billed in advance. See the [Refund Policy](/legal/refund) for cancellation and refund terms.
+Paid plans are billed in advance. See the [Refund Policy](./refund) for cancellation and refund terms.
 
 ## 4. Termination
 We may suspend or terminate your account for breach of these Terms.

--- a/src/modules/legal/assets/templates/terms.template.md
+++ b/src/modules/legal/assets/templates/terms.template.md
@@ -7,19 +7,25 @@ These Terms of Service ("Terms") govern your use of services provided by **{{ent
 By accessing or using the service, you agree to be bound by these Terms.
 
 ## 1. Account
+
 You are responsible for safeguarding your credentials and for all activities under your account.
 
 ## 2. Acceptable use
+
 You agree not to misuse the service. Prohibited activities include but are not limited to: unauthorized access, scraping in violation of third-party terms, or any unlawful activity.
 
 ## 3. Subscription and billing
+
 Paid plans are billed in advance. See the [Refund Policy](./refund) for cancellation and refund terms.
 
 ## 4. Termination
+
 We may suspend or terminate your account for breach of these Terms.
 
 ## 5. Liability
+
 The service is provided "as is". To the fullest extent permitted by law, our liability is limited.
 
 ## 6. Contact
+
 Questions about these Terms: {{entity.contactEmail}}

--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-snackbar
+    v-if="enabled"
+    v-model="visible"
+    location="bottom right"
+    :timeout="-1"
+    multi-line
+    :max-width="480"
+    color="surface"
+  >
+    <div class="text-body-2">
+      {{ message }}
+      <router-link :to="privacyPolicyPath" class="text-primary">
+        {{ $t('legal.banner.privacyPolicy') }}
+      </router-link>
+    </div>
+    <template #actions>
+      <v-btn variant="text" color="primary" @click="onAccept">
+        {{ $t('legal.banner.accept') }}
+      </v-btn>
+      <v-btn variant="text" @click="onReject">
+        {{ $t('legal.banner.reject') }}
+      </v-btn>
+    </template>
+  </v-snackbar>
+</template>
+
+<script setup>
+import { computed, getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useCookieConsent } from '../composables/useCookieConsent';
+
+const instance = getCurrentInstance();
+
+// Read config lazily inside computed to support both globalProperties (prod)
+// and Vue Test Utils mocks (tests), which are only available after setup.
+const getConfig = () =>
+  instance?.proxy?.config ||
+  instance?.appContext?.config?.globalProperties?.config ||
+  {};
+
+const enabled = computed(() => Boolean(getConfig()?.legal?.cookieConsent?.enabled));
+const privacyPolicyPath = computed(() => getConfig()?.legal?.cookieConsent?.privacyPolicyPath || '/legal/privacy');
+const appName = computed(() => getConfig()?.name || '');
+
+const { consentNeeded, consent, accept, reject } = useCookieConsent();
+const visible = computed({
+  get: () => enabled.value && consentNeeded.value,
+  set: () => {},
+});
+
+const { t } = useI18n();
+const message = computed(() => {
+  if (consent.value !== null) return t('legal.banner.revokeMessage', { appName: appName.value });
+  return t('legal.banner.message', { appName: appName.value });
+});
+
+const onAccept = () => accept();
+const onReject = () => reject();
+</script>

--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -32,8 +32,11 @@ import { useCookieConsent } from '../composables/useCookieConsent';
 
 const instance = getCurrentInstance();
 
-// Read config lazily inside computed to support both globalProperties (prod)
-// and Vue Test Utils mocks (tests), which are only available after setup.
+/**
+ * Reads the devkit config lazily to support both globalProperties (prod) and
+ * Vue Test Utils mocks (tests), which are only available after setup.
+ * @returns {object} The resolved config object (may be empty).
+ */
 const getConfig = () =>
   instance?.proxy?.config ||
   instance?.appContext?.config?.globalProperties?.config ||
@@ -55,6 +58,17 @@ const message = computed(() => {
   return t('legal.banner.message', { appName: appName.value });
 });
 
+/**
+ * Delegates to the accept() action from useCookieConsent.
+ * Opts PostHog in and persists the user's choice to localStorage.
+ * @returns {void}
+ */
 const onAccept = () => accept();
+
+/**
+ * Delegates to the reject() action from useCookieConsent.
+ * Opts PostHog out and persists the user's choice to localStorage.
+ * @returns {void}
+ */
 const onReject = () => reject();
 </script>

--- a/src/modules/legal/components/legal.footerSection.component.vue
+++ b/src/modules/legal/components/legal.footerSection.component.vue
@@ -1,0 +1,61 @@
+<!-- eslint-disable-next-line vue/valid-template-root -->
+<template><span style="display:none" /></template>
+
+<script setup>
+import { computed, watch, onUnmounted, getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useCookieConsent } from '../composables/useCookieConsent';
+import { useFooterExtras } from '@/lib/composables/useFooterExtras';
+
+const SECTION_ID = 'legal';
+const { t } = useI18n();
+const instance = getCurrentInstance();
+const config = computed(() => instance?.proxy?.config || instance?.appContext?.config?.globalProperties?.config || {});
+const { reopenSettings } = useCookieConsent();
+const { register, unregister } = useFooterExtras();
+
+/**
+ * Derives the legal footer section from config.
+ * Returns null when neither cookieConsent nor pages are enabled.
+ * @type {import('vue').ComputedRef<{title: string, items: Array}|null>}
+ */
+const section = computed(() => {
+  const cc = config.value?.legal?.cookieConsent;
+  const pages = config.value?.legal?.pages;
+  const items = [];
+
+  if (pages?.enabled && pages.items) {
+    Object.values(pages.items)
+      .filter((it) => it.enabled)
+      .forEach((it) => {
+        items.push({
+          label: it.title,
+          icon: 'fa-solid fa-file-lines',
+          url: `${pages.routePrefix || '/legal'}/${it.slug}`,
+        });
+      });
+  }
+
+  if (cc?.enabled) {
+    items.push({
+      label: t('legal.footer.cookieSettings'),
+      icon: 'fa-solid fa-cookie-bite',
+      onClick: reopenSettings,
+    });
+  }
+
+  if (items.length === 0) return null;
+  return { title: t('legal.footer.sectionTitle'), items };
+});
+
+watch(
+  section,
+  (val) => {
+    if (val) register(SECTION_ID, val);
+    else unregister(SECTION_ID);
+  },
+  { immediate: true },
+);
+
+onUnmounted(() => unregister(SECTION_ID));
+</script>

--- a/src/modules/legal/composables/useCookieConsent.js
+++ b/src/modules/legal/composables/useCookieConsent.js
@@ -31,6 +31,20 @@ const writeStored = (analytics) => {
   try { localStorage.setItem(COOKIE_CONSENT_LS_KEY, JSON.stringify(payload)); } catch { /* quota / private mode — accept session-only */ }
 };
 
+/**
+ * Vue composable for cookie consent state and PostHog opt-in/out gating.
+ *
+ * Reads/writes localStorage under `cookie_consent_v1` (12-month expiry, version-checked).
+ * On mount, re-applies posthog opt_in if the user previously accepted.
+ *
+ * @returns {{
+ *   consentNeeded: import('vue').Ref<boolean>,
+ *   consent: import('vue').Ref<{analytics: boolean} | null>,
+ *   accept: () => void,
+ *   reject: () => void,
+ *   reopenSettings: () => void
+ * }}
+ */
 export function useCookieConsent() {
   const stored = readStored();
   const consent = ref(stored);

--- a/src/modules/legal/composables/useCookieConsent.js
+++ b/src/modules/legal/composables/useCookieConsent.js
@@ -1,0 +1,78 @@
+import { ref, getCurrentInstance } from 'vue';
+
+export const COOKIE_CONSENT_LS_KEY = 'cookie_consent_v1';
+export const CONSENT_VERSION = 1;
+const TWELVE_MONTHS_MS = 12 * 30 * 24 * 60 * 60 * 1000;
+
+const isBrowser = () => typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+
+const readStored = () => {
+  if (!isBrowser()) return null;
+  let raw;
+  try { raw = localStorage.getItem(COOKIE_CONSENT_LS_KEY); } catch { return null; }
+  if (!raw) return null;
+  let parsed;
+  try { parsed = JSON.parse(raw); } catch { return null; }
+  if (!parsed || parsed.version !== CONSENT_VERSION) return null;
+  if (!parsed.expiresAt || Date.parse(parsed.expiresAt) < Date.now()) return null;
+  if (typeof parsed.analytics !== 'boolean') return null;
+  return { analytics: parsed.analytics };
+};
+
+const writeStored = (analytics) => {
+  if (!isBrowser()) return;
+  const now = Date.now();
+  const payload = {
+    version: CONSENT_VERSION,
+    timestamp: new Date(now).toISOString(),
+    expiresAt: new Date(now + TWELVE_MONTHS_MS).toISOString(),
+    analytics,
+  };
+  try { localStorage.setItem(COOKIE_CONSENT_LS_KEY, JSON.stringify(payload)); } catch { /* quota / private mode — accept session-only */ }
+};
+
+export function useCookieConsent() {
+  const stored = readStored();
+  const consent = ref(stored);
+  const consentNeeded = ref(stored === null);
+
+  const instance = getCurrentInstance();
+  const getPosthog = () => instance?.appContext?.config?.globalProperties?.$posthog || null;
+
+  const accept = () => {
+    writeStored(true);
+    consent.value = { analytics: true };
+    consentNeeded.value = false;
+    const ph = getPosthog();
+    if (ph) {
+      ph.set_config({ persistence: 'localStorage+cookie' });
+      ph.opt_in_capturing();
+      ph.capture('consent_given', { analytics: true });
+    }
+  };
+
+  const reject = () => {
+    writeStored(false);
+    consent.value = { analytics: false };
+    consentNeeded.value = false;
+    const ph = getPosthog();
+    if (ph) {
+      ph.opt_out_capturing();
+      ph.reset();
+    }
+  };
+
+  const reopenSettings = () => {
+    consentNeeded.value = true;
+  };
+
+  if (stored?.analytics === true) {
+    const ph = getPosthog();
+    if (ph) {
+      ph.set_config({ persistence: 'localStorage+cookie' });
+      ph.opt_in_capturing();
+    }
+  }
+
+  return { consentNeeded, consent, accept, reject, reopenSettings };
+}

--- a/src/modules/legal/composables/useCookieConsent.js
+++ b/src/modules/legal/composables/useCookieConsent.js
@@ -2,10 +2,20 @@ import { ref, getCurrentInstance } from 'vue';
 
 export const COOKIE_CONSENT_LS_KEY = 'cookie_consent_v1';
 export const CONSENT_VERSION = 1;
-const TWELVE_MONTHS_MS = 12 * 30 * 24 * 60 * 60 * 1000;
+/** 365 days in milliseconds — GDPR-standard 12-month consent validity. */
+const TWELVE_MONTHS_MS = 365 * 24 * 60 * 60 * 1000;
 
+/**
+ * Returns true when running in a browser environment with localStorage available.
+ * @returns {boolean}
+ */
 const isBrowser = () => typeof window !== 'undefined' && typeof localStorage !== 'undefined';
 
+/**
+ * Reads and validates the stored consent record from localStorage.
+ * Returns null when absent, expired, version-mismatched, or malformed.
+ * @returns {{ analytics: boolean } | null}
+ */
 const readStored = () => {
   if (!isBrowser()) return null;
   let raw;
@@ -19,6 +29,12 @@ const readStored = () => {
   return { analytics: parsed.analytics };
 };
 
+/**
+ * Writes a consent record to localStorage with a 365-day expiry.
+ * Silently swallows quota / private-mode errors (session-only in that case).
+ * @param {boolean} analytics - Whether analytics consent was granted
+ * @returns {void}
+ */
 const writeStored = (analytics) => {
   if (!isBrowser()) return;
   const now = Date.now();
@@ -31,11 +47,39 @@ const writeStored = (analytics) => {
   try { localStorage.setItem(COOKIE_CONSENT_LS_KEY, JSON.stringify(payload)); } catch { /* quota / private mode — accept session-only */ }
 };
 
+// ---------------------------------------------------------------------------
+// Module-scope singleton refs — shared across all useCookieConsent() consumers
+// so that banner + footer-section (and any future caller) stay in sync.
+// ---------------------------------------------------------------------------
+const _initialStored = readStored();
+const consent = ref(_initialStored);
+const consentNeeded = ref(_initialStored === null);
+let _posthogReHydrated = false;
+
+/**
+ * Test-only helper to reset module-scope singleton state between test cases.
+ * Re-reads localStorage so tests that seed LS before calling this get correct state.
+ * NOT for production use.
+ * @internal
+ * @returns {void}
+ */
+export function __resetCookieConsentForTests() {
+  const stored = readStored();
+  consent.value = stored;
+  consentNeeded.value = stored === null;
+  _posthogReHydrated = false;
+}
+
 /**
  * Vue composable for cookie consent state and PostHog opt-in/out gating.
  *
- * Reads/writes localStorage under `cookie_consent_v1` (12-month expiry, version-checked).
- * On mount, re-applies posthog opt_in if the user previously accepted.
+ * Singleton: `consent` and `consentNeeded` refs are module-scope and shared
+ * across all consumers (banner, footer-section, etc.) so that calling
+ * `reopenSettings()` in one instance is immediately reactive in others.
+ *
+ * Reads/writes localStorage under `cookie_consent_v1` (365-day expiry,
+ * version-checked). On first call with prior opt-in, re-applies PostHog
+ * opt_in so analytics resume on reload without re-prompting.
  *
  * @returns {{
  *   consentNeeded: import('vue').Ref<boolean>,
@@ -46,13 +90,20 @@ const writeStored = (analytics) => {
  * }}
  */
 export function useCookieConsent() {
-  const stored = readStored();
-  const consent = ref(stored);
-  const consentNeeded = ref(stored === null);
-
   const instance = getCurrentInstance();
+
+  /**
+   * Lazily resolves the PostHog plugin instance from Vue globalProperties.
+   * Returns null when PostHog is not injected (non-analytics builds).
+   * @returns {object|null}
+   */
   const getPosthog = () => instance?.appContext?.config?.globalProperties?.$posthog || null;
 
+  /**
+   * Accept all analytics cookies.
+   * Persists consent to localStorage, updates singleton refs, and opts PostHog in.
+   * @returns {void}
+   */
   const accept = () => {
     writeStored(true);
     consent.value = { analytics: true };
@@ -65,6 +116,11 @@ export function useCookieConsent() {
     }
   };
 
+  /**
+   * Reject optional analytics cookies.
+   * Persists the rejection to localStorage, updates singleton refs, and opts PostHog out.
+   * @returns {void}
+   */
   const reject = () => {
     writeStored(false);
     consent.value = { analytics: false };
@@ -76,16 +132,24 @@ export function useCookieConsent() {
     }
   };
 
+  /**
+   * Re-open the consent banner so the user can update their preferences.
+   * Sets consentNeeded=true on the shared singleton ref — reactive in all consumers.
+   * @returns {void}
+   */
   const reopenSettings = () => {
     consentNeeded.value = true;
   };
 
-  if (stored?.analytics === true) {
+  // Re-hydrate PostHog opt-in on first composable call after a page load where
+  // the user had previously accepted. Only runs once per module lifetime.
+  if (!_posthogReHydrated && consent.value?.analytics === true) {
     const ph = getPosthog();
     if (ph) {
       ph.set_config({ persistence: 'localStorage+cookie' });
       ph.opt_in_capturing();
     }
+    _posthogReHydrated = true;
   }
 
   return { consentNeeded, consent, accept, reject, reopenSettings };

--- a/src/modules/legal/composables/useLegalPage.js
+++ b/src/modules/legal/composables/useLegalPage.js
@@ -1,0 +1,27 @@
+import { marked } from 'marked';
+
+const defaultSources = import.meta.glob('/src/**/*.md', { query: '?raw', import: 'default' });
+
+const substitutePlaceholders = (md, entity) =>
+  md.replace(/\{\{entity\.([a-zA-Z0-9_]+)\}\}/g, (match, key) => {
+    const v = entity?.[key];
+    return v === null || v === undefined || v === '' ? match : String(v);
+  });
+
+const NOT_FOUND = { title: '', html: '', notFound: true };
+
+export async function useLegalPage(slug, { sources = defaultSources, config } = {}) {
+  const cfg = config || {};
+  const items = cfg?.legal?.pages?.items || {};
+  const entity = cfg?.legal?.pages?.entity || {};
+  const item = Object.values(items).find((it) => it.slug === slug);
+  if (!item || !item.enabled) return { ...NOT_FOUND };
+  const loader = sources[item.markdownPath];
+  if (!loader) return { ...NOT_FOUND };
+  let raw;
+  try { raw = await loader(); } catch { return { ...NOT_FOUND }; }
+  if (typeof raw !== 'string' || !raw) return { ...NOT_FOUND };
+  const substituted = substitutePlaceholders(raw, entity);
+  const html = marked.parse(substituted);
+  return { title: item.title, html, notFound: false };
+}

--- a/src/modules/legal/composables/useLegalPage.js
+++ b/src/modules/legal/composables/useLegalPage.js
@@ -3,6 +3,14 @@ import DOMPurify from 'dompurify';
 
 const defaultSources = import.meta.glob('/src/**/*.md', { query: '?raw', import: 'default' });
 
+/**
+ * Replaces `{{entity.fieldName}}` placeholders in a markdown string with
+ * values from the entity map. Leaves the placeholder literal when the
+ * corresponding field is absent, null, or empty.
+ * @param {string} md - Raw markdown source
+ * @param {Object} entity - Key/value map of entity fields (e.g. name, legalForm)
+ * @returns {string} Markdown with placeholders substituted
+ */
 const substitutePlaceholders = (md, entity) =>
   md.replace(/\{\{entity\.([a-zA-Z0-9_]+)\}\}/g, (match, key) => {
     const v = entity?.[key];

--- a/src/modules/legal/composables/useLegalPage.js
+++ b/src/modules/legal/composables/useLegalPage.js
@@ -1,4 +1,5 @@
 import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 
 const defaultSources = import.meta.glob('/src/**/*.md', { query: '?raw', import: 'default' });
 
@@ -10,6 +11,15 @@ const substitutePlaceholders = (md, entity) =>
 
 const NOT_FOUND = { title: '', html: '', notFound: true };
 
+/**
+ * Resolves a legal page slug to rendered HTML.
+ *
+ * @param {string} slug — page slug (e.g., 'terms', 'privacy')
+ * @param {Object} [options]
+ * @param {Object<string, () => Promise<string>>} [options.sources] — markdown loader map (defaults to import.meta.glob)
+ * @param {Object} [options.config] — devkit config (provides legal.pages.items + entity)
+ * @returns {Promise<{title: string, html: string, notFound: boolean}>}
+ */
 export async function useLegalPage(slug, { sources = defaultSources, config } = {}) {
   const cfg = config || {};
   const items = cfg?.legal?.pages?.items || {};
@@ -22,6 +32,6 @@ export async function useLegalPage(slug, { sources = defaultSources, config } = 
   try { raw = await loader(); } catch { return { ...NOT_FOUND }; }
   if (typeof raw !== 'string' || !raw) return { ...NOT_FOUND };
   const substituted = substitutePlaceholders(raw, entity);
-  const html = marked.parse(substituted);
+  const html = DOMPurify.sanitize(marked.parse(substituted));
   return { title: item.title, html, notFound: false };
 }

--- a/src/modules/legal/config/legal.development.config.js
+++ b/src/modules/legal/config/legal.development.config.js
@@ -1,0 +1,25 @@
+export default {
+  legal: {
+    cookieConsent: {
+      enabled: false,
+      privacyPolicyPath: '/legal/privacy',
+    },
+    pages: {
+      enabled: false,
+      routePrefix: '/legal',
+      items: {
+        terms:       { enabled: true,  slug: 'terms',        title: 'Terms of Service',          markdownPath: '/src/modules/legal/assets/templates/terms.template.md' },
+        privacy:     { enabled: true,  slug: 'privacy',      title: 'Privacy Policy',            markdownPath: '/src/modules/legal/assets/templates/privacy.template.md' },
+        refund:      { enabled: true,  slug: 'refund',       title: 'Refund Policy',             markdownPath: '/src/modules/legal/assets/templates/refund.template.md' },
+        legalNotice: { enabled: true,  slug: 'legal-notice', title: 'Legal Notice',              markdownPath: '/src/modules/legal/assets/templates/legal-notice.template.md' },
+        dpa:         { enabled: true,  slug: 'dpa',          title: 'Data Processing Agreement', markdownPath: '/src/modules/legal/assets/templates/dpa.template.md' },
+        aup:         { enabled: false, slug: 'aup',          title: 'Acceptable Use Policy',     markdownPath: '/src/modules/legal/assets/templates/aup.template.md' },
+      },
+      entity: {
+        name: null, legalForm: null, address: null, country: null,
+        registrationId: null, contactEmail: null, dpoEmail: null,
+        hostingProvider: null, hostingAddress: null,
+      },
+    },
+  },
+};

--- a/src/modules/legal/lang/en.js
+++ b/src/modules/legal/lang/en.js
@@ -1,0 +1,18 @@
+export const legalEn = {
+  legal: {
+    banner: {
+      message: 'We use analytics cookies to improve {appName}. See our',
+      privacyPolicy: 'Privacy Policy',
+      accept: 'Accept',
+      reject: 'Reject',
+      revokeMessage: 'Update your cookie preferences for {appName}.',
+    },
+    footer: {
+      sectionTitle: 'Legal',
+      cookieSettings: 'Cookie settings',
+    },
+    pages: {
+      notFound: 'This legal page does not exist.',
+    },
+  },
+};

--- a/src/modules/legal/lang/fr.js
+++ b/src/modules/legal/lang/fr.js
@@ -1,0 +1,18 @@
+export const legalFr = {
+  legal: {
+    banner: {
+      message: "Nous utilisons des cookies d'analyse pour améliorer {appName}. Consultez notre",
+      privacyPolicy: 'Politique de confidentialité',
+      accept: 'Accepter',
+      reject: 'Refuser',
+      revokeMessage: 'Mettez à jour vos préférences de cookies pour {appName}.',
+    },
+    footer: {
+      sectionTitle: 'Mentions légales',
+      cookieSettings: 'Paramètres des cookies',
+    },
+    pages: {
+      notFound: "Cette page légale n'existe pas.",
+    },
+  },
+};

--- a/src/modules/legal/router/legal.router.js
+++ b/src/modules/legal/router/legal.router.js
@@ -1,0 +1,18 @@
+import config from '@/config';
+import legalPage from '../views/legal.page.view.vue';
+
+const enabled = Boolean(config?.legal?.pages?.enabled);
+const prefix = config?.legal?.pages?.routePrefix || '/legal';
+
+const routes = enabled
+  ? [
+      {
+        path: `${prefix}/:slug`,
+        name: 'LegalPage',
+        component: legalPage,
+        meta: { display: false, footer: true },
+      },
+    ]
+  : [];
+
+export default routes;

--- a/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
+++ b/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
@@ -77,7 +77,7 @@ describe('legal.cookieBanner.component', () => {
 
   it('does not render snackbar content when consentNeeded is false', async () => {
     consentNeeded.value = false;
-    const wrapper = mountBanner();
+    mountBanner();
     await flushPromises();
     // v-snackbar teleports outside wrapper; query document.body for content
     expect(document.body.innerHTML).not.toContain('Accept');
@@ -113,7 +113,7 @@ describe('legal.cookieBanner.component', () => {
   });
 
   it('renders privacy policy link to configured path', async () => {
-    const wrapper = mountBanner({ privacyPath: '/custom-privacy' });
+    mountBanner({ privacyPath: '/custom-privacy' });
     await flushPromises();
     // v-snackbar teleports; query document.body for the rendered link
     expect(document.body.innerHTML).toContain('Privacy Policy');

--- a/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
+++ b/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
@@ -28,7 +28,16 @@ vi.mock('../composables/useCookieConsent', () => ({
 
 import LegalCookieBanner from '../components/legal.cookieBanner.component.vue';
 
+/**
+ * Returns a fresh Vuetify instance for each test.
+ * @returns {import('vuetify').Vuetify}
+ */
 const vuetify = () => createVuetify({ components, directives });
+
+/**
+ * Returns a fresh vue-i18n instance with the legal banner message keys.
+ * @returns {import('vue-i18n').I18n}
+ */
 const i18n = () =>
   createI18n({
     legacy: false,
@@ -48,8 +57,16 @@ const i18n = () =>
     },
   });
 
-const mountBanner = ({ enabled = true, appName = 'Devkit', privacyPath = '/legal/privacy' } = {}) =>
-  mount(LegalCookieBanner, {
+let wrapper;
+
+/**
+ * Mounts LegalCookieBanner attached to document.body and tracks the
+ * wrapper so afterEach can unmount it and clear the DOM.
+ * @param {{ enabled?: boolean, appName?: string, privacyPath?: string }} [opts]
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountBanner = ({ enabled = true, appName = 'Devkit', privacyPath = '/legal/privacy' } = {}) => {
+  wrapper = mount(LegalCookieBanner, {
     attachTo: document.body,
     global: {
       plugins: [vuetify(), i18n()],
@@ -62,6 +79,8 @@ const mountBanner = ({ enabled = true, appName = 'Devkit', privacyPath = '/legal
       stubs: { RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] } },
     },
   });
+  return wrapper;
+};
 
 describe('legal.cookieBanner.component', () => {
   beforeEach(() => {
@@ -69,6 +88,11 @@ describe('legal.cookieBanner.component', () => {
     consent.value = null;
     acceptMock.mockReset();
     rejectMock.mockReset();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    document.body.innerHTML = '';
   });
 
   it('does not render snackbar when cookieConsent.enabled is false', () => {

--- a/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
+++ b/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { ref } from 'vue';
+import { createI18n } from 'vue-i18n';
+
+// v-snackbar uses visualViewport which is not available in happy-dom
+if (typeof globalThis.visualViewport === 'undefined') {
+  globalThis.visualViewport = { addEventListener: vi.fn(), removeEventListener: vi.fn(), width: 1024, height: 768 };
+}
+
+const acceptMock = vi.fn();
+const rejectMock = vi.fn();
+const consentNeeded = ref(true);
+
+vi.mock('../composables/useCookieConsent', () => ({
+  useCookieConsent: () => ({
+    consentNeeded,
+    consent: ref(null),
+    accept: acceptMock,
+    reject: rejectMock,
+    reopenSettings: vi.fn(),
+  }),
+}));
+
+import LegalCookieBanner from '../components/legal.cookieBanner.component.vue';
+
+const vuetify = () => createVuetify({ components, directives });
+const i18n = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en: {
+        legal: {
+          banner: {
+            message: 'We use analytics cookies to improve {appName}. See our',
+            privacyPolicy: 'Privacy Policy',
+            accept: 'Accept',
+            reject: 'Reject',
+            revokeMessage: 'Update your cookie preferences for {appName}.',
+          },
+        },
+      },
+    },
+  });
+
+const mountBanner = ({ enabled = true, appName = 'Devkit', privacyPath = '/legal/privacy' } = {}) =>
+  mount(LegalCookieBanner, {
+    attachTo: document.body,
+    global: {
+      plugins: [vuetify(), i18n()],
+      mocks: {
+        config: {
+          name: appName,
+          legal: { cookieConsent: { enabled, privacyPolicyPath: privacyPath } },
+        },
+      },
+      stubs: { RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] } },
+    },
+  });
+
+describe('legal.cookieBanner.component', () => {
+  beforeEach(() => {
+    consentNeeded.value = true;
+    acceptMock.mockReset();
+    rejectMock.mockReset();
+  });
+
+  it('does not render snackbar when cookieConsent.enabled is false', () => {
+    consentNeeded.value = true;
+    const wrapper = mountBanner({ enabled: false });
+    expect(wrapper.find('.v-snackbar').exists()).toBe(false);
+  });
+
+  it('does not render snackbar content when consentNeeded is false', async () => {
+    consentNeeded.value = false;
+    const wrapper = mountBanner();
+    await flushPromises();
+    // v-snackbar teleports outside wrapper; query document.body for content
+    expect(document.body.innerHTML).not.toContain('Accept');
+  });
+
+  it('renders Accept and Reject buttons when enabled and consentNeeded', async () => {
+    const wrapper = mountBanner();
+    await flushPromises();
+    // v-snackbar teleports outside wrapper; use findAllComponents to traverse VNode tree
+    const buttons = wrapper.findAllComponents({ name: 'VBtn' });
+    expect(buttons.some((b) => b.text() === 'Accept')).toBe(true);
+    expect(buttons.some((b) => b.text() === 'Reject')).toBe(true);
+  });
+
+  it('Accept button calls accept()', async () => {
+    const wrapper = mountBanner();
+    await flushPromises();
+    const buttons = wrapper.findAllComponents({ name: 'VBtn' });
+    const acceptBtn = buttons.find((b) => b.text() === 'Accept');
+    expect(acceptBtn).toBeTruthy();
+    await acceptBtn.trigger('click');
+    expect(acceptMock).toHaveBeenCalledOnce();
+  });
+
+  it('Reject button calls reject()', async () => {
+    const wrapper = mountBanner();
+    await flushPromises();
+    const buttons = wrapper.findAllComponents({ name: 'VBtn' });
+    const rejectBtn = buttons.find((b) => b.text() === 'Reject');
+    expect(rejectBtn).toBeTruthy();
+    await rejectBtn.trigger('click');
+    expect(rejectMock).toHaveBeenCalledOnce();
+  });
+
+  it('renders privacy policy link to configured path', async () => {
+    const wrapper = mountBanner({ privacyPath: '/custom-privacy' });
+    await flushPromises();
+    // v-snackbar teleports; query document.body for the rendered link
+    expect(document.body.innerHTML).toContain('Privacy Policy');
+    // RouterLink stub renders as <a> without "to" attr; check the path via innerHTML
+    expect(document.body.innerHTML).toContain('/custom-privacy');
+  });
+});

--- a/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
+++ b/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
@@ -14,11 +14,12 @@ if (typeof globalThis.visualViewport === 'undefined') {
 const acceptMock = vi.fn();
 const rejectMock = vi.fn();
 const consentNeeded = ref(true);
+const consent = ref(null);
 
 vi.mock('../composables/useCookieConsent', () => ({
   useCookieConsent: () => ({
     consentNeeded,
-    consent: ref(null),
+    consent,
     accept: acceptMock,
     reject: rejectMock,
     reopenSettings: vi.fn(),
@@ -65,12 +66,12 @@ const mountBanner = ({ enabled = true, appName = 'Devkit', privacyPath = '/legal
 describe('legal.cookieBanner.component', () => {
   beforeEach(() => {
     consentNeeded.value = true;
+    consent.value = null;
     acceptMock.mockReset();
     rejectMock.mockReset();
   });
 
   it('does not render snackbar when cookieConsent.enabled is false', () => {
-    consentNeeded.value = true;
     const wrapper = mountBanner({ enabled: false });
     expect(wrapper.find('.v-snackbar').exists()).toBe(false);
   });
@@ -119,5 +120,13 @@ describe('legal.cookieBanner.component', () => {
     expect(document.body.innerHTML).toContain('Privacy Policy');
     // RouterLink stub renders as <a> without "to" attr; check the path via innerHTML
     expect(document.body.innerHTML).toContain('/custom-privacy');
+  });
+
+  it('renders revokeMessage when consent is not null (banner reopened from footer)', async () => {
+    consentNeeded.value = true;
+    consent.value = { analytics: true };
+    mountBanner({ appName: 'Devkit' });
+    await flushPromises();
+    expect(document.body.innerHTML).toContain('Update your cookie preferences for Devkit');
   });
 });

--- a/src/modules/legal/tests/legal.footerSection.component.unit.tests.js
+++ b/src/modules/legal/tests/legal.footerSection.component.unit.tests.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import { useFooterExtras } from '@/lib/composables/useFooterExtras';
+
+const reopenSettingsMock = vi.fn();
+
+vi.mock('../composables/useCookieConsent', () => ({
+  useCookieConsent: () => ({
+    consentNeeded: { value: true },
+    consent: { value: null },
+    accept: vi.fn(),
+    reject: vi.fn(),
+    reopenSettings: reopenSettingsMock,
+  }),
+}));
+
+import LegalFooterSection from '../components/legal.footerSection.component.vue';
+
+/**
+ * Returns a fresh vue-i18n instance with legal footer keys.
+ * @returns {import('vue-i18n').I18n}
+ */
+const i18n = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en: {
+        legal: {
+          footer: { sectionTitle: 'Legal', cookieSettings: 'Cookie settings' },
+        },
+      },
+    },
+  });
+
+/**
+ * Mounts LegalFooterSection with the given config mock.
+ * @param {object} config - Config to inject as globalProperty
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountSection = (config = {}) =>
+  mount(LegalFooterSection, {
+    global: {
+      plugins: [i18n()],
+      config: { globalProperties: { config } },
+    },
+  });
+
+describe('legal.footerSection.component — registry behavior', () => {
+  beforeEach(() => {
+    const { extras } = useFooterExtras();
+    extras.value = [];
+    reopenSettingsMock.mockReset();
+  });
+
+  afterEach(() => {
+    const { extras } = useFooterExtras();
+    extras.value = [];
+  });
+
+  it('registers a "legal" section when cookieConsent is enabled', async () => {
+    const config = {
+      legal: {
+        cookieConsent: { enabled: true, privacyPolicyPath: '/legal/privacy' },
+        pages: { enabled: false, routePrefix: '/legal', items: {} },
+      },
+    };
+    mountSection(config);
+    await flushPromises();
+    const { extras } = useFooterExtras();
+    const legal = extras.value.find((s) => s._id === 'legal');
+    expect(legal).toBeTruthy();
+    expect(legal.title).toBe('Legal');
+    const cookie = legal.items.find((i) => i.label === 'Cookie settings');
+    expect(cookie).toBeTruthy();
+    expect(typeof cookie.onClick).toBe('function');
+  });
+
+  it('registers page items when pages.enabled is true', async () => {
+    const config = {
+      legal: {
+        cookieConsent: { enabled: false },
+        pages: {
+          enabled: true,
+          routePrefix: '/legal',
+          items: {
+            terms:   { enabled: true,  slug: 'terms',   title: 'Terms',   markdownPath: '/p/terms.md' },
+            privacy: { enabled: true,  slug: 'privacy', title: 'Privacy', markdownPath: '/p/privacy.md' },
+            off:     { enabled: false, slug: 'off',     title: 'Off',     markdownPath: '/p/off.md' },
+          },
+        },
+      },
+    };
+    mountSection(config);
+    await flushPromises();
+    const { extras } = useFooterExtras();
+    const legal = extras.value.find((s) => s._id === 'legal');
+    expect(legal).toBeTruthy();
+    const labels = legal.items.map((i) => i.label);
+    expect(labels).toContain('Terms');
+    expect(labels).toContain('Privacy');
+    expect(labels).not.toContain('Off');
+  });
+
+  it('does not register when both legal flags are off', async () => {
+    const config = {
+      legal: {
+        cookieConsent: { enabled: false },
+        pages: { enabled: false, items: {} },
+      },
+    };
+    mountSection(config);
+    await flushPromises();
+    const { extras } = useFooterExtras();
+    expect(extras.value.find((s) => s._id === 'legal')).toBeUndefined();
+  });
+
+  it('unregisters legal section on unmount', async () => {
+    const config = {
+      legal: {
+        cookieConsent: { enabled: true },
+        pages: { enabled: false, items: {} },
+      },
+    };
+    const wrapper = mountSection(config);
+    await flushPromises();
+    const { extras } = useFooterExtras();
+    expect(extras.value.find((s) => s._id === 'legal')).toBeTruthy();
+    wrapper.unmount();
+    expect(extras.value.find((s) => s._id === 'legal')).toBeUndefined();
+  });
+
+  it('cookie settings item.onClick calls reopenSettings', async () => {
+    const config = {
+      legal: {
+        cookieConsent: { enabled: true },
+        pages: { enabled: false, items: {} },
+      },
+    };
+    mountSection(config);
+    await flushPromises();
+    const { extras } = useFooterExtras();
+    const legal = extras.value.find((s) => s._id === 'legal');
+    const cookie = legal?.items.find((i) => i.label === 'Cookie settings');
+    expect(cookie).toBeTruthy();
+    cookie.onClick();
+    expect(reopenSettingsMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/modules/legal/tests/legal.page.view.unit.tests.js
+++ b/src/modules/legal/tests/legal.page.view.unit.tests.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { createI18n } from 'vue-i18n';
+
+let currentRouteParams = { slug: 'terms' };
+vi.mock('vue-router', () => ({ useRoute: () => ({ params: currentRouteParams }) }));
+
+vi.mock('../composables/useLegalPage', () => ({ useLegalPage: vi.fn() }));
+
+import LegalPageView from '../views/legal.page.view.vue';
+import { useLegalPage as useLegalPageMock } from '../composables/useLegalPage';
+
+const vuetify = () => createVuetify({ components, directives });
+const i18n = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: { legal: { pages: { notFound: 'This legal page does not exist.' } } } },
+  });
+
+const mountView = (slug = 'terms', config = {}) => {
+  currentRouteParams = { slug };
+  return mount(LegalPageView, {
+    global: {
+      plugins: [vuetify(), i18n()],
+      mocks: { config },
+    },
+  });
+};
+
+describe('legal.page.view', () => {
+  it('renders title + html for a valid page', async () => {
+    useLegalPageMock.mockResolvedValueOnce({ title: 'Terms', html: '<h1>Terms</h1><p>Body</p>', notFound: false });
+    const wrapper = mountView('terms');
+    await flushPromises();
+    expect(wrapper.text()).toContain('Terms');
+    expect(wrapper.html()).toContain('<h1>Terms</h1>');
+  });
+
+  it('renders not found message for unknown slug', async () => {
+    useLegalPageMock.mockResolvedValueOnce({ title: '', html: '', notFound: true });
+    const wrapper = mountView('unknown');
+    await flushPromises();
+    expect(wrapper.text()).toContain('This legal page does not exist.');
+  });
+});

--- a/src/modules/legal/tests/legal.page.view.unit.tests.js
+++ b/src/modules/legal/tests/legal.page.view.unit.tests.js
@@ -21,6 +21,12 @@ const i18n = () =>
     messages: { en: { legal: { pages: { notFound: 'This legal page does not exist.' } } } },
   });
 
+/**
+ * Mounts LegalPageView with a stubbed route param slug and optional config mock.
+ * @param {string} [slug='terms'] - Route param to simulate
+ * @param {object} [config={}] - Config mock injected via Vue Test Utils mocks
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
 const mountView = (slug = 'terms', config = {}) => {
   currentRouteParams = { slug };
   return mount(LegalPageView, {

--- a/src/modules/legal/tests/legal.router.unit.tests.js
+++ b/src/modules/legal/tests/legal.router.unit.tests.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+vi.mock('../views/legal.page.view.vue', () => ({ default: { name: 'LegalPageView' } }));
+
+vi.mock('@/config', () => ({
+  default: {
+    legal: {
+      pages: {
+        enabled: false,
+        routePrefix: '/legal',
+        items: {
+          terms:  { enabled: true,  slug: 'terms',   title: 'Terms',   markdownPath: '/p/terms.md' },
+          privacy:{ enabled: true,  slug: 'privacy', title: 'Privacy', markdownPath: '/p/privacy.md' },
+          off:    { enabled: false, slug: 'off',     title: 'Off',     markdownPath: '/p/off.md' },
+        },
+      },
+    },
+  },
+}));
+
+describe('legal.router', () => {
+  it('exports empty array when pages.enabled is false', async () => {
+    const mod = await import('../router/legal.router');
+    expect(mod.default).toEqual([]);
+  });
+});
+
+describe('legal.router — enabled', () => {
+  beforeAll(() => {
+    vi.resetModules();
+    vi.doMock('@/config', () => ({
+      default: {
+        legal: {
+          pages: {
+            enabled: true,
+            routePrefix: '/legal',
+            items: {
+              terms:  { enabled: true,  slug: 'terms',   title: 'Terms',   markdownPath: '/p/terms.md' },
+              privacy:{ enabled: true,  slug: 'privacy', title: 'Privacy', markdownPath: '/p/privacy.md' },
+              off:    { enabled: false, slug: 'off',     title: 'Off',     markdownPath: '/p/off.md' },
+            },
+          },
+        },
+      },
+    }));
+    vi.doMock('../views/legal.page.view.vue', () => ({ default: { name: 'LegalPageView' } }));
+  });
+
+  it('registers one dynamic catch-all route under routePrefix', async () => {
+    const mod = await import('../router/legal.router');
+    expect(mod.default).toHaveLength(1);
+    expect(mod.default[0].path).toBe('/legal/:slug');
+    expect(mod.default[0].name).toBe('LegalPage');
+    expect(mod.default[0].meta?.footer).toBe(true);
+  });
+});

--- a/src/modules/legal/tests/useCookieConsent.unit.tests.js
+++ b/src/modules/legal/tests/useCookieConsent.unit.tests.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, nextTick } from 'vue';
+import { useCookieConsent, COOKIE_CONSENT_LS_KEY, CONSENT_VERSION } from '../composables/useCookieConsent';
+
+const posthogMock = () => ({
+  set_config: vi.fn(),
+  opt_in_capturing: vi.fn(),
+  opt_out_capturing: vi.fn(),
+  reset: vi.fn(),
+  capture: vi.fn(),
+});
+
+const mountComposable = (posthog = posthogMock()) => {
+  let api;
+  const Comp = defineComponent({
+    setup() { api = useCookieConsent(); return {}; },
+    template: '<div />',
+  });
+  const wrapper = mount(Comp, {
+    global: { config: { globalProperties: { $posthog: posthog } } },
+  });
+  return { api, wrapper, posthog };
+};
+
+describe('useCookieConsent — storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it('reports consentNeeded=true when localStorage is empty', () => {
+    const { api } = mountComposable();
+    expect(api.consentNeeded.value).toBe(true);
+    expect(api.consent.value).toBe(null);
+  });
+
+  it('reads stored valid consent (analytics:true) and reports consentNeeded=false', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(
+      COOKIE_CONSENT_LS_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
+    );
+    const { api } = mountComposable();
+    expect(api.consentNeeded.value).toBe(false);
+    expect(api.consent.value).toEqual({ analytics: true });
+  });
+
+  it('treats expired consent as missing (re-prompts)', () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    localStorage.setItem(
+      COOKIE_CONSENT_LS_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, timestamp: '2024-01-01T00:00:00.000Z', expiresAt: past, analytics: true }),
+    );
+    const { api } = mountComposable();
+    expect(api.consentNeeded.value).toBe(true);
+  });
+
+  it('treats version mismatch as missing (re-prompts)', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(
+      COOKIE_CONSENT_LS_KEY,
+      JSON.stringify({ version: 999, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
+    );
+    const { api } = mountComposable();
+    expect(api.consentNeeded.value).toBe(true);
+  });
+
+  it('treats malformed JSON as missing (re-prompts, no throw)', () => {
+    localStorage.setItem(COOKIE_CONSENT_LS_KEY, '{not-json');
+    const { api } = mountComposable();
+    expect(api.consentNeeded.value).toBe(true);
+  });
+});

--- a/src/modules/legal/tests/useCookieConsent.unit.tests.js
+++ b/src/modules/legal/tests/useCookieConsent.unit.tests.js
@@ -72,3 +72,82 @@ describe('useCookieConsent — storage', () => {
     expect(api.consentNeeded.value).toBe(true);
   });
 });
+
+describe('useCookieConsent — actions', () => {
+  beforeEach(() => { localStorage.clear(); });
+
+  it('accept: writes LS, sets consent, calls posthog set_config + opt_in + capture', () => {
+    const { api, posthog } = mountComposable();
+    api.accept();
+    expect(api.consentNeeded.value).toBe(false);
+    expect(api.consent.value).toEqual({ analytics: true });
+    const stored = JSON.parse(localStorage.getItem(COOKIE_CONSENT_LS_KEY));
+    expect(stored.analytics).toBe(true);
+    expect(stored.version).toBe(CONSENT_VERSION);
+    expect(posthog.set_config).toHaveBeenCalledWith({ persistence: 'localStorage+cookie' });
+    expect(posthog.opt_in_capturing).toHaveBeenCalledOnce();
+    expect(posthog.capture).toHaveBeenCalledWith('consent_given', { analytics: true });
+  });
+
+  it('reject: writes LS, sets consent, calls posthog opt_out + reset', () => {
+    const { api, posthog } = mountComposable();
+    api.reject();
+    expect(api.consentNeeded.value).toBe(false);
+    expect(api.consent.value).toEqual({ analytics: false });
+    const stored = JSON.parse(localStorage.getItem(COOKIE_CONSENT_LS_KEY));
+    expect(stored.analytics).toBe(false);
+    expect(posthog.opt_out_capturing).toHaveBeenCalledOnce();
+    expect(posthog.reset).toHaveBeenCalledOnce();
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+  });
+
+  it('reopenSettings: flips consentNeeded to true without touching posthog or LS', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(
+      COOKIE_CONSENT_LS_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
+    );
+    const { api, posthog } = mountComposable();
+    expect(api.consentNeeded.value).toBe(false);
+    posthog.set_config.mockClear();
+    posthog.opt_in_capturing.mockClear();
+    api.reopenSettings();
+    expect(api.consentNeeded.value).toBe(true);
+    expect(posthog.set_config).not.toHaveBeenCalled();
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+    expect(localStorage.getItem(COOKIE_CONSENT_LS_KEY)).toBeTruthy();
+  });
+
+  it('on mount with prior accept: re-applies posthog opt_in (so banner-less reload still tracks)', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(
+      COOKIE_CONSENT_LS_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
+    );
+    const { posthog } = mountComposable();
+    expect(posthog.set_config).toHaveBeenCalledWith({ persistence: 'localStorage+cookie' });
+    expect(posthog.opt_in_capturing).toHaveBeenCalledOnce();
+  });
+
+  it('on mount with prior reject: does NOT call posthog opt_in (stays opt-out)', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(
+      COOKIE_CONSENT_LS_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: false }),
+    );
+    const { posthog } = mountComposable();
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+    expect(posthog.set_config).not.toHaveBeenCalled();
+  });
+
+  it('works without $posthog injected (no-op)', () => {
+    let api;
+    const Comp = defineComponent({
+      setup() { api = useCookieConsent(); return {}; },
+      template: '<div />',
+    });
+    mount(Comp, { global: { config: { globalProperties: {} } } });
+    expect(() => api.accept()).not.toThrow();
+    expect(() => api.reject()).not.toThrow();
+  });
+});

--- a/src/modules/legal/tests/useCookieConsent.unit.tests.js
+++ b/src/modules/legal/tests/useCookieConsent.unit.tests.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { defineComponent, nextTick } from 'vue';
+import { defineComponent } from 'vue';
 import { useCookieConsent, COOKIE_CONSENT_LS_KEY, CONSENT_VERSION } from '../composables/useCookieConsent';
 
 const posthogMock = () => ({

--- a/src/modules/legal/tests/useCookieConsent.unit.tests.js
+++ b/src/modules/legal/tests/useCookieConsent.unit.tests.js
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { defineComponent } from 'vue';
-import { useCookieConsent, COOKIE_CONSENT_LS_KEY, CONSENT_VERSION } from '../composables/useCookieConsent';
+import { useCookieConsent, COOKIE_CONSENT_LS_KEY, CONSENT_VERSION, __resetCookieConsentForTests } from '../composables/useCookieConsent';
 
+/**
+ * Returns a fresh PostHog mock with all tracked methods.
+ * @returns {{ set_config: vi.Mock, opt_in_capturing: vi.Mock, opt_out_capturing: vi.Mock, reset: vi.Mock, capture: vi.Mock }}
+ */
 const posthogMock = () => ({
   set_config: vi.fn(),
   opt_in_capturing: vi.fn(),
@@ -11,6 +15,12 @@ const posthogMock = () => ({
   capture: vi.fn(),
 });
 
+/**
+ * Mounts a minimal component that calls useCookieConsent in setup and
+ * returns the composable API alongside the wrapper and posthog mock.
+ * @param {object} [posthog] - PostHog mock to inject as $posthog globalProperty
+ * @returns {{ api: object, wrapper: import('@vue/test-utils').VueWrapper, posthog: object }}
+ */
 const mountComposable = (posthog = posthogMock()) => {
   let api;
   const Comp = defineComponent({
@@ -27,6 +37,7 @@ describe('useCookieConsent — storage', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.useRealTimers();
+    __resetCookieConsentForTests();
   });
 
   it('reports consentNeeded=true when localStorage is empty', () => {
@@ -41,6 +52,7 @@ describe('useCookieConsent — storage', () => {
       COOKIE_CONSENT_LS_KEY,
       JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
     );
+    __resetCookieConsentForTests();
     const { api } = mountComposable();
     expect(api.consentNeeded.value).toBe(false);
     expect(api.consent.value).toEqual({ analytics: true });
@@ -52,6 +64,7 @@ describe('useCookieConsent — storage', () => {
       COOKIE_CONSENT_LS_KEY,
       JSON.stringify({ version: CONSENT_VERSION, timestamp: '2024-01-01T00:00:00.000Z', expiresAt: past, analytics: true }),
     );
+    __resetCookieConsentForTests();
     const { api } = mountComposable();
     expect(api.consentNeeded.value).toBe(true);
   });
@@ -62,19 +75,24 @@ describe('useCookieConsent — storage', () => {
       COOKIE_CONSENT_LS_KEY,
       JSON.stringify({ version: 999, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
     );
+    __resetCookieConsentForTests();
     const { api } = mountComposable();
     expect(api.consentNeeded.value).toBe(true);
   });
 
   it('treats malformed JSON as missing (re-prompts, no throw)', () => {
     localStorage.setItem(COOKIE_CONSENT_LS_KEY, '{not-json');
+    __resetCookieConsentForTests();
     const { api } = mountComposable();
     expect(api.consentNeeded.value).toBe(true);
   });
 });
 
 describe('useCookieConsent — actions', () => {
-  beforeEach(() => { localStorage.clear(); });
+  beforeEach(() => {
+    localStorage.clear();
+    __resetCookieConsentForTests();
+  });
 
   it('accept: writes LS, sets consent, calls posthog set_config + opt_in + capture', () => {
     const { api, posthog } = mountComposable();
@@ -89,7 +107,7 @@ describe('useCookieConsent — actions', () => {
     expect(posthog.capture).toHaveBeenCalledWith('consent_given', { analytics: true });
   });
 
-  it('reject: writes LS, sets consent, calls posthog opt_out + reset', () => {
+  it('reject: writes LS, sets consent, calls posthog opt_out + reset, does NOT call set_config', () => {
     const { api, posthog } = mountComposable();
     api.reject();
     expect(api.consentNeeded.value).toBe(false);
@@ -99,6 +117,7 @@ describe('useCookieConsent — actions', () => {
     expect(posthog.opt_out_capturing).toHaveBeenCalledOnce();
     expect(posthog.reset).toHaveBeenCalledOnce();
     expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+    expect(posthog.set_config).not.toHaveBeenCalled();
   });
 
   it('reopenSettings: flips consentNeeded to true without touching posthog or LS', () => {
@@ -107,6 +126,7 @@ describe('useCookieConsent — actions', () => {
       COOKIE_CONSENT_LS_KEY,
       JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
     );
+    __resetCookieConsentForTests();
     const { api, posthog } = mountComposable();
     expect(api.consentNeeded.value).toBe(false);
     posthog.set_config.mockClear();
@@ -124,6 +144,7 @@ describe('useCookieConsent — actions', () => {
       COOKIE_CONSENT_LS_KEY,
       JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
     );
+    __resetCookieConsentForTests();
     const { posthog } = mountComposable();
     expect(posthog.set_config).toHaveBeenCalledWith({ persistence: 'localStorage+cookie' });
     expect(posthog.opt_in_capturing).toHaveBeenCalledOnce();
@@ -135,6 +156,7 @@ describe('useCookieConsent — actions', () => {
       COOKIE_CONSENT_LS_KEY,
       JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: false }),
     );
+    __resetCookieConsentForTests();
     const { posthog } = mountComposable();
     expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
     expect(posthog.set_config).not.toHaveBeenCalled();
@@ -149,5 +171,22 @@ describe('useCookieConsent — actions', () => {
     mount(Comp, { global: { config: { globalProperties: {} } } });
     expect(() => api.accept()).not.toThrow();
     expect(() => api.reject()).not.toThrow();
+  });
+
+  it('reopenSettings in one instance updates consentNeeded in a second instance (singleton state)', () => {
+    // Pre-fill LS so first mount has consent
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(
+      COOKIE_CONSENT_LS_KEY,
+      JSON.stringify({ version: CONSENT_VERSION, timestamp: '2026-05-07T00:00:00.000Z', expiresAt: future, analytics: true }),
+    );
+    __resetCookieConsentForTests();
+    const { api: api1 } = mountComposable();
+    const { api: api2 } = mountComposable();
+    expect(api1.consentNeeded.value).toBe(false);
+    expect(api2.consentNeeded.value).toBe(false);
+    api1.reopenSettings();
+    expect(api1.consentNeeded.value).toBe(true);
+    expect(api2.consentNeeded.value).toBe(true);
   });
 });

--- a/src/modules/legal/tests/useLegalPage.unit.tests.js
+++ b/src/modules/legal/tests/useLegalPage.unit.tests.js
@@ -1,6 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import { mount } from '@vue/test-utils';
-import { defineComponent } from 'vue';
 import { useLegalPage } from '../composables/useLegalPage';
 
 const mockSources = {
@@ -9,84 +7,77 @@ const mockSources = {
   '/src/modules/legal/assets/templates/no-placeholder.template.md': async () => '# Plain\n\nNo placeholders here.',
 };
 
-const mountWith = (slug, configOverrides = {}) => {
-  let api;
-  const config = {
-    legal: {
-      pages: {
-        routePrefix: '/legal',
-        items: {
-          terms:  { enabled: true,  slug: 'terms',   title: 'Terms',   markdownPath: '/src/modules/legal/assets/templates/terms.template.md' },
-          privacy:{ enabled: true,  slug: 'privacy', title: 'Privacy', markdownPath: '/src/modules/legal/assets/templates/privacy.template.md' },
-          plain:  { enabled: true,  slug: 'plain',   title: 'Plain',   markdownPath: '/src/modules/legal/assets/templates/no-placeholder.template.md' },
-          missing:{ enabled: true,  slug: 'missing', title: 'Missing', markdownPath: '/src/missing.md' },
-          off:    { enabled: false, slug: 'off',     title: 'Off',     markdownPath: '/src/modules/legal/assets/templates/terms.template.md' },
-        },
-        entity: { name: 'Acme Inc', legalForm: 'SAS', contactEmail: 'hi@acme.io' },
-        ...configOverrides,
+const baseConfig = (overrides = {}) => ({
+  legal: {
+    pages: {
+      routePrefix: '/legal',
+      items: {
+        terms:  { enabled: true,  slug: 'terms',   title: 'Terms',   markdownPath: '/src/modules/legal/assets/templates/terms.template.md' },
+        privacy:{ enabled: true,  slug: 'privacy', title: 'Privacy', markdownPath: '/src/modules/legal/assets/templates/privacy.template.md' },
+        plain:  { enabled: true,  slug: 'plain',   title: 'Plain',   markdownPath: '/src/modules/legal/assets/templates/no-placeholder.template.md' },
+        missing:{ enabled: true,  slug: 'missing', title: 'Missing', markdownPath: '/src/missing.md' },
+        off:    { enabled: false, slug: 'off',     title: 'Off',     markdownPath: '/src/modules/legal/assets/templates/terms.template.md' },
       },
+      entity: { name: 'Acme Inc', legalForm: 'SAS', contactEmail: 'hi@acme.io' },
+      ...overrides,
     },
-  };
-  const Comp = defineComponent({
-    async setup() { api = await useLegalPage(slug, { sources: mockSources, config }); return {}; },
-    template: '<div />',
-  });
-  return { mount: mount(Comp, { global: { config: { globalProperties: { config } } } }), getApi: () => api };
-};
+  },
+});
 
 describe('useLegalPage', () => {
   it('returns title and rendered HTML for valid slug', async () => {
-    const { getApi } = mountWith('terms');
-    await new Promise((r) => setTimeout(r, 0));
-    const api = getApi();
+    const api = await useLegalPage('terms', { sources: mockSources, config: baseConfig() });
     expect(api.title).toBe('Terms');
     expect(api.html).toContain('<h1>Terms</h1>');
   });
 
   it('substitutes {{entity.*}} placeholders from config', async () => {
-    const { getApi } = mountWith('terms');
-    await new Promise((r) => setTimeout(r, 0));
-    const api = getApi();
+    const api = await useLegalPage('terms', { sources: mockSources, config: baseConfig() });
     expect(api.html).toContain('Acme Inc');
     expect(api.html).toContain('SAS');
     expect(api.html).not.toContain('{{entity.name}}');
   });
 
   it('leaves placeholder literal when entity field is missing (no throw)', async () => {
-    const { getApi } = mountWith('privacy', {
-      entity: { name: null, legalForm: null, contactEmail: null },
+    const api = await useLegalPage('privacy', {
+      sources: mockSources,
+      config: baseConfig({ entity: { name: null, legalForm: null, contactEmail: null } }),
     });
-    await new Promise((r) => setTimeout(r, 0));
-    const api = getApi();
     expect(api.html).toContain('{{entity.contactEmail}}');
   });
 
   it('returns notFound=true for unknown slug', async () => {
-    const { getApi } = mountWith('does-not-exist');
-    await new Promise((r) => setTimeout(r, 0));
-    const api = getApi();
+    const api = await useLegalPage('does-not-exist', { sources: mockSources, config: baseConfig() });
     expect(api.notFound).toBe(true);
   });
 
   it('returns notFound=true when item is enabled=false', async () => {
-    const { getApi } = mountWith('off');
-    await new Promise((r) => setTimeout(r, 0));
-    const api = getApi();
+    const api = await useLegalPage('off', { sources: mockSources, config: baseConfig() });
     expect(api.notFound).toBe(true);
   });
 
   it('returns notFound=true when markdownPath does not exist in sources', async () => {
-    const { getApi } = mountWith('missing');
-    await new Promise((r) => setTimeout(r, 0));
-    const api = getApi();
+    const api = await useLegalPage('missing', { sources: mockSources, config: baseConfig() });
     expect(api.notFound).toBe(true);
   });
 
   it('does not error on placeholders without dot path', async () => {
-    const { getApi } = mountWith('plain');
-    await new Promise((r) => setTimeout(r, 0));
-    const api = getApi();
+    const api = await useLegalPage('plain', { sources: mockSources, config: baseConfig() });
     expect(api.html).toContain('<p>No placeholders here.</p>');
     expect(api.notFound).toBe(false);
+  });
+
+  it('strips XSS payloads from rendered markdown', async () => {
+    const xssSources = {
+      '/src/xss.md': async () => '# XSS Test\n\n<img src="x" onerror="alert(1)">',
+    };
+    const xssConfig = baseConfig({
+      items: {
+        xss: { enabled: true, slug: 'xss', title: 'XSS', markdownPath: '/src/xss.md' },
+      },
+    });
+    const api = await useLegalPage('xss', { sources: xssSources, config: xssConfig });
+    expect(api.notFound).toBe(false);
+    expect(api.html).not.toContain('onerror');
   });
 });

--- a/src/modules/legal/tests/useLegalPage.unit.tests.js
+++ b/src/modules/legal/tests/useLegalPage.unit.tests.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { useLegalPage } from '../composables/useLegalPage';
+
+const mockSources = {
+  '/src/modules/legal/assets/templates/terms.template.md': async () => '# Terms\n\nWelcome to {{entity.name}} ({{entity.legalForm}}).',
+  '/src/modules/legal/assets/templates/privacy.template.md': async () => '# Privacy\n\nContact: {{entity.contactEmail}}.',
+  '/src/modules/legal/assets/templates/no-placeholder.template.md': async () => '# Plain\n\nNo placeholders here.',
+};
+
+const mountWith = (slug, configOverrides = {}) => {
+  let api;
+  const config = {
+    legal: {
+      pages: {
+        routePrefix: '/legal',
+        items: {
+          terms:  { enabled: true,  slug: 'terms',   title: 'Terms',   markdownPath: '/src/modules/legal/assets/templates/terms.template.md' },
+          privacy:{ enabled: true,  slug: 'privacy', title: 'Privacy', markdownPath: '/src/modules/legal/assets/templates/privacy.template.md' },
+          plain:  { enabled: true,  slug: 'plain',   title: 'Plain',   markdownPath: '/src/modules/legal/assets/templates/no-placeholder.template.md' },
+          missing:{ enabled: true,  slug: 'missing', title: 'Missing', markdownPath: '/src/missing.md' },
+          off:    { enabled: false, slug: 'off',     title: 'Off',     markdownPath: '/src/modules/legal/assets/templates/terms.template.md' },
+        },
+        entity: { name: 'Acme Inc', legalForm: 'SAS', contactEmail: 'hi@acme.io' },
+        ...configOverrides,
+      },
+    },
+  };
+  const Comp = defineComponent({
+    async setup() { api = await useLegalPage(slug, { sources: mockSources, config }); return {}; },
+    template: '<div />',
+  });
+  return { mount: mount(Comp, { global: { config: { globalProperties: { config } } } }), getApi: () => api };
+};
+
+describe('useLegalPage', () => {
+  it('returns title and rendered HTML for valid slug', async () => {
+    const { getApi } = mountWith('terms');
+    await new Promise((r) => setTimeout(r, 0));
+    const api = getApi();
+    expect(api.title).toBe('Terms');
+    expect(api.html).toContain('<h1>Terms</h1>');
+  });
+
+  it('substitutes {{entity.*}} placeholders from config', async () => {
+    const { getApi } = mountWith('terms');
+    await new Promise((r) => setTimeout(r, 0));
+    const api = getApi();
+    expect(api.html).toContain('Acme Inc');
+    expect(api.html).toContain('SAS');
+    expect(api.html).not.toContain('{{entity.name}}');
+  });
+
+  it('leaves placeholder literal when entity field is missing (no throw)', async () => {
+    const { getApi } = mountWith('privacy', {
+      entity: { name: null, legalForm: null, contactEmail: null },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const api = getApi();
+    expect(api.html).toContain('{{entity.contactEmail}}');
+  });
+
+  it('returns notFound=true for unknown slug', async () => {
+    const { getApi } = mountWith('does-not-exist');
+    await new Promise((r) => setTimeout(r, 0));
+    const api = getApi();
+    expect(api.notFound).toBe(true);
+  });
+
+  it('returns notFound=true when item is enabled=false', async () => {
+    const { getApi } = mountWith('off');
+    await new Promise((r) => setTimeout(r, 0));
+    const api = getApi();
+    expect(api.notFound).toBe(true);
+  });
+
+  it('returns notFound=true when markdownPath does not exist in sources', async () => {
+    const { getApi } = mountWith('missing');
+    await new Promise((r) => setTimeout(r, 0));
+    const api = getApi();
+    expect(api.notFound).toBe(true);
+  });
+
+  it('does not error on placeholders without dot path', async () => {
+    const { getApi } = mountWith('plain');
+    await new Promise((r) => setTimeout(r, 0));
+    const api = getApi();
+    expect(api.html).toContain('<p>No placeholders here.</p>');
+    expect(api.notFound).toBe(false);
+  });
+});

--- a/src/modules/legal/views/legal.page.view.vue
+++ b/src/modules/legal/views/legal.page.view.vue
@@ -1,0 +1,34 @@
+<template>
+  <v-container class="legal-container py-12">
+    <v-row justify="center">
+      <v-col cols="12" md="10" lg="9">
+        <template v-if="page.notFound">
+          <v-alert type="warning" variant="tonal">
+            {{ $t('legal.pages.notFound') }}
+          </v-alert>
+        </template>
+        <template v-else>
+          <h1 class="mb-6">{{ page.title }}</h1>
+          <!-- eslint-disable-next-line vue/no-v-html -- Static markdown bundled at build time, no user input -->
+          <article class="legal-prose" v-html="page.html" />
+        </template>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import { useLegalPage } from '../composables/useLegalPage';
+
+const route = useRoute();
+const config = {};
+const page = ref({ title: '', html: '', notFound: false });
+
+const load = async (slug) => {
+  page.value = await useLegalPage(slug, { config });
+};
+
+watch(() => route.params.slug, (s) => load(s), { immediate: true });
+</script>

--- a/src/modules/legal/views/legal.page.view.vue
+++ b/src/modules/legal/views/legal.page.view.vue
@@ -21,9 +21,9 @@
 import { ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useLegalPage } from '../composables/useLegalPage';
+import config from '@/config';
 
 const route = useRoute();
-const config = {};
 const page = ref({ title: '', html: '', notFound: false });
 
 const load = async (slug) => {

--- a/src/modules/legal/views/legal.page.view.vue
+++ b/src/modules/legal/views/legal.page.view.vue
@@ -26,8 +26,20 @@ import config from '@/config';
 const route = useRoute();
 const page = ref({ title: '', html: '', notFound: false });
 
+/**
+ * Loads legal page content by slug.
+ * On network or parse failure, falls back to a not-found state so the view
+ * degrades gracefully without an unhandled rejection.
+ * @param {string} slug - The legal page slug (e.g. 'terms', 'privacy')
+ * @returns {Promise<void>}
+ */
 const load = async (slug) => {
-  page.value = await useLegalPage(slug, { config });
+  try {
+    page.value = await useLegalPage(slug, { config });
+  } catch (err) {
+    console.warn('[legal] page load failed', err);
+    page.value = { title: '', html: '', notFound: true };
+  }
 };
 
 watch(() => route.params.slug, (s) => load(s), { immediate: true });


### PR DESCRIPTION
## Why

Stripe KYC requires a legal compliance baseline (ToS, Privacy, Refund, Legal Notice, DPA) + RGPD cookie consent for EU. Centralizing in devkit avoids duplicating this across every downstream project and gives every new project a working baseline out of the box.

## What changed

See `MIGRATIONS.md` top entry (2026-05-07) for the full breakdown. Summary:

- **NEW** `src/modules/legal/` — cookie consent composable + banner + markdown legal pages renderer + 6 baseline templates + config + i18n
- **MODIFIED** `src/lib/plugins/posthog.js` — `opt_out_capturing_by_default: true` + `persistence: 'memory'` (RGPD: PostHog waits for explicit opt-in before setting cookies)
- **MODIFIED** `src/modules/core/components/core.footer.component.vue` — auto-injects "Legal" section + cookie settings link when enabled; fixes pre-existing hard-load footer-hide bug
- **MODIFIED** `src/modules/app/app.vue` — global mount of `<legalCookieBanner />`
- **MODIFIED** `src/modules/app/app.router.js` — spreads legal routes (empty array when `pages.enabled: false`)
- **MODIFIED** `src/lib/plugins/i18n.js` — merges `legalEn` / `legalFr`

**Non-breaking for default consumers** — all features disabled by default. PostHog opt-out is active globally (correct default for EU regardless of cookie consent module state).

## Test plan

- [ ] `npm run lint` — 0 issues
- [ ] `npm run test` — 1509/1509 passing (95 files)
- [ ] `npm run audit` — 0 new vulnerabilities (8 preexisting unchanged)
- [ ] Cookie banner appears on a downstream project after `legal.cookieConsent.enabled: true`
- [ ] Accept flow: PostHog `opt_in_capturing()` called, localStorage key `cookie_consent_v1` set with `analytics: true`
- [ ] Reject flow: PostHog `opt_out_capturing()` + `reset()` called, localStorage key set with `analytics: false`
- [ ] Legal page at `/legal/terms` renders with entity placeholder substitution when `pages.enabled: true`
- [ ] Footer "Legal" section and "Cookie settings" link appear only when enabled
- [ ] No footer flash on hard-load (created() hook fix)
- [ ] Downstream project with existing legal view can migrate by overriding `markdownPath` per item

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cookie consent banner with accept/reject options
  * Introduced legal pages module (Terms of Service, Privacy Policy, Refund Policy, and additional legal documents)
  * Added "Cookie settings" link in footer for managing consent preferences
  * PostHog analytics now respects user opt-in/opt-out choices before enabling data collection
  
* **Tests**
  * Added comprehensive unit tests for cookie consent and legal pages functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->