### PR TITLE
fix(billing): 4 pricing page bugs (signed-in features, hero bg, truncation, guest CTA)

### DIFF
--- a/src/modules/billing/components/billing.pricingCard.component.vue
+++ b/src/modules/billing/components/billing.pricingCard.component.vue
@@ -127,18 +127,19 @@
       </v-btn>
     </div>
 
-    <!-- Equivalences (meter mode — structured) -->
+    <!-- Equivalences (meter mode — structured) — renders ABOVE features when present -->
     <BillingEquivalencesChipsComponent
       v-if="isStructuredEquivalences"
       :equivalences="equivalences"
+      class="mb-3"
     />
 
-    <!-- Equivalences (meter mode — legacy flat) -->
+    <!-- Equivalences (meter mode — legacy flat) — renders ABOVE features when present -->
     <v-list
       v-else-if="equivalences && equivalences.length > 0"
       density="compact"
       bg-color="transparent"
-      class="pa-0"
+      class="pa-0 mb-3"
     >
       <v-list-item
         v-for="equiv in equivalences"
@@ -152,8 +153,8 @@
       </v-list-item>
     </v-list>
 
-    <!-- Sectioned features (preferred when present and non-empty) -->
-    <template v-else-if="hasSections">
+    <!-- Sectioned features (always renders when sections present, independent of equivalences) -->
+    <template v-if="hasSections">
       <BillingPricingFeatureSectionComponent
         v-for="(section, idx) in plan.featureSections"
         :key="`section-${idx}`"
@@ -163,8 +164,8 @@
       />
     </template>
 
-    <!-- Flat features (backward-compat) -->
-    <v-list v-else density="compact" bg-color="transparent" class="pa-0">
+    <!-- Flat features (backward-compat — only when no sections) -->
+    <v-list v-else-if="plan.features && plan.features.length > 0" density="compact" bg-color="transparent" class="pa-0">
       <v-list-item
         v-for="feature in plan.features"
         :key="feature.text"

--- a/src/modules/billing/components/billing.pricingFeatureSection.component.vue
+++ b/src/modules/billing/components/billing.pricingFeatureSection.component.vue
@@ -104,3 +104,15 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+/* Allow feature/pack item text to wrap — Vuetify default v-list-item-title
+   has white-space: nowrap + text-overflow: ellipsis which truncates substantive
+   descriptions like "Stacks on top of subscription quota" into "… q…". */
+.billing-pricing-feature-section :deep(.v-list-item-title) {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  line-height: 1.4;
+}
+</style>

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -394,4 +394,13 @@ describe('BillingPricingView — currentPlanId guest guard', () => {
     expect(wrapper.vm.currentPlanId).toBe('growth');
     expect(wrapper.vm.isCurrentPlan('growth')).toBe(true);
   });
+
+  it('returns "free" when logged in but subscription has no plan', async () => {
+    wrapper = mountPricing({ isLoggedIn: true });
+    await flushPromises();
+    store.subscription = undefined;
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.currentPlanId).toBe('free');
+    expect(wrapper.vm.isCurrentPlan('free')).toBe(true);
+  });
 });

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -358,3 +358,40 @@ describe('BillingPricingView — mode-aware layout', () => {
     expect(wrapper.find('.blur-background').exists()).toBe(true);
   });
 });
+
+// ─── Suite: currentPlanId guest guard ────────────────────────────────────────
+
+describe('BillingPricingView — currentPlanId guest guard', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    store = useBillingStore();
+    seedStore(store);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    sessionStorage.clear();
+  });
+
+  it('returns null when not logged in', async () => {
+    wrapper = mountPricing({ isLoggedIn: false });
+    await flushPromises();
+    expect(wrapper.vm.currentPlanId).toBeNull();
+    expect(wrapper.vm.isCurrentPlan('free')).toBe(false);
+  });
+
+  it('returns subscription.plan when logged in with a subscription', async () => {
+    wrapper = mountPricing({ isLoggedIn: true });
+    await flushPromises();
+    store.subscription = { plan: 'growth' };
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.currentPlanId).toBe('growth');
+    expect(wrapper.vm.isCurrentPlan('growth')).toBe(true);
+  });
+});

--- a/src/modules/billing/tests/billing.pricingCard.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingCard.component.unit.tests.js
@@ -218,13 +218,14 @@ describe('BillingPricingCardComponent', () => {
     expect(wrapper.text()).toContain('~500 autofixes / week');
   });
 
