### PR TITLE
feat(billing): pricingCard Free CTA conditional on auth state

### DIFF
--- a/src/modules/billing/components/billing.pricingCard.component.vue
+++ b/src/modules/billing/components/billing.pricingCard.component.vue
@@ -93,7 +93,7 @@
                 size="large"
                 disabled
               >
-                {{ plan.cta }}
+                {{ effectiveCtaLabel }}
               </v-btn>
             </span>
           </template>
@@ -110,7 +110,7 @@
           :disabled="ctaDisabled"
           @click="selectPlan"
         >
-          {{ plan.cta }}
+          {{ effectiveCtaLabel }}
         </v-btn>
       </template>
       <v-btn
@@ -194,6 +194,7 @@ import BillingEquivalencesChipsComponent from './billing.equivalencesChips.compo
 import BillingPricingFeatureSectionComponent from './billing.pricingFeatureSection.component.vue';
 import { useCurrencyFormat } from '../composables/billing.useCurrencyFormat.js';
 import { computeAnnualSavingsPct } from '../lib/pricingMath.js';
+import { useAuthStore } from '../../auth/stores/auth.store.js';
 
 /**
  * Component definition.
@@ -232,12 +233,13 @@ export default {
   },
   emits: ['select'],
   /**
-   * @desc Inject currency formatter so templates can call formatPrice(amount).
-   * @returns {{ formatPrice: Function }}
+   * @desc Inject currency formatter and auth store.
+   * @returns {{ formatPrice: Function, authStore: Object }}
    */
   setup() {
     const { formatPrice } = useCurrencyFormat();
-    return { formatPrice };
+    const authStore = useAuthStore();
+    return { formatPrice, authStore };
   },
   computed: {
     /**
@@ -253,6 +255,21 @@ export default {
         typeof this.equivalences[0] === 'object' &&
         this.equivalences[0]?.kind != null
       );
+    },
+    /**
+     * @desc Whether the visiting user is a guest (not signed-in).
+     * @returns {boolean}
+     */
+    isGuest() {
+      return !this.authStore.isLoggedIn;
+    },
+    /**
+     * @desc CTA label — Free plan + guest → i18n "Sign up", else plan.cta.
+     * @returns {string}
+     */
+    effectiveCtaLabel() {
+      if (this.isFree && this.isGuest) return this.$t('billing.pricingCard.signUpCta');
+      return this.plan.cta;
     },
     /**
      * @desc Whether this plan is explicitly free (by ID convention).
@@ -332,19 +349,28 @@ export default {
     },
     /**
      * @desc Whether the CTA should be disabled.
+     * Free + guest is always actionable (routes to signup) — never disabled.
      * @returns {boolean}
      */
     ctaDisabled() {
+      // Free + guest is always actionable (routes to signup) — never disabled
+      if (this.isFree && this.isGuest) return false;
       return this.loading || (!this.isFree && !this.activePriceId);
     },
   },
   methods: {
     /**
      * @desc Emit a plan selection when the CTA is actionable.
+     * Free plan + guest → emit different shape so the view can route to /signup.
      * @returns {void}
      */
     selectPlan() {
       if (this.ctaDisabled) return;
+      // Free plan + guest → emit different shape so the view can route to /signup
+      if (this.isFree && this.isGuest) {
+        this.$emit('select', { planId: this.plan.id, priceId: null, intent: 'signup' });
+        return;
+      }
       this.$emit('select', { planId: this.plan.id, priceId: this.activePriceId });
     },
   },

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -247,6 +247,8 @@ export const billingEn = {
       currentPlan: 'Current Plan',
       /** i18n key: billing.pricingCard.saveAnnual — interpolate {pct} */
       saveAnnual: 'Save {pct}% with annual',
+      /** i18n key: billing.pricingCard.signUpCta */
+      signUpCta: 'Sign up',
     },
     pricingFeatureSection: {
       /** i18n key: billing.pricingFeatureSection.everythingIn — interpolate {plan} */

--- a/src/modules/billing/lang/fr.js
+++ b/src/modules/billing/lang/fr.js
@@ -241,6 +241,8 @@ export const billingFr = {
       currentPlan: 'Plan actuel',
       /** i18n key: billing.pricingCard.saveAnnual — interpolate {pct} */
       saveAnnual: '-{pct}% en annuel',
+      /** i18n key: billing.pricingCard.signUpCta */
+      signUpCta: 'Créer un compte',
     },
     pricingFeatureSection: {
       /** i18n key: billing.pricingFeatureSection.everythingIn — interpolate {plan} */

--- a/src/modules/billing/tests/billing.pricingCard.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingCard.component.unit.tests.js
@@ -5,6 +5,7 @@ import { createVuetify } from 'vuetify';
 import { createI18n } from 'vue-i18n';
 import BillingPricingCardComponent from '../components/billing.pricingCard.component.vue';
 import { billingEn } from '../lang/en.js';
+import { useAuthStore } from '../../auth/stores/auth.store.js';
 
 const i18n = createI18n({ legacy: false, globalInjection: true, locale: 'en', fallbackLocale: 'en', messages: { en: { ...billingEn } } });
 
@@ -65,6 +66,40 @@ const mountComponent = (props = {}) =>
       },
     },
   });
