### PR TITLE
fix(build): restore Layer 5 empty-string env override (revert #4112 part 2)

### DIFF
--- a/scripts/generateConfig.js
+++ b/scripts/generateConfig.js
@@ -139,11 +139,19 @@ const getConfiguration = async () => {
   }
 
   // 5. DEVKIT_VUE_* env var overrides (final layer).
-  // Skip empty-string values: they're typically Dockerfile ARG defaults that
-  // BuildKit leaks into process.env, and treating them as overrides would
-  // silently zero downstream config-file values. See Vue#4110.
+  // Empty-string values DO override (intentional clear pattern: workflow build-args
+  // pass `DEVKIT_VUE_X=` to neutralize a config-file default for prod builds, e.g.
+  // a dev port hardcoded in {project}.config.js that should resolve to the prod
+  // ingress URL without a port segment).
+  // The original Vue#4110 bug (empty ARG defaults from Dockerfile leaking into env
+  // and silently zeroing config-file values) is mitigated by dropping ARG defaults
+  // in the upstream Devkit Dockerfile (Vue#4112 part 1) — downstream Dockerfiles
+  // must do the same to stay safe. The earlier defense-in-depth filter
+  // (`value !== ''`) was over-correction: it broke the documented Layer 5 contract
+  // and silently ignored explicit-clear overrides, causing the trawl prod signin
+  // outage on 2026-05-09 (port `:3010` from trawl.config.js could not be cleared).
   const environmentVars = mapKeys(
-    pickBy(process.env, (value, key) => key.startsWith('DEVKIT_VUE_') && value !== ''),
+    pickBy(process.env, (_value, key) => key.startsWith('DEVKIT_VUE_')),
     (_v, k) => k.split('_').slice(2).join('.'),
   );
   const environmentConfigVars = {};


### PR DESCRIPTION
## Summary

Restore the documented Layer 5 contract in \`scripts/generateConfig.js\` : empty-string \`DEVKIT_VUE_*\` env values once again override config-file values. Reverts the \`value !== ''\` filter introduced by #4112 part 2.

## Why revert

#4112 part 1 (drop ARG defaults in this Dockerfile) is the **right** fix for the original Vue#4110 leak. Part 2 (empty filter) was defense-in-depth that over-corrected by breaking the documented Layer 5 contract — empty IS a valid override value, used by downstreams to clear config-file defaults for prod builds.

## Incident triggered

trawl prod signin outage on 2026-05-09 16:56 UTC :

1. \`trawl_vue/.github/workflows/build.yml\` passes \`DEVKIT_VUE_api_port=\` (empty, intentional clear of dev port \`'3010'\` hardcoded in \`trawl.config.js\` so prod URLs hit \`https://trawl.me/api\` without a port)
2. With #4112's filter active, the empty override was silently ignored
3. Dev port \`:3010\` baked into prod bundle → all API calls timed out → \`fetchServerConfig\` hung → \`serverConfig\` stayed undefined → signin form hidden + Google btn disabled

Downstream fix : comes-io/trawl_vue#880 (merged 2026-05-10 09:12 UTC, verified ✅ in prod).

## Safety contract

Downstreams must keep their own Dockerfiles ARG-default-free (matching this Dockerfile). If a downstream forgets, the original Vue#4110 leak can re-occur. Defense for that lives in the **Dockerfile layer**, not in generateConfig.

Workflows can also pass explicit values for every ARG to avoid relying on defaults — current trawl_vue workflow already does this for \`app_title\` / \`cookie_prefix\` / \`api_protocol\` / \`api_host\`.

## Verification

Behavior matrix confirmed locally with NODE_ENV=trawl :

| Workflow passes                  | Layer 5 result | Final \`config.api.port\` |
|----------------------------------|----------------|---------------------------|
| (nothing — local dev)            | no override    | \`'3010'\` (file)         |
| \`DEVKIT_VUE_api_port=3000\`     | \`'3000'\`     | \`'3000'\`                |
| \`DEVKIT_VUE_api_port=\` (empty) | \`''\`         | \`''\` (was \`'3010'\`)   |

Local dev flow preserved. Prod explicit-clear restored.

## Test plan

- [ ] CI green
- [ ] CodeRabbit pass (or addressed)
- [ ] Memory entry & ERRORS.md note for future maintainers (follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable override handling to properly support empty-string values when overriding configuration defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->