### PR TITLE
feat(analytics): PostHog service wrapper with GDPR-safe defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@
 # Analytics
 # VITE_POSTHOG_HOST=
 # VITE_POSTHOG_KEY=
+# DEVKIT_VUE_POSTHOG_KEY=
+# DEVKIT_VUE_POSTHOG_HOST=https://eu.i.posthog.com
 
 # Variables DEVKIT personnalisées (via generateConfig)
 # ===================================================

--- a/src/lib/services/posthog.js
+++ b/src/lib/services/posthog.js
@@ -1,0 +1,146 @@
+/**
+ * Module dependencies.
+ */
+import posthog from 'posthog-js';
+
+// ---------------------------------------------------------------------------
+// Module-scope initialization flag — prevents double-init across callers.
+// ---------------------------------------------------------------------------
+let _initialized = false;
+
+/**
+ * Test-only helper to reset the module-scope `_initialized` flag between test cases.
+ * NOT for production use.
+ * @internal
+ * @returns {void}
+ */
+export function __resetPostHogServiceForTests() {
+  _initialized = false;
+}
+
+/**
+ * @desc Initialize PostHog with GDPR-safe defaults.
+ *
+ * Idempotent: a second call is a no-op when PostHog is already loaded.
+ * Returns null when `enabled` is false or the project key is missing,
+ * so callers can check initialization without importing posthog-js directly.
+ *
+ * Key is read from `import.meta.env.DEVKIT_VUE_POSTHOG_KEY` (public-by-design,
+ * injected at build time). Host falls back to the EU PostHog cloud endpoint.
+ *
+ * GDPR gating: `opt_out_capturing_by_default: true` ensures no event is sent
+ * until the user explicitly accepts cookies via `optInTracking()`.
+ *
+ * @param {{ enabled?: boolean }} [options]
+ * @param {boolean} [options.enabled=true] - Pass false to skip initialization
+ *   (e.g. in development or when the feature is toggled off).
+ * @returns {object|null} The posthog singleton or null when not initialized.
+ */
+function initPostHog({ enabled = true } = {}) {
+  if (!enabled) return null;
+
+  const key = import.meta.env.DEVKIT_VUE_POSTHOG_KEY;
+  if (!key) return null;
+
+  // Already initialized (idempotency guard)
+  if (posthog.__loaded || _initialized) return posthog;
+
+  const host = import.meta.env.DEVKIT_VUE_POSTHOG_HOST || 'https://eu.i.posthog.com';
+
+  posthog.init(key, {
+    api_host: host,
+
+    // GDPR: no data until user explicitly opts in
+    opt_out_capturing_by_default: true,
+    persistence: 'localStorage+cookie',
+    // Only create profiles for identified users — avoids anonymous profile quota waste
+    person_profiles: 'identified_only',
+
+    // Pageview / pageleave tracking
+    capture_pageview: true,
+    capture_pageleave: true,
+
+    // Autocapture on (standard click/input events)
+    autocapture: true,
+
+    // Session recordings disabled by default; projects opt-in per downstream config
+    disable_session_recording: true,
+  });
+
+  _initialized = true;
+  return posthog;
+}
+
+/**
+ * @desc Check whether PostHog has been initialized and is ready to capture.
+ * @returns {boolean}
+ */
+function isReady() {
+  return !!(posthog && posthog.__loaded);
+}
+
+/**
+ * @desc Opt the current visitor into analytics capturing.
+ * No-op when PostHog is not initialized.
+ * Call this after the user accepts the cookie consent banner.
+ * @returns {void}
+ */
+function optInTracking() {
+  if (!isReady()) return;
+  posthog.opt_in_capturing();
+}
+
+/**
+ * @desc Opt the current visitor out of analytics capturing.
+ * No-op when PostHog is not initialized.
+ * Call this when the user declines or withdraws cookie consent.
+ * @returns {void}
+ */
+function optOutTracking() {
+  if (!isReady()) return;
+  posthog.opt_out_capturing();
+}
+
+/**
+ * @desc Associate subsequent events with a known user identity.
+ * No-op when PostHog is not initialized.
+ * Call after a successful sign-in.
+ *
+ * @param {string} distinctId - Unique user identifier (e.g. user._id from the API).
+ * @param {Object} [properties={}] - Optional user properties (email, plan, etc.).
+ * @returns {void}
+ */
+function identify(distinctId, properties = {}) {
+  if (!isReady()) return;
+  posthog.identify(distinctId, properties);
+}
+
+/**
+ * @desc Reset the PostHog session, generating a new anonymous distinct ID.
+ * No-op when PostHog is not initialized.
+ * Call on user sign-out so future events are not linked to the previous identity.
+ * @returns {void}
+ */
+function reset() {
+  if (!isReady()) return;
+  posthog.reset();
+}
+
+/**
+ * @desc Capture an explicit business event.
+ * No-op when PostHog is not initialized.
+ *
+ * @param {string} event - Event name (e.g. 'signup_completed').
+ * @param {Object} [properties={}] - Optional event properties.
+ * @returns {void}
+ */
+function capture(event, properties = {}) {
+  if (!isReady()) return;
+  posthog.capture(event, properties);
+}
+
+/**
+ * Exports.
+ */
+export { initPostHog, isReady, optInTracking, optOutTracking, identify, reset, capture };
+export default { initPostHog, isReady, optInTracking, optOutTracking, identify, reset, capture };