+
+/**
+ * Mount the pricing card with auth store seeded.
+ * @param {Object} options - { plan, authIsLoggedIn, ...componentProps }
+ * @returns {import('@vue/test-utils').VueWrapper} Mounted wrapper
+ */
+const mountCard = ({ authIsLoggedIn = false, ...props } = {}) => {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  // Seed auth store: isLoggedIn = !!cookieExpire
+  if (authIsLoggedIn) {
+    const auth = useAuthStore();
+    auth.cookieExpire = '2099-01-01';
+  }
+  return mount(BillingPricingCardComponent, {
+    props: { plan: freePlan, annual: false, current: false, ...props },
+    global: {
+      plugins: [pinia, vuetify, i18n],
+      mocks: { config: mockConfig },
+      stubs: {
+        'v-tooltip': {
+          name: 'v-tooltip',
+          props: ['text', 'location'],
+          template: '<div class="v-tooltip-stub"><slot name="activator" :props="{}" /></div>',
+        },
+        'v-skeleton-loader': {
+          name: 'v-skeleton-loader',
+          props: ['type'],
+          template: '<div class="v-skeleton-loader-stub" />',
+        },
+      },
+    },
+  });
+};
 
 describe('BillingPricingCardComponent', () => {
   beforeEach(() => {
@@ -344,5 +379,36 @@ describe('BillingPricingCardComponent', () => {
     expect(wrapper.text()).toContain('190');
     // 19*12=228, 190 → 17% savings
     expect(wrapper.text()).toMatch(/17%/);
+  });
+
+  // ── Task 1.1: auth-aware CTA for Free plan ────────────────────────────────
+
+  it('Free plan + guest → CTA label is "Sign up"', () => {
+    const plan = { id: 'free', name: 'Free', tagline: 't', cta: 'Get Started', features: [], featureSections: [] };
+    const wrapper = mountCard({ plan, authIsLoggedIn: false });
+    expect(wrapper.text()).toContain('Sign up');
+    expect(wrapper.text()).not.toContain('Get Started');
+  });
+
+  it('Free plan + signed-in → CTA label uses plan.cta (default)', () => {
+    const plan = { id: 'free', name: 'Free', tagline: 't', cta: 'Get Started', features: [], featureSections: [] };
+    const wrapper = mountCard({ plan, authIsLoggedIn: true });
+    expect(wrapper.text()).toContain('Get Started');
+  });
+
+  it('Paid plan + guest → CTA label uses plan.cta (NOT "Sign up")', () => {
+    const plan = { id: 'pro', name: 'Pro', tagline: 't', cta: 'Go Pro', features: [], featureSections: [], monthlyPrice: 39, annualPrice: 390 };
+    const wrapper = mountCard({ plan, authIsLoggedIn: false });
+    expect(wrapper.text()).toContain('Go Pro');
+    expect(wrapper.text()).not.toContain('Sign up');
+  });
+
+  it('Free plan + guest click → emits select with intent: "signup"', async () => {
+    const plan = { id: 'free', name: 'Free', tagline: 't', cta: 'Get Started', features: [], featureSections: [] };
+    const wrapper = mountCard({ plan, authIsLoggedIn: false });
+    await wrapper.find('button').trigger('click');
+    const emits = wrapper.emitted('select');
+    expect(emits).toBeTruthy();
+    expect(emits[0][0].intent).toBe('signup');
   });
 });

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -325,7 +325,17 @@ export default {
         this.error = this.$t('billing.pricing.error.loadFailed');
       }
     },
-    async onSelectPlan({ planId, priceId }) {
+    /**
+     * @desc Handle plan select event from card.
+     * @param {{ planId: string, priceId: string|null, intent?: 'signup' }} payload
+     * @returns {Promise<void>}
+     */
+    async onSelectPlan({ planId, priceId, intent }) {
+      // Free + guest → route to signup
+      if (intent === 'signup') {
+        this.$router.push({ path: '/signup', query: { redirect: '/pricing' } });
+        return;
+      }
       if (!this.authStore.isLoggedIn) {
         this.$router.push({ path: '/signin', query: { redirect: '/pricing' } });
         return;


### PR DESCRIPTION
## Summary

Free plan CTA on `BillingPricingCardComponent` is now auth-aware:
- **Guest (not signed-in)** → CTA shows i18n "Sign up" + click navigates to `/signup?redirect=/pricing`
- **Signed-in (non-current free)** → uses default `plan.cta` label (unchanged)
- **Signed-in + current free** → "Current plan" disabled state (unchanged)

Other plans unchanged. Other behaviors in `onSelectPlan` (org-required redirect, downgrade detection, checkout) preserved.

## Test plan

- [x] 4 new unit tests covering: guest CTA label, signed-in CTA label, paid plan + guest stays on plan.cta, guest click emits `intent: 'signup'`
- [x] Existing 26 pricingCard tests still pass (no regression)
- [x] Full suite: 100 test files, 1594 tests all green
- [x] Lint clean

## Followup

This unlocks the Trawl static-content rebalance PR (will be opened separately on trawl_vue post-merge here, includes header copy / 6 comparable features / 3-tier packs).

Plan: `infra/docs/superpowers/plans/2026-05-08-pricing-v2-polish.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pricing cards now personalize the free plan CTA for guest users, displaying "Sign up" with direct routing to account creation.

* **Tests**
  * Added authentication-aware test coverage for pricing card interactions and guest signup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->