-  it('hides feature list when equivalences are provided', () => {
+  it('renders feature list alongside equivalences (additive — flat features show when no featureSections)', () => {
+    // proPlan has flat features but no featureSections → v-else-if flat features fires even when equivalences present
     const wrapper = mountComponent({
       plan: proPlan,
       equivalences: [{ label: 'operations / week', count: 2000 }],
     });
-    expect(wrapper.text()).not.toContain('Unlimited projects');
-    expect(wrapper.text()).not.toContain('Priority support');
+    expect(wrapper.text()).toContain('Unlimited projects');
+    expect(wrapper.text()).toContain('Priority support');
   });
 
   it('shows feature list when equivalences prop is null (backward compat)', () => {
@@ -257,9 +258,9 @@ describe('BillingPricingCardComponent', () => {
     });
     const chipsComp = wrapper.findComponent({ name: 'BillingEquivalencesChipsComponent' });
     expect(chipsComp.exists()).toBe(true);
-    // Feature list must be hidden
-    expect(wrapper.text()).not.toContain('Unlimited projects');
-    // Legacy bullet list (with tilde prefix) must be hidden
+    // Flat features render additively (proPlan has no featureSections, so v-else-if flat list fires)
+    expect(wrapper.text()).toContain('Unlimited projects');
+    // Legacy bullet list (with tilde prefix) must be hidden — chips component is used instead
     expect(wrapper.text()).not.toContain('~500');
   });
 
@@ -410,5 +411,86 @@ describe('BillingPricingCardComponent', () => {
     const emits = wrapper.emitted('select');
     expect(emits).toBeTruthy();
     expect(emits[0][0].intent).toBe('signup');
+  });
+
+  // ── Bug fix: equivalences + featureSections additive rendering ────────────
+
+  describe('equivalences + featureSections additive rendering', () => {
+    it('renders BOTH equivalences chips AND feature sections when both present', () => {
+      const plan = {
+        id: 'pro',
+        name: 'Pro',
+        tagline: 't',
+        cta: 'Go Pro',
+        monthlyPrice: 39,
+        annualPrice: 390,
+        features: [{ text: 'flat-feature', included: true }],
+        featureSections: [
+          { title: 'Core', items: [{ text: 'sectioned-feature' }] },
+        ],
+      };
+      const wrapper = mountComponent({
+        plan,
+        equivalences: [
+          { kind: 'easy', count: 1600, label: 'scrap runs / week' },
+        ],
+      });
+      // Equivalences chips component renders
+      const chipsComp = wrapper.findComponent({ name: 'BillingEquivalencesChipsComponent' });
+      expect(chipsComp.exists()).toBe(true);
+      // Feature section renders (independent of equivalences)
+      const sectionComp = wrapper.findComponent({ name: 'BillingPricingFeatureSectionComponent' });
+      expect(sectionComp.exists()).toBe(true);
+      // Sectioned feature text is present
+      expect(wrapper.text()).toContain('sectioned-feature');
+      // Flat features do NOT render (featureSections takes precedence via v-if/v-else-if)
+      expect(wrapper.text()).not.toContain('flat-feature');
+    });
+
+    it('renders ONLY feature sections when equivalences is null', () => {
+      const plan = {
+        id: 'pro',
+        name: 'Pro',
+        tagline: 't',
+        cta: 'Go Pro',
+        monthlyPrice: 39,
+        annualPrice: 390,
+        features: [{ text: 'flat-feature', included: true }],
+        featureSections: [
+          { title: 'Core', items: [{ text: 'sectioned-feature' }] },
+        ],
+      };
+      const wrapper = mountComponent({ plan, equivalences: null });
+      // No chips component
+      const chipsComp = wrapper.findComponent({ name: 'BillingEquivalencesChipsComponent' });
+      expect(chipsComp.exists()).toBe(false);
+      // Feature section renders
+      const sectionComp = wrapper.findComponent({ name: 'BillingPricingFeatureSectionComponent' });
+      expect(sectionComp.exists()).toBe(true);
+      expect(wrapper.text()).toContain('sectioned-feature');
+    });
+
+    it('renders ONLY equivalences chips when plan has no featureSections and no flat features', () => {
+      const plan = {
+        id: 'pro',
+        name: 'Pro',
+        tagline: 't',
+        cta: 'Go Pro',
+        monthlyPrice: 39,
+        annualPrice: 390,
+        features: [],
+        featureSections: [],
+      };
+      const wrapper = mountComponent({
+        plan,
+        equivalences: [{ kind: 'easy', count: 800, label: 'ops / week' }],
+      });
+      // Chips component renders
+      const chipsComp = wrapper.findComponent({ name: 'BillingEquivalencesChipsComponent' });
+      expect(chipsComp.exists()).toBe(true);
+      // No feature section (empty featureSections)
+      const sectionComp = wrapper.findComponent({ name: 'BillingPricingFeatureSectionComponent' });
+      expect(sectionComp.exists()).toBe(false);
+    });
   });
 });

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -212,6 +212,7 @@ export default {
       return this.billingStore.loading;
     },
     currentPlanId() {
+      if (!this.authStore.isLoggedIn) return null;
       return this.billingStore.subscription?.plan ?? 'free';
     },
     meterMode() {

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -3,6 +3,7 @@
     <!-- Hero + pricing wrapped in animated blur halo -->
     <homeBlurBackgroundComponent
       no-margin
+      full-bleed
       fit-content
       :background-colors="haloPalette.backgroundColors"
       :halo-colors="haloPalette.haloColors"

--- a/src/modules/home/components/utils/home.blur.background.component.vue
+++ b/src/modules/home/components/utils/home.blur.background.component.vue
@@ -37,7 +37,7 @@
   }
 -->
 <template>
-  <div class="blur-background" :class="[themeName, { 'no-margin': noMargin }]">
+  <div class="blur-background" :class="[themeName, { 'no-margin': noMargin, 'full-bleed': fullBleed }]">
     <!-- Background layers -->
     <div class="blur-bg">
       <!-- Base gradient layer -->
@@ -96,6 +96,11 @@ export default {
     },
     // When true, height is auto (grows with content) instead of fixed vh
     fitContent: {
+      type: Boolean,
+      default: false,
+    },
+    // Break out of v-main width to fill full viewport (signed-in layout with nav drawer)
+    fullBleed: {
       type: Boolean,
       default: false,
     },
@@ -182,6 +187,16 @@ export default {
 
 .blur-background.no-margin {
   margin-top: 0;
+}
+
+/* full-bleed: break out of parent v-main width so the halo fills the
+   full viewport even when a Vuetify v-navigation-drawer offsets the
+   layout (signed-in users on routes that share the app shell). */
+.blur-background.full-bleed {
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .blur-bg {

--- a/src/modules/home/components/utils/home.blur.background.component.vue
+++ b/src/modules/home/components/utils/home.blur.background.component.vue
@@ -22,6 +22,8 @@
   - backgroundColors (Array): 5 colors for gradient background
   - haloColors (Array): 5 colors for animated halos
   - noMargin (Boolean): If true, removes the -65px top margin (for non-banner usage)
+  - fitContent (Boolean): If true, height is auto (grows with content) instead of fixed vh
+  - fullBleed (Boolean): If true, breaks out of parent width to fill full viewport — use on pages with a v-navigation-drawer offset (signed-in layout)
 
   CONFIG EXAMPLE:
   blur: {
@@ -191,9 +193,11 @@ export default {
 
 /* full-bleed: break out of parent v-main width so the halo fills the
    full viewport even when a Vuetify v-navigation-drawer offsets the
-   layout (signed-in users on routes that share the app shell). */
+   layout (signed-in users on routes that share the app shell).
+   calc(100vw - (100vw - 100%)) avoids the scrollbar-width inclusion
+   that plain 100vw produces, preventing a horizontal overflow. */
 .blur-background.full-bleed {
-  width: 100vw;
+  width: calc(100vw - (100vw - 100%));
   position: relative;
   left: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
## Summary

Fixes 4 user-reported regressions on the Trawl pricing page (all rooted in shared devkit Vue billing module) :

1. **Signed-in users see ONLY equivalences, no feature list.** Pricing card v-if/else-if chain excluded feature sections when equivalences were passed (meter mode = signed-in). Now renders both additively — equivalences ABOVE feature sections.
2. **Hero blue background offset by v-navigation-drawer.** New `fullBleed` prop on `homeBlurBackgroundComponent` breaks out to viewport width via classic full-bleed CSS trick.
3. **Pack/feature description strings truncated to "…".** Vuetify `v-list-item-title` default `white-space: nowrap` truncated substantive copy. Scoped CSS override allows wrap.
4. **"Current Plan" shown to signed-out guests on Free.** `currentPlanId` defaulted to `'free'` when no subscription. Now returns `null` for guests — Free card correctly shows "Sign up free" CTA.

All 4 fixes ship on devkit Vue. Propagation to Trawl downstream via standard `/update-stack` flow after merge.

## Test plan

- [x] `npm run lint` green
- [x] `NODE_ENV=development npm run test:unit` green (99 files / 1599 tests, +5 new tests across Tasks 1+2+4)
- [x] `npm run build` succeeds
- [ ] Post-merge `/update-stack` on trawl_vue → visual verify pricing page on `https://trawl.me/pricing` in both signed-in + signed-out states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-bleed background option for hero section to extend across full viewport width.
  * Pricing cards now display features and equivalences together simultaneously.

* **Bug Fixes**
  * Fixed text truncation in pricing feature lists to allow proper text wrapping and visibility.

* **Tests**
  * Expanded test coverage for pricing view, pricing cards, and feature rendering scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4123)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->