### PR TITLE
fix(legal): cookie banner UA-detection + appName fallback to app.title

### DIFF
--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -33,13 +33,16 @@ import { useCookieConsent } from '../composables/useCookieConsent';
 
 const instance = getCurrentInstance();
 
-// Skip render under Puppeteer prerender (UA contains 'HeadlessChrome').
-// Without this, the prerender plugin captures the v-snackbar into the static
-// HTML, then Vue hydrates a SECOND copy at runtime via Vuetify's Teleport →
-// duplicate banner stacked on prod (the prerendered one is non-interactive).
-// UA-based detection is more specific than navigator.webdriver (which JSDOM
-// also sets, breaking unit tests).
 const isMounted = ref(false);
+
+/**
+ * Sets the isMounted flag after hydration, skipping Puppeteer prerender
+ * environments (UA contains 'HeadlessChrome') to prevent v-snackbar from being
+ * captured into static HTML and duplicated on hydration via Vuetify's Teleport.
+ * UA-based detection is more specific than navigator.webdriver (which JSDOM
+ * also sets, breaking unit tests).
+ * @returns {void}
+ */
 onMounted(() => {
   if (typeof navigator !== 'undefined' && /HeadlessChrome/.test(navigator.userAgent || '')) return;
   isMounted.value = true;

--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -33,8 +33,17 @@ import { useCookieConsent } from '../composables/useCookieConsent';
 
 const instance = getCurrentInstance();
 
+// Skip render under Puppeteer prerender (UA contains 'HeadlessChrome').
+// Without this, the prerender plugin captures the v-snackbar into the static
+// HTML, then Vue hydrates a SECOND copy at runtime via Vuetify's Teleport →
+// duplicate banner stacked on prod (the prerendered one is non-interactive).
+// UA-based detection is more specific than navigator.webdriver (which JSDOM
+// also sets, breaking unit tests).
 const isMounted = ref(false);
-onMounted(() => { isMounted.value = true; });
+onMounted(() => {
+  if (typeof navigator !== 'undefined' && /HeadlessChrome/.test(navigator.userAgent || '')) return;
+  isMounted.value = true;
+});
 
 /**
  * Reads the devkit config lazily to support both globalProperties (prod) and
@@ -69,7 +78,7 @@ const enabled = computed(() => {
   return true;
 });
 const privacyPolicyPath = computed(() => getConfig()?.legal?.cookieConsent?.privacyPolicyPath || '/legal/privacy');
-const appName = computed(() => getConfig()?.name || '');
+const appName = computed(() => getConfig()?.app?.title || getConfig()?.name || '');
 
 const { consentNeeded, consent, accept, reject } = useCookieConsent();
 const visible = computed({


### PR DESCRIPTION
## Summary
- Replace plain `isMounted` guard with UA-based prerender detection (`HeadlessChrome` in UA). PR #4109's isMounted approach was insufficient — Puppeteer waits for `networkidle0` before DOM capture, by which point `onMounted` has fired and isMounted=true. Banner gets captured into static HTML, Vue hydrates a SECOND via Teleport → 2 stacked banners on prod.
- `appName` falls back to `config.app.title` before `config.name` (Trawl-style vs Devkit-style configs). Without fallback, i18n template `improve {appName}` renders as `improve .` (empty interpolation).

## Why
Confirmed live on Trawl prod : both bugs visible until trawl_vue#876 patched downstream. This PR ports those fixes upstream so all Devkit-using projects (Comes, Pierreb, Montaine, future) inherit them. Without this, trawl_vue#876's downstream patch will be wiped by next `/update-stack` (memory `feedback_update_stack_theirs_wipes_patches`).

## Why UA detection over navigator.webdriver
JSDOM (Vitest test env) sets `navigator.webdriver=true` by default → blanket webdriver check breaks unit tests. `HeadlessChrome` UA string is specific to Puppeteer headless and not present in JSDOM.

## Test plan
- [ ] CI green (existing test suite uses JSDOM with no HeadlessChrome UA → isMounted lifts as expected)
- [ ] CodeRabbit pass

## Follow-up
After this merges, `/update-stack` on trawl_vue will converge — the downstream patch becomes a no-op (same content).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate and non-interactive cookie banner appearing during page prerendering in certain environments
  * Enhanced cookie banner application name resolution to intelligently select from available configuration sources with appropriate fallback
  * Improved cookie banner rendering behavior to ensure correct functionality across different prerendering scenarios and browser types

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4113)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->