### PR TITLE
fix(legal): cookie consent + footer polish (5 QA bugs)

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -52,6 +52,14 @@ Stripe KYC requires a legal compliance baseline (ToS, Privacy, Refund, Legal Not
 
 ---
 
+### Polish (2026-05-07 QA)
+
+Three follow-up fixes shipped:
+- **Banner auto-hides when no posthog key** — `cookieConsent.enabled: true` without `analytics.posthog.key` is now a console-warned no-op (banner doesn't render). Previous behavior would render a banner whose Accept/Reject buttons silently did nothing.
+- **Banner viewport-anchored** — overrides `--v-layout-bottom: 0px` so the snackbar isn't pushed up by `<v-footer app>`'s height (was rendering mid-page on tall pages).
+- **Footer dedupes by title** — projects with a manual `footer.links` "Legal" section no longer get a duplicate column from the registry; the cookie settings link merges into the existing column.
+- **PostHog site apps disabled** — `opt_in_site_apps: false` on init prevents PostHog dashboard "Cookie Consent" site apps from rendering a second banner.
+
 ## core.pageHeader — breadcrumb slot + canonical 56px height + overflow fix (2026-04-26)
 
 **Non-breaking for default consumers.** The shared

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -54,7 +54,7 @@ Stripe KYC requires a legal compliance baseline (ToS, Privacy, Refund, Legal Not
 
 ### Polish (2026-05-07 QA)
 
-Three follow-up fixes shipped:
+Four follow-up fixes shipped:
 - **Banner auto-hides when no posthog key** — `cookieConsent.enabled: true` without `analytics.posthog.key` is now a console-warned no-op (banner doesn't render). Previous behavior would render a banner whose Accept/Reject buttons silently did nothing.
 - **Banner viewport-anchored** — overrides `--v-layout-bottom: 0px` so the snackbar isn't pushed up by `<v-footer app>`'s height (was rendering mid-page on tall pages).
 - **Footer dedupes by title** — projects with a manual `footer.links` "Legal" section no longer get a duplicate column from the registry; the cookie settings link merges into the existing column.

--- a/src/lib/plugins/posthog.js
+++ b/src/lib/plugins/posthog.js
@@ -41,6 +41,7 @@ export default {
 
       opt_out_capturing_by_default: true,
       persistence: 'memory',
+      opt_in_site_apps: false,
 
       autocapture: isEnabled(phConfig.autoCapture),
       capture_pageleave: isEnabled(phConfig.capturePageleave),

--- a/src/lib/plugins/tests/posthog.unit.tests.js
+++ b/src/lib/plugins/tests/posthog.unit.tests.js
@@ -258,4 +258,13 @@ describe('posthog plugin', () => {
       expect.objectContaining({ persistence: 'memory' }),
     );
   });
+
+  it('initializes posthog with opt_in_site_apps: false (prevents PostHog dashboard cookie banner site app)', () => {
+    const app = makeApp({ key: 'phc_testkey' });
+    posthogPlugin.install(app);
+    expect(posthog.init).toHaveBeenCalledWith(
+      'phc_testkey',
+      expect.objectContaining({ opt_in_site_apps: false }),
+    );
+  });
 });

--- a/src/modules/core/components/core.footer.component.vue
+++ b/src/modules/core/components/core.footer.component.vue
@@ -90,13 +90,28 @@ export default {
     },
     /**
      * @desc Combines the prop-provided footer links with sections registered by
-     * optional modules via `useFooterExtras`. Core has no knowledge of which
-     * modules injected the extras — they register/unregister via lifecycle hooks.
+     * optional modules via `useFooterExtras`. Extras whose title matches an
+     * existing config-driven section are merged into that section (items
+     * appended) rather than added as a new column — preventing duplicate
+     * headings (e.g. two "Legal" columns).
      * @returns {Array}
      */
     allLinks() {
-      const base = this.links || [];
-      return [...base, ...this.extras];
+      const base = (this.links || []).map((s) => ({ ...s, items: [...(s.items || [])] }));
+      const result = [...base];
+      const extras = this.extras || [];
+      for (const extra of extras) {
+        const existingIdx = result.findIndex((s) => s.title === extra.title);
+        if (existingIdx >= 0) {
+          result[existingIdx] = {
+            ...result[existingIdx],
+            items: [...result[existingIdx].items, ...(extra.items || [])],
+          };
+        } else {
+          result.push(extra);
+        }
+      }
+      return result;
     },
   },
   watch: {

--- a/src/modules/core/components/tests/core.footer.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.footer.component.unit.tests.js
@@ -111,6 +111,39 @@ describe('core.footer.component — registry extras', () => {
     expect(wrapper.text()).not.toContain('Removable');
   });
 
+  it('merges registered extras into existing config-driven section by title (no duplicate column)', () => {
+    const { register } = useFooterExtras();
+    register('legal-module', {
+      title: 'Legal',
+      items: [{ label: 'Cookie settings', icon: 'fa-solid fa-cookie', onClick: vi.fn() }],
+    });
+    const wrapper = mountFooter({
+      footer: {
+        links: [
+          {
+            title: 'Legal',
+            items: [
+              { label: 'Terms of Service', icon: 'fa-solid fa-file-contract', url: '/terms' },
+              { label: 'Privacy Policy', icon: 'fa-solid fa-shield-halved', url: '/privacy' },
+            ],
+          },
+        ],
+      },
+      vuetify: { theme: { flat: false } },
+      legal: {
+        cookieConsent: { enabled: true, privacyPolicyPath: '/privacy' },
+        pages: { enabled: false, routePrefix: '/legal', items: {} },
+      },
+    });
+    const text = wrapper.text();
+    expect(text).toContain('Terms of Service');
+    expect(text).toContain('Privacy Policy');
+    expect(text).toContain('Cookie settings');
+    // Single "Legal" column heading, not two
+    const legalHeadings = wrapper.findAll('.v-card-title').filter((c) => c.text().trim() === 'Legal');
+    expect(legalHeadings.length).toBe(1);
+  });
+
   it('calls item.onClick when item has an onClick callback', async () => {
     const { register } = useFooterExtras();
     const onClick = vi.fn();

--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -7,6 +7,7 @@
     multi-line
     :max-width="480"
     color="surface"
+    :style="{ '--v-layout-bottom': '0px' }"
   >
     <div class="text-body-2">
       {{ message }}

--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -42,7 +42,21 @@ const getConfig = () =>
   instance?.appContext?.config?.globalProperties?.config ||
   {};
 
-const enabled = computed(() => Boolean(getConfig()?.legal?.cookieConsent?.enabled));
+const enabled = computed(() => {
+  const cfgEnabled = Boolean(getConfig()?.legal?.cookieConsent?.enabled);
+  if (!cfgEnabled) return false;
+  const hasPosthog = Boolean(instance?.proxy?.$posthog || instance?.appContext?.config?.globalProperties?.$posthog);
+  if (!hasPosthog) {
+    if (typeof console !== 'undefined') {
+      console.warn(
+        '[legal.cookieBanner] cookieConsent.enabled is true but $posthog is not available. ' +
+        'The banner will not render. Set analytics.posthog.key to enable PostHog and the consent banner together.',
+      );
+    }
+    return false;
+  }
+  return true;
+});
 const privacyPolicyPath = computed(() => getConfig()?.legal?.cookieConsent?.privacyPolicyPath || '/legal/privacy');
 const appName = computed(() => getConfig()?.name || '');
 

--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -43,6 +43,13 @@ const getConfig = () =>
   instance?.appContext?.config?.globalProperties?.config ||
   {};
 
+/**
+ * Resolves whether the cookie banner can render.
+ * Returns true only when cookieConsent is enabled in config AND a PostHog
+ * instance is available via $posthog. When PostHog is absent, a console.warn
+ * is emitted and the banner is suppressed (no-op guard).
+ * @returns {boolean} True when the banner should render, false otherwise.
+ */
 const enabled = computed(() => {
   const cfgEnabled = Boolean(getConfig()?.legal?.cookieConsent?.enabled);
   if (!cfgEnabled) return false;

--- a/src/modules/legal/config/legal.development.config.js
+++ b/src/modules/legal/config/legal.development.config.js
@@ -1,5 +1,19 @@
 export default {
   legal: {
+    // ============================================================
+    // COOKIE CONSENT — RGPD/GDPR analytics gating
+    // ============================================================
+    // Activates a Vuetify v-snackbar (bottom-right) shown to the user
+    // on first visit. Only Accept persists posthog cookies.
+    //
+    // Prerequisites:
+    // - PostHog MUST be configured (analytics.posthog.key set, e.g.
+    //   via DEVKIT_VUE_analytics_posthog_key build-arg). When the
+    //   key is empty, the banner auto-hides and a console.warn is
+    //   emitted at init time. Enabling cookieConsent without posthog
+    //   is a no-op and should stay disabled.
+    //
+    // Defaults: disabled. Override per project.
     cookieConsent: {
       enabled: false,
       privacyPolicyPath: '/legal/privacy',

--- a/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
+++ b/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
@@ -75,6 +75,7 @@ const mountBanner = ({ enabled = true, appName = 'Devkit', privacyPath = '/legal
           name: appName,
           legal: { cookieConsent: { enabled, privacyPolicyPath: privacyPath } },
         },
+        $posthog: { capture: vi.fn(), opt_in_capturing: vi.fn(), opt_out_capturing: vi.fn(), reset: vi.fn(), set_config: vi.fn() },
       },
       stubs: { RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] } },
     },
@@ -152,5 +153,50 @@ describe('legal.cookieBanner.component', () => {
     mountBanner({ appName: 'Devkit' });
     await flushPromises();
     expect(document.body.innerHTML).toContain('Update your cookie preferences for Devkit');
+  });
+
+  it('does not render snackbar when $posthog is not available even if cookieConsent.enabled', async () => {
+    consentNeeded.value = true;
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const wrapper = mount(LegalCookieBanner, {
+      global: {
+        plugins: [vuetify(), i18n()],
+        mocks: {
+          config: {
+            name: 'Trawl',
+            legal: { cookieConsent: { enabled: true, privacyPolicyPath: '/privacy' } },
+          },
+        },
+        stubs: { RouterLink: { template: '<a><slot /></a>', props: ['to'] } },
+      },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    expect(document.body.innerHTML).not.toContain('Accept');
+    wrapper.unmount();
+    document.body.innerHTML = '';
+    consoleSpy.mockRestore();
+  });
+
+  it('renders snackbar when $posthog IS available and cookieConsent.enabled', async () => {
+    consentNeeded.value = true;
+    const wrapper = mount(LegalCookieBanner, {
+      global: {
+        plugins: [vuetify(), i18n()],
+        mocks: {
+          config: {
+            name: 'Trawl',
+            legal: { cookieConsent: { enabled: true, privacyPolicyPath: '/privacy' } },
+          },
+          $posthog: { capture: vi.fn(), opt_in_capturing: vi.fn(), opt_out_capturing: vi.fn(), reset: vi.fn(), set_config: vi.fn() },
+        },
+        stubs: { RouterLink: { template: '<a><slot /></a>', props: ['to'] } },
+      },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    expect(document.body.innerHTML).toContain('Accept');
+    wrapper.unmount();
+    document.body.innerHTML = '';
   });
 });


### PR DESCRIPTION
## Summary
Polish on the just-shipped legal module + cookie consent (PR #4097, merged 2026-05-07). Five visual / behavioral bugs found in QA on trawl.me prod.

- 🟠 #5 — Banner auto-hides when posthog key is missing (console.warn) so we don't show a banner whose buttons silently no-op
- 🟠 #2 — Banner viewport-anchored (was being pushed up ~288px by `<v-footer app>` height through Vuetify layout system)
- 🟠 #4 — Footer dedupes by title (registry "Legal" column no longer duplicates a config-driven "Legal" section)
- 🔴 #1 — `opt_in_site_apps: false` defensive (prevents PostHog dashboard "Cookie Consent" site app from rendering a second banner)
- 🟠 Bug #3 (CSS dark-on-dark on legal pages) → handled in trawl_vue separately

See MIGRATIONS.md polish addendum for downstream guidance.

## Test plan
- [x] Banner does not render when `analytics.posthog.key` is unset (console.warn'd)
- [x] Banner v-snackbar rendered with `--v-layout-bottom: 0px` (no layout offset)
- [x] Footer extras merge into existing config sections by title (no duplicate columns)
- [x] PostHog plugin: `opt_in_site_apps: false` asserted in unit test
- [ ] Visual smoke on trawl.me after merge (Bug #1 confirmation requires real posthog key + posthog dashboard config)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cookie consent banner now requires PostHog availability for operation.
  * Footer link sections with matching titles automatically merge to prevent duplicate headings.

* **Bug Fixes**
  * PostHog site apps opt-in rendering is now disabled by default.
  * Cookie banner gracefully disables when PostHog is unavailable, with console warnings logged.

* **Documentation**
  * Migration guide updated with legal module and cookie consent feature details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->