--- a/src/lib/services/tests/posthog.unit.tests.js
+++ b/src/lib/services/tests/posthog.unit.tests.js
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// posthog-js mock — must be hoisted before the service import.
+// ---------------------------------------------------------------------------
+vi.mock('posthog-js', () => {
+  const instance = {
+    __loaded: false,
+    init: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    capture: vi.fn(),
+  };
+  return { default: instance };
+});
+
+// import.meta.env stubs must be set before the module is first imported.
+vi.stubEnv('DEVKIT_VUE_POSTHOG_KEY', '');
+vi.stubEnv('DEVKIT_VUE_POSTHOG_HOST', '');
+
+import posthog from 'posthog-js';
+import {
+  initPostHog,
+  isReady,
+  optInTracking,
+  optOutTracking,
+  identify,
+  reset,
+  capture,
+  __resetPostHogServiceForTests,
+} from '../posthog';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset the service module-scope `_initialized` flag between tests.
+ * Resets both posthog.__loaded and the service internal flag.
+ */
+function resetServiceState() {
+  posthog.__loaded = false;
+  __resetPostHogServiceForTests();
+  vi.clearAllMocks();
+  // Re-stub envs to empty so each test controls its own setup
+  vi.stubEnv('DEVKIT_VUE_POSTHOG_KEY', '');
+  vi.stubEnv('DEVKIT_VUE_POSTHOG_HOST', '');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('posthog service', () => {
+  beforeEach(() => {
+    resetServiceState();
+  });
+
+  // -------------------------------------------------------------------------
+  // initPostHog
+  // -------------------------------------------------------------------------
+  describe('initPostHog', () => {
+    it('is a no-op and returns null when enabled is false', () => {
+      vi.stubEnv('DEVKIT_VUE_POSTHOG_KEY', 'phc_testkey');
+      const result = initPostHog({ enabled: false });
+      expect(result).toBeNull();
+      expect(posthog.init).not.toHaveBeenCalled();
+    });
+
+    it('returns null when DEVKIT_VUE_POSTHOG_KEY is missing', () => {
+      vi.stubEnv('DEVKIT_VUE_POSTHOG_KEY', '');
+      const result = initPostHog({ enabled: true });
+      expect(result).toBeNull();
+      expect(posthog.init).not.toHaveBeenCalled();
+    });
+
+    it('initializes posthog when enabled and key is present', () => {
+      vi.stubEnv('DEVKIT_VUE_POSTHOG_KEY', 'phc_testkey');
+      vi.stubEnv('DEVKIT_VUE_POSTHOG_HOST', 'https://eu.i.posthog.com');
+
+      const result = initPostHog({ enabled: true });
+
+      expect(posthog.init).toHaveBeenCalledOnce();
+      expect(posthog.init).toHaveBeenCalledWith(
+        'phc_testkey',
+        expect.objectContaining({
+          api_host: 'https://eu.i.posthog.com',
+          opt_out_capturing_by_default: true,
+          disable_session_recording: true,
+          capture_pageview: true,
+          capture_pageleave: true,
+          autocapture: true,
+          persistence: 'localStorage+cookie',
+          person_profiles: 'identified_only',
+        }),
+      );
+      expect(result).toBe(posthog);
+    });
+
+    it('uses the EU fallback host when DEVKIT_VUE_POSTHOG_HOST is not set', () => {
+      vi.stubEnv('DEVKIT_VUE_POSTHOG_KEY', 'phc_testkey');
+      vi.stubEnv('DEVKIT_VUE_POSTHOG_HOST', '');
+
+      initPostHog({ enabled: true });
+
+      expect(posthog.init).toHaveBeenCalledWith(
+        'phc_testkey',
+        expect.objectContaining({ api_host: 'https://eu.i.posthog.com' }),
+      );
+    });
+
+    it('is idempotent: second call does not re-init when posthog is already loaded', () => {
+      vi.stubEnv('DEVKIT_VUE_POSTHOG_KEY', 'phc_testkey');
+
+      // First call — simulate successful init by setting __loaded
+      initPostHog({ enabled: true });
+      posthog.__loaded = true;
+
+      // Second call — should be skipped
+      initPostHog({ enabled: true });
+
+      expect(posthog.init).toHaveBeenCalledOnce();
+    });
+
+    it('enabled defaults to true when not specified', () => {
+      vi.stubEnv('DEVKIT_VUE_POSTHOG_KEY', 'phc_testkey');
+
+      initPostHog();
+
+      expect(posthog.init).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isReady
+  // -------------------------------------------------------------------------
+  describe('isReady', () => {
+    it('returns false when posthog is not loaded', () => {
+      posthog.__loaded = false;
+      expect(isReady()).toBe(false);
+    });
+
+    it('returns true when posthog is loaded', () => {
+      posthog.__loaded = true;
+      expect(isReady()).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // optInTracking — no-op guard
+  // -------------------------------------------------------------------------
+  describe('optInTracking', () => {
+    it('is a no-op when posthog is not initialized', () => {
+      posthog.__loaded = false;
+      optInTracking();
+      expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+    });
+
+    it('calls posthog.opt_in_capturing when initialized', () => {
+      posthog.__loaded = true;
+      optInTracking();
+      expect(posthog.opt_in_capturing).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // optOutTracking — no-op guard
+  // -------------------------------------------------------------------------
+  describe('optOutTracking', () => {
+    it('is a no-op when posthog is not initialized', () => {
+      posthog.__loaded = false;
+      optOutTracking();
+      expect(posthog.opt_out_capturing).not.toHaveBeenCalled();
+    });
+
+    it('calls posthog.opt_out_capturing when initialized', () => {
+      posthog.__loaded = true;
+      optOutTracking();
+      expect(posthog.opt_out_capturing).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // identify — no-op guard
+  // -------------------------------------------------------------------------
+  describe('identify', () => {
+    it('is a no-op when posthog is not initialized', () => {
+      posthog.__loaded = false;
+      identify('user-123', { email: 'test@example.com' });
+      expect(posthog.identify).not.toHaveBeenCalled();
+    });
+
+    it('calls posthog.identify with distinctId and properties when initialized', () => {
+      posthog.__loaded = true;
+      identify('user-123', { email: 'test@example.com', plan: 'pro' });
+      expect(posthog.identify).toHaveBeenCalledOnce();
+      expect(posthog.identify).toHaveBeenCalledWith('user-123', { email: 'test@example.com', plan: 'pro' });
+    });
+
+    it('defaults properties to empty object when not provided', () => {
+      posthog.__loaded = true;
+      identify('user-456');
+      expect(posthog.identify).toHaveBeenCalledWith('user-456', {});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reset — no-op guard
+  // -------------------------------------------------------------------------
+  describe('reset', () => {
+    it('is a no-op when posthog is not initialized', () => {
+      posthog.__loaded = false;
+      reset();
+      expect(posthog.reset).not.toHaveBeenCalled();
+    });
+
+    it('calls posthog.reset when initialized', () => {
+      posthog.__loaded = true;
+      reset();
+      expect(posthog.reset).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // capture — no-op guard
+  // -------------------------------------------------------------------------
+  describe('capture', () => {
+    it('is a no-op when posthog is not initialized', () => {
+      posthog.__loaded = false;
+      capture('test_event', { key: 'value' });
+      expect(posthog.capture).not.toHaveBeenCalled();
+    });
+
+    it('calls posthog.capture with event and properties when initialized', () => {
+      posthog.__loaded = true;
+      capture('signup_completed', { plan: 'free' });
+      expect(posthog.capture).toHaveBeenCalledOnce();
+      expect(posthog.capture).toHaveBeenCalledWith('signup_completed', { plan: 'free' });
+    });
+
+    it('defaults properties to empty object when not provided', () => {
+      posthog.__loaded = true;
+      capture('page_viewed');
+      expect(posthog.capture).toHaveBeenCalledWith('page_viewed', {});
+    });
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import plugins from './lib/plugins';
 import config from './config/index.js';
 import { ability } from './lib/helpers/ability';
 import { captureException } from './lib/helpers/errorTracker.js';
+import { initPostHog } from './lib/services/posthog.js';
 import App from './modules/app/app.vue';
 
 const app = createApp(App);
@@ -39,6 +40,9 @@ app
 
 // Initialize stores after all plugins are loaded
 initializeStores(routes);
+
+// Bootstrap PostHog service (idempotent: no-op if plugin already initialized via config key)
+initPostHog({ enabled: import.meta.env.PROD });
 
 // Wire global error handlers — fan-out to active trackers (Sentry / PostHog)
 // Must be set after plugins so Sentry is already initialised


### PR DESCRIPTION
## Summary

- Adds `src/lib/services/posthog.js` — singleton wrapper exporting `initPostHog`, `optInTracking`, `optOutTracking`, `identify`, `reset`, `capture`
- `opt_out_capturing_by_default: true` + `person_profiles: 'identified_only'` ensure GDPR-safe defaults; no event fired until cookie consent accepted
- Idempotent with existing `plugins.posthog` (config-based init path): skips re-init if `posthog.__loaded` already true
- Wires `initPostHog({ enabled: import.meta.env.PROD })` in `main.js` (fallback init path for projects using env vars directly)
- Adds `DEVKIT_VUE_POSTHOG_KEY` / `DEVKIT_VUE_POSTHOG_HOST` to `.env.example`
- 20 unit tests, 100% `lib/services` coverage (statements/functions/lines)

## Test plan

- [ ] `npm run test:unit` — 1541 tests pass (97 files)
- [ ] `npm run test:coverage` — `lib/services` 100% stmts/funcs/lines, 98%+ branches
- [ ] `npx eslint src/lib/services/posthog.js src/lib/services/tests/posthog.unit.tests.js src/main.js` — 0 issues
- [ ] Verify idempotency: downstream project with config-based key set → plugin init fires, service `initPostHog` is no-op
- [ ] Verify GDPR gate: no PostHog events fire until `optInTracking()` called (opt_out_capturing_by_default)