### PR TITLE
fix(legal): gate cookie banner on isMounted to prevent prerender hydration double-render

### DIFF
--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -1,6 +1,6 @@
 <template>
   <v-snackbar
-    v-if="enabled"
+    v-if="enabled && isMounted"
     v-model="visible"
     location="bottom right"
     :timeout="-1"
@@ -27,11 +27,14 @@
 </template>
 
 <script setup>
-import { computed, getCurrentInstance } from 'vue';
+import { computed, getCurrentInstance, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useCookieConsent } from '../composables/useCookieConsent';
 
 const instance = getCurrentInstance();
+
+const isMounted = ref(false);
+onMounted(() => { isMounted.value = true; });
 
 /**
  * Reads the devkit config lazily to support both globalProperties (prod) and

--- a/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
+++ b/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
@@ -101,6 +101,18 @@ describe('legal.cookieBanner.component', () => {
     expect(wrapper.find('.v-snackbar').exists()).toBe(false);
   });
 
+  it('renders snackbar after mount completes (isMounted hydration guard lifts on onMounted)', async () => {
+    // The component gates v-snackbar on `isMounted` (set true in onMounted) to prevent
+    // prerender from capturing the teleported snackbar outside #app, which would cause
+    // Vue hydration to mount a second banner alongside the prerendered one.
+    // In the test environment onMounted fires synchronously, so the banner IS visible
+    // immediately after mount — confirming the guard correctly lifts at runtime.
+    const w = mountBanner();
+    await flushPromises();
+    const buttons = w.findAllComponents({ name: 'VBtn' });
+    expect(buttons.some((b) => b.text() === 'Accept')).toBe(true);
+  });
+
   it('does not render snackbar content when consentNeeded is false', async () => {
     consentNeeded.value = false;
     mountBanner();


### PR DESCRIPTION
## Summary

- Adds `isMounted` ref (initialized `false`, set `true` in `onMounted`) to `legal.cookieBanner.component.vue`
- Gates `v-snackbar` on `v-if="enabled && isMounted"` so the banner is never rendered during prerender/SSR
- Fixes a prod bug on trawl.me where the Puppeteer prerender plugin captured the teleported snackbar outside `#app`, causing Vue hydration to mount a second banner alongside the prerendered one (two `.v-snackbar` elements visible in the HTML response)

## Root cause

`v-snackbar` uses Vue's `<Teleport>` to render to `<body>`. The Puppeteer prerender plugin captured the teleported DOM outside `#app`. At client runtime, Vue hydrated `#app` (which did not contain the snackbar) and mounted a new one, leaving the prerendered element orphaned — resulting in two stacked banners, only the new one interactive.

## Fix

`onMounted` never fires during SSR/prerender, so gating on `isMounted` ensures the snackbar is absent from the prerendered HTML entirely. The client then mounts it fresh without a hydration conflict.

## Test plan

- [ ] All 1595 existing unit tests pass (`npm run test:unit`)
- [ ] Lint clean (`npm run lint`)
- [ ] New test `renders snackbar after mount completes (isMounted hydration guard lifts on onMounted)` confirms the guard lifts correctly at runtime
- [ ] Coverage non-regressive (98.9% statements)
- [ ] Verify on trawl.me after deploy: only one `.v-snackbar` element in HTML response body