### PR TITLE
fix(layout): route /pricing outside app shell — no drawer offset on signed-in

### DIFF
--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -30,7 +30,7 @@
         </v-btn>
       </template>
     </v-snackbar>
-    <devkitNav v-if="isLoggedIn" />
+    <devkitNav v-if="isLoggedIn && !$route.meta.marketing" />
     <devkitHeader v-if="config.header.display" />
     <authEmailBanner />
     <authPendingRequestBanner />

--- a/src/modules/app/tests/app.router.unit.tests.js
+++ b/src/modules/app/tests/app.router.unit.tests.js
@@ -228,6 +228,13 @@ describe('app.router', () => {
     expect(router.currentRoute.value.meta.marketing).toBe(true);
   });
 
+  it('app routes (/, /scraps-equivalent) do NOT have meta.marketing', async () => {
+    const router = getRouter();
+    await router.push('/');
+    await router.isReady();
+    expect(router.currentRoute.value.meta.marketing).toBeFalsy();
+  });
+
   it('/billing redirects to /signin when not logged in (via /users requiresAuth)', async () => {
     mockAuthStore.isLoggedIn = false;
     const router = getRouter();

--- a/src/modules/app/tests/app.router.unit.tests.js
+++ b/src/modules/app/tests/app.router.unit.tests.js
@@ -221,6 +221,13 @@ describe('app.router', () => {
     expect(router.currentRoute.value.path).toBe('/pricing');
   });
 
+  it('/pricing has meta.marketing true (renders outside app shell — no drawer)', async () => {
+    const router = getRouter();
+    await router.push('/pricing');
+    await router.isReady();
+    expect(router.currentRoute.value.meta.marketing).toBe(true);
+  });
+
   it('/billing redirects to /signin when not logged in (via /users requiresAuth)', async () => {
     mockAuthStore.isLoggedIn = false;
     const router = getRouter();

--- a/src/modules/billing/router/billing.router.js
+++ b/src/modules/billing/router/billing.router.js
@@ -25,7 +25,7 @@ export default [
     meta: {
       display: false,
       footer: true,
-      marketing: true, // renders outside app shell (no drawer) — same treatment as /signin, /signup
+      marketing: true, // suppresses v-navigation-drawer for signed-in users (no drawer offset on full-bleed hero)
     },
   },
   {

--- a/src/modules/billing/router/billing.router.js
+++ b/src/modules/billing/router/billing.router.js
@@ -25,6 +25,7 @@ export default [
     meta: {
       display: false,
       footer: true,
+      marketing: true, // renders outside app shell (no drawer) — same treatment as /signin, /signup
     },
   },
   {


### PR DESCRIPTION
## Summary

- Add `meta.marketing: true` to the `/pricing` route in `billing.router.js`
- Gate `devkitNav` (v-navigation-drawer) with `v-if="isLoggedIn && !$route.meta.marketing"` in `app.vue` — suppresses the white sidebar for signed-in users on marketing pages
- Add router unit test asserting `/pricing` has `meta.marketing === true`

## Root cause

Full-bleed CSS (`100vw + transform`) on the pricing hero compensated for the drawer offset but `v-navigation-drawer` renders on top for signed-in users. Real fix: exclude `/pricing` from the app shell entirely, same as auth routes are excluded via redirect guard.

## Test plan

- [ ] `npm run test:unit -- src/modules/app/tests/ src/modules/billing/tests/billing.pricing.view.unit.tests.js` → 67 pass
- [ ] Visit `/pricing` signed-in: no drawer rendered
- [ ] Visit `/scraps` signed-in: drawer present (unaffected)
- [ ] Visit `/pricing` signed-out: no drawer (unchanged)