### PR TITLE
fix(build): drop ARG defaults for analytics_* + filter empty env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,22 @@ ARG DEVKIT_VUE_api_host='localhost'
 ARG DEVKIT_VUE_api_port='3000'
 ARG DEVKIT_VUE_api_base='api'
 ARG DEVKIT_VUE_cookie_prefix='waos'
-ARG DEVKIT_VUE_analytics_sentry_dsn=''
-ARG DEVKIT_VUE_analytics_sentry_environment='production'
-ARG DEVKIT_VUE_analytics_posthog_key=''
-ARG DEVKIT_VUE_analytics_posthog_host='https://us.i.posthog.com'
-ARG DEVKIT_VUE_analytics_posthog_errorTracking='false'
-ARG DEVKIT_VUE_analytics_posthog_autoCapture='false'
-ARG DEVKIT_VUE_analytics_posthog_sessionReplay='false'
-ARG DEVKIT_VUE_analytics_posthog_featureFlags='false'
-ARG DEVKIT_VUE_analytics_posthog_surveys='false'
-ARG DEVKIT_VUE_analytics_posthog_webVitals='false'
-ARG DEVKIT_VUE_analytics_posthog_capturePageleave='false'
+# Analytics ARGs: declared without defaults so BuildKit does NOT leak empty
+# strings into process.env at build time. With defaults, BuildKit exposes
+# the ARG as an env var to RUN steps, and generateConfig.js Layer 5
+# (DEVKIT_VUE_* env-var override) silently overrides downstream
+# config-file values with the empty/false defaults. Issue: pierreb-devkit/Vue#4110
+ARG DEVKIT_VUE_analytics_sentry_dsn
+ARG DEVKIT_VUE_analytics_sentry_environment
+ARG DEVKIT_VUE_analytics_posthog_key
+ARG DEVKIT_VUE_analytics_posthog_host
+ARG DEVKIT_VUE_analytics_posthog_errorTracking
+ARG DEVKIT_VUE_analytics_posthog_autoCapture
+ARG DEVKIT_VUE_analytics_posthog_sessionReplay
+ARG DEVKIT_VUE_analytics_posthog_featureFlags
+ARG DEVKIT_VUE_analytics_posthog_surveys
+ARG DEVKIT_VUE_analytics_posthog_webVitals
+ARG DEVKIT_VUE_analytics_posthog_capturePageleave
 
 # Install app dependencies & build
 COPY package*.json ./

--- a/scripts/generateConfig.js
+++ b/scripts/generateConfig.js
@@ -138,9 +138,12 @@ const getConfiguration = async () => {
     }
   }
 
-  // 5. DEVKIT_VUE_* env var overrides (final layer)
+  // 5. DEVKIT_VUE_* env var overrides (final layer).
+  // Skip empty-string values: they're typically Dockerfile ARG defaults that
+  // BuildKit leaks into process.env, and treating them as overrides would
+  // silently zero downstream config-file values. See Vue#4110.
   const environmentVars = mapKeys(
-    pickBy(process.env, (_value, key) => key.startsWith('DEVKIT_VUE_')),
+    pickBy(process.env, (value, key) => key.startsWith('DEVKIT_VUE_') && value !== ''),
     (_v, k) => k.split('_').slice(2).join('.'),
   );
   const environmentConfigVars = {};


### PR DESCRIPTION
Closes #4110

## Summary
- Dockerfile : drop empty/false default values from `ARG DEVKIT_VUE_analytics_posthog_*` and `ARG DEVKIT_VUE_analytics_sentry_*`. ARG declarations stay (so workflows can still pass values via `--build-arg`) but without defaults, BuildKit no longer leaks them as env vars when the workflow doesn't pass them
- generateConfig.js : skip `DEVKIT_VUE_*` env vars whose value is an empty string in Layer 5 (defense-in-depth against future regressions)

## Why
Docker BuildKit (used by all GH Actions `docker/build-push-action@v6` workflows) exposes every declared ARG as an env var to shell-form RUN steps. Empty-string ARG defaults end up as `process.env.DEVKIT_VUE_analytics_posthog_key=''` during `RUN npm run build`, and `generateConfig.js` Layer 5 `pickBy(process.env, key.startsWith('DEVKIT_VUE_'))` picks them up and overwrites downstream config-file values via `deepMerge`.

Result before this PR : downstream's `src/config/defaults/{project}.config.js` setting `analytics.posthog.key = 'phc_*'` is silently zeroed at CI build time.

Hit on Trawl 2026-05-09 : cookie banner depends on `$posthog` available, but key was zeroed → plugin bailed out at `if (!phConfig.key) return` → banner never rendered. Workaround was hardcoding values in trawl_vue's workflow build-args (works around but pollutes the YAML).

This PR is the right fix : remove the leak source + add safety net in generateConfig.

## Test plan
- [ ] CI green
- [ ] Local repro : `env -i NODE_ENV=trawl node scripts/generateConfig.js` produces no posthog overrides (the ARGs no longer have defaults, no env vars to leak)
- [ ] CodeRabbit pass