### PR TITLE
docs(stack): forbid downstream side-effect imports in src/main.js (#4093)

### DIFF
--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -107,3 +107,22 @@ Read the last entries — they list breaking changes requiring updates in projec
 Diff project modules against `src/modules/tasks` (stack reference). Fix any pattern drift flagged by `ERRORS.md`.
 
 ### 6. `/verify`
+
+---
+
+### Red flag: conflicts in `src/main.js`
+
+`src/main.js` is stack-managed. If `/update-stack` reports a conflict here, do NOT keep the downstream side via `--ours`. Instead:
+
+1. List the downstream-only lines:
+
+   ```bash
+   git diff --name-only HEAD..origin/master -- src/main.js
+   git log --oneline -- src/main.js | head -10
+   ```
+
+2. Move each downstream-only side-effect (`import './modules/.../foo.css'`, posthog/sentry init, custom plugin install) into a project-owned entry — typically `src/modules/{project}/views/{project}.view.vue` (preferred) or a downstream-only module index imported from there.
+3. Take the upstream version of `src/main.js` (`git checkout --theirs src/main.js`) once the migrations are committed.
+4. Add a regression note to `DOWNSTREAM_PATCHES.md` if the migration is non-obvious.
+
+This protects against the silent visual / analytics regressions seen in `comes-io/trawl_vue#856` (per-card mesh/grain CSS wiped on stack sync).

--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -117,7 +117,9 @@ Diff project modules against `src/modules/tasks` (stack reference). Fix any patt
 1. List the downstream-only lines:
 
    ```bash
-   git diff --name-only HEAD..origin/master -- src/main.js
+   # Show the actual downstream-only lines that exist locally but not in upstream stack
+   git diff devkit-vue/master..HEAD -- src/main.js
+   # (alternatively, check the conflict markers left by the merge)
    git log --oneline -- src/main.js | head -10
    ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,16 @@ Vue 3 + Vuetify 4 stack from Devkit. Standalone frontend or fullstack with Node/
 - **Post-login redirect**: Set `sign.route` in global config override. Used by signin, signup, and org flows. Default: `/tasks`.
 - **Custom home page**: Replace `home.router.js` with a project-specific router that maps `/` to a custom view. Set `display: false` in route meta to hide from sidenav.
 
+## Stack-managed entry points
+
+- `src/main.js` is **strictly stack-managed**. Downstream projects MUST NOT add side-effect imports here — global CSS, analytics config, sentry tags, plugin bootstrap, etc. — because `/update-stack --theirs` will silently wipe them on the next sync.
+- Downstream-only side effects belong in a project-owned entry:
+  - A project view that always mounts (e.g. `src/modules/{project}/views/{project}.view.vue`).
+  - A project module index imported from a downstream-only file.
+  - A project-scoped barrel imported from a downstream-only `App.vue` slot or layout.
+- If a downstream project has no such entry, the right escape hatch is to create one (issue [pierreb-devkit/Vue#4093](https://github.com/pierreb-devkit/Vue/issues/4093) — option C is reserved for future migration if option A friction grows).
+- This rule applies retroactively: when `/update-stack` reports `src/main.js` as a conflict, the downstream side of the conflict must be moved to a project-only entry, never re-applied as a `--ours` patch.
+
 ## Guardrails
 
 - Never commit secrets (`.env*`, keys, tokens)

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -21,3 +21,4 @@ Use this file as a compact memory of recurring AI mistakes.
 - [2026-03-13] docs: duplicate doc files covering the same topic (e.g. MIGRATION.md + MIGRATIONS.md) -> single file, no duplication
 - [2026-03-15] auth: adding CASL route guard (action/subject) without checking abilities config -> read abilities file first to confirm the ability exists for target roles; deny access by default if no matching ability (do not downgrade to `requiresAuth`)
 - [2026-03-15] pr scope: batching multiple unrelated fixes in one PR -> one fix = one PR to isolate blast radius and reduce iteration loops
+- [2026-05-09] update-stack: adding `import './modules/foo/styles/x.css'` to src/main.js downstream -> moved to project view (`src/modules/{project}/views/{project}.view.vue`). Stack-managed entry; --theirs wipes silently. See pierreb-devkit/Vue#4093.


### PR DESCRIPTION
## Summary

Document the convention that downstream-only side-effect imports (CSS, posthog, sentry, plugin bootstrap, etc.) MUST NOT live in `src/main.js` — they survive `/update-stack --theirs` only when scoped to a project-owned entry.

## Changes

- `CLAUDE.md` — "Stack-managed entry points" rule + escape-hatch guidance
- `.claude/skills/update-stack/SKILL.md` — red-flag entry for `src/main.js` conflicts
- `ERRORS.md` — pitfall entry dated 2026-05-09

## Why option A (convention only)?

The issue listed three options:
- **A. Convention only (docs)** ← chosen
- B. Vite plugin `@stack-keep` magic-comment guardrail
- C. `src/main.project.js` slot file imported from `main.js`, gitignored from stack updates

A keeps the rupture surface minimal — no new tooling, no new files for downstream to remember to create. C is reserved as a future escalation if A's discipline proves insufficient.

## Test plan

- [x] Markdown renders cleanly
- [x] No code/test changes
- [x] No behaviour change for existing downstreams

closes pierreb-devkit/Vue#4093