### PR TITLE
feat(billing): redesign Subscriptions view to match user-tabs aesthetic

### DIFF
--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -138,6 +138,7 @@
               :icon="subscriptionStatusIcon"
               size="x-small"
               :color="subscriptionStatusMeta.color"
+              aria-hidden="true"
             />
             <v-chip
               :color="subscriptionStatusMeta.color"
@@ -164,7 +165,7 @@
 
         <!-- Next billing date -->
         <div v-if="nextBillingDate" class="d-flex align-center ga-2 mb-6 text-body-medium text-medium-emphasis">
-          <v-icon icon="fa-solid fa-calendar" size="x-small" />
+          <v-icon icon="fa-solid fa-calendar" size="x-small" aria-hidden="true" />
           <span>{{ $t('billing.subscriptions.plan.nextBilling', { date: nextBillingDate }) }}</span>
         </div>
         <div v-else class="mb-6" />
@@ -262,7 +263,7 @@
           elevation="0"
         >
           <!-- Header row: title + balance chip inline -->
-          <div class="d-flex align-center justify-space-between mb-4">
+          <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
             <p class="text-title-medium font-weight-medium mb-0">{{ $t('billing.subscriptions.extras.balance') }}</p>
             <v-chip
               variant="tonal"

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -72,7 +72,7 @@
       elevation="0"
     >
       <div class="d-flex align-center mb-3">
-        <v-icon icon="fa-solid fa-triangle-exclamation" color="error" size="small" class="mr-3" />
+        <v-icon icon="fa-solid fa-triangle-exclamation" color="error" size="small" class="mr-3" aria-hidden="true" />
         <span class="text-title-large font-weight-medium">{{ $t('billing.subscriptions.unavailable') }}</span>
       </div>
       <p class="text-body-medium text-medium-emphasis mb-4">

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -182,7 +182,7 @@
         </v-alert>
 
         <!-- CTAs -->
-        <div class="d-flex ga-3 flex-wrap" :class="!nextBillingDate && !portalError ? 'mt-6' : ''">
+        <div class="d-flex ga-3 flex-wrap" :class="{ 'mt-6': !nextBillingDate && !portalError }">
           <v-btn
             color="primary"
             variant="flat"

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -168,7 +168,6 @@
           <v-icon icon="fa-solid fa-calendar" size="x-small" aria-hidden="true" />
           <span>{{ $t('billing.subscriptions.plan.nextBilling', { date: nextBillingDate }) }}</span>
         </div>
-        <div v-else class="mb-6" />
 
         <!-- Portal error -->
         <v-alert
@@ -183,7 +182,7 @@
         </v-alert>
 
         <!-- CTAs -->
-        <div class="d-flex ga-3 flex-wrap">
+        <div class="d-flex ga-3 flex-wrap" :class="!nextBillingDate && !portalError ? 'mt-6' : ''">
           <v-btn
             color="primary"
             variant="flat"
@@ -882,22 +881,22 @@ export default {
 <style scoped>
 /* Plan card: accent left-border on paid plans */
 .billing-subscriptions__plan-card--paid {
-  border: 1px solid rgb(var(--v-theme-on-surface) / 0.08);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
   border-left: 3px solid rgb(var(--v-theme-primary));
 }
 
 /* Free plan card: standard border, no accent */
 .billing-subscriptions__plan-card--free {
-  border: 1px solid rgb(var(--v-theme-on-surface) / 0.08);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
 }
 
 /* Error card: error-tinted border */
 .billing-subscriptions__error-card {
-  border: 1px solid rgb(var(--v-theme-error) / 0.2);
+  border: 1px solid rgba(var(--v-theme-error), 0.2);
 }
 
 /* Meter section cards: consistent surface border */
 .billing-subscriptions .v-card:not(.billing-subscriptions__plan-card):not(.billing-subscriptions__error-card) {
-  border: 1px solid rgb(var(--v-theme-on-surface) / 0.08);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
 }
 </style>

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -15,8 +15,9 @@
   - none
 -->
 <template>
-  <v-container class="py-6 px-0" :style="{ 'max-width': config.vuetify.theme.maxWidth }">
-    <!-- Checkout success / processing banner -->
+  <v-container class="billing-subscriptions py-6 px-0" :style="{ 'max-width': config.vuetify.theme.maxWidth }">
+
+    <!-- ── Status banners ────────────────────────────────────────────────── -->
     <v-alert
       v-if="checkoutProcessing"
       type="info"
@@ -56,22 +57,21 @@
       {{ paymentSuccessMessage }}
     </v-alert>
 
-    <!-- Loading -->
+    <!-- ── Loading ──────────────────────────────────────────────────────── -->
     <v-row v-if="fetchLoading" justify="center" class="py-10">
       <v-progress-circular indeterminate color="primary" />
     </v-row>
 
-    <!-- P1-1: Subscription fetch error — do NOT show free-plan fallback.
-         Suppressed while checkout polling/timeout UX is active to prevent
-         transient fetch errors from disrupting the payment flow. -->
+    <!-- ── P1-1: Subscription fetch error ─────────────────────────────── -->
     <v-card
       v-else-if="subscriptionError && !subscription && !checkoutProcessing && !checkoutTimeout"
       role="alert"
       aria-live="assertive"
       :class="config.vuetify.theme.rounded"
-      class="pa-6 mb-4"
+      class="billing-subscriptions__error-card pa-6 mb-4"
+      elevation="0"
     >
-      <div class="d-flex align-center mb-4">
+      <div class="d-flex align-center mb-3">
         <v-icon icon="fa-solid fa-triangle-exclamation" color="error" size="small" class="mr-3" />
         <span class="text-title-large font-weight-medium">{{ $t('billing.subscriptions.unavailable') }}</span>
       </div>
@@ -90,15 +90,23 @@
       </v-btn>
     </v-card>
 
-    <!-- Content -->
+    <!-- ── Main content ─────────────────────────────────────────────────── -->
     <template v-else>
-      <!-- ── Current plan card ────────────────────────────────────────── -->
-      <v-card v-if="!subscription || currentPlan === 'free'" :class="config.vuetify.theme.rounded" class="pa-6 mb-4">
-        <div class="d-flex align-center mb-4">
-          <span class="text-title-large font-weight-medium mr-3">{{ $t('billing.subscriptions.plan.current') }}</span>
-          <BillingPlanBadgeComponent plan="free" />
+
+      <!-- ── Plan summary card (free) ──────────────────────────────────── -->
+      <v-card
+        v-if="!subscription || currentPlan === 'free'"
+        :class="config.vuetify.theme.rounded"
+        class="billing-subscriptions__plan-card billing-subscriptions__plan-card--free pa-6 mb-4"
+        elevation="0"
+      >
+        <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
+          <div class="d-flex align-center ga-3">
+            <span class="text-title-large font-weight-medium">{{ $t('billing.subscriptions.plan.current') }}</span>
+            <BillingPlanBadgeComponent plan="free" />
+          </div>
         </div>
-        <p class="text-body-medium mb-6">
+        <p class="text-body-medium text-medium-emphasis mb-6">
           {{ $t('billing.subscriptions.plan.free.description') }}
         </p>
         <v-btn
@@ -112,56 +120,56 @@
         </v-btn>
       </v-card>
 
-      <v-card v-else :class="config.vuetify.theme.rounded" class="pa-6 mb-4">
-        <div class="d-flex align-center mb-4">
-          <span class="text-title-large font-weight-medium mr-3">{{ $t('billing.subscriptions.plan.current') }}</span>
-          <BillingPlanBadgeComponent :plan="currentPlan" />
+      <!-- ── Plan summary card (paid) ───────────────────────────────────── -->
+      <v-card
+        v-else
+        :class="config.vuetify.theme.rounded"
+        class="billing-subscriptions__plan-card billing-subscriptions__plan-card--paid pa-6 mb-4"
+        elevation="0"
+      >
+        <!-- Header row: plan name + badge left, status chip + action right -->
+        <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
+          <div class="d-flex align-center ga-3">
+            <span class="text-title-large font-weight-medium">{{ $t('billing.subscriptions.plan.current') }}</span>
+            <BillingPlanBadgeComponent :plan="currentPlan" />
+          </div>
+          <div class="d-flex align-center ga-2">
+            <v-icon
+              :icon="subscriptionStatusIcon"
+              size="x-small"
+              :color="subscriptionStatusMeta.color"
+            />
+            <v-chip
+              :color="subscriptionStatusMeta.color"
+              variant="tonal"
+              size="small"
+              class="text-capitalize"
+            >
+              {{ subscriptionStatusMeta.label }}
+            </v-chip>
+            <v-btn
+              v-if="subscriptionStatusAction"
+              :color="subscriptionStatusAction.color"
+              variant="tonal"
+              size="small"
+              :class="config.vuetify.theme.rounded"
+              class="text-none text-body-medium"
+              :loading="portalLoading"
+              @click="manageSubscription"
+            >
+              {{ subscriptionStatusAction.label }}
+            </v-btn>
+          </div>
         </div>
 
-        <v-list density="compact" class="bg-transparent pa-0 mb-6">
-          <v-list-item class="px-0">
-            <template #prepend>
-              <v-icon
-                :icon="subscriptionStatusIcon"
-                size="small"
-                :color="subscriptionStatusMeta.color"
-                class="mr-3"
-              />
-            </template>
-            <v-list-item-title class="billing-subscriptions__status-row text-body-medium">
-              <span>{{ $t('billing.subscriptions.plan.status') }}</span>
-              <v-chip
-                class="billing-subscriptions__status-chip text-capitalize"
-                :color="subscriptionStatusMeta.color"
-                variant="tonal"
-                size="small"
-              >
-                {{ subscriptionStatusMeta.label }}
-              </v-chip>
-              <v-btn
-                v-if="subscriptionStatusAction"
-                :color="subscriptionStatusAction.color"
-                variant="tonal"
-                size="small"
-                :class="config.vuetify.theme.rounded"
-                class="text-none text-body-medium"
-                :loading="portalLoading"
-                @click="manageSubscription"
-              >
-                {{ subscriptionStatusAction.label }}
-              </v-btn>
-            </v-list-item-title>
-          </v-list-item>
-          <v-list-item v-if="nextBillingDate" class="px-0">
-            <template #prepend>
-              <v-icon icon="fa-solid fa-calendar" size="small" class="mr-3" />
-            </template>
-            <v-list-item-title class="text-body-medium">
-              {{ $t('billing.subscriptions.plan.nextBilling', { date: nextBillingDate }) }}
-            </v-list-item-title>
-          </v-list-item>
-        </v-list>
+        <!-- Next billing date -->
+        <div v-if="nextBillingDate" class="d-flex align-center ga-2 mb-6 text-body-medium text-medium-emphasis">
+          <v-icon icon="fa-solid fa-calendar" size="x-small" />
+          <span>{{ $t('billing.subscriptions.plan.nextBilling', { date: nextBillingDate }) }}</span>
+        </div>
+        <div v-else class="mb-6" />
 
+        <!-- Portal error -->
         <v-alert
           v-if="portalError"
           type="error"
@@ -173,6 +181,7 @@
           {{ portalError }}
         </v-alert>
 
+        <!-- CTAs -->
         <div class="d-flex ga-3 flex-wrap">
           <v-btn
             color="primary"
@@ -198,7 +207,8 @@
 
       <!-- ── Meter mode sections (gated) ──────────────────────────────── -->
       <template v-if="meterMode">
-        <!-- ── Meter polling error ──────────────────────────────── -->
+
+        <!-- Meter polling error -->
         <v-alert
           v-if="meterError"
           type="warning"
@@ -213,15 +223,18 @@
           {{ $t('billing.meter.error.refreshFailed') }}
         </v-alert>
 
-        <!-- Usage bar (informational, opt-in here in account context) -->
-        <BillingUsageBarComponent
-          mode="meter"
-          class="mb-4"
-        />
-
-        <!-- Meter progress card -->
-        <v-card :class="config.vuetify.theme.rounded" class="pa-6 mb-4">
+        <!-- ── Usage overview card (UsageBar + MeterProgress merged) ─────── -->
+        <v-card
+          :class="config.vuetify.theme.rounded"
+          class="pa-6 mb-4"
+          elevation="0"
+        >
           <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.weekly') }}</p>
+          <BillingUsageBarComponent
+            mode="meter"
+            class="mb-4"
+          />
+          <v-divider class="mb-4" />
           <BillingMeterProgressComponent
             :used="meterUsed"
             :quota="meterQuota"
@@ -232,18 +245,33 @@
           />
         </v-card>
 
-        <!-- Breakdown card -->
-        <v-card :class="config.vuetify.theme.rounded" class="pa-6 mb-4">
+        <!-- ── Breakdown card ─────────────────────────────────────────────── -->
+        <v-card
+          :class="config.vuetify.theme.rounded"
+          class="pa-6 mb-4"
+          elevation="0"
+        >
           <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.breakdown') }}</p>
           <BillingMeterBreakdownChartComponent :breakdown="meterBreakdown" />
         </v-card>
 
-        <!-- Extras card -->
-        <v-card :class="config.vuetify.theme.rounded" class="pa-6 mb-4">
-          <p class="text-title-medium font-weight-medium mb-2">{{ $t('billing.subscriptions.extras.balance') }}</p>
-          <p class="text-body-medium text-medium-emphasis mb-4">
-            {{ $t('billing.extras.balance', { units: meterExtras, n: meterExtras }) }}
-          </p>
+        <!-- ── Extras card ────────────────────────────────────────────────── -->
+        <v-card
+          :class="config.vuetify.theme.rounded"
+          class="pa-6 mb-4"
+          elevation="0"
+        >
+          <!-- Header row: title + balance chip inline -->
+          <div class="d-flex align-center justify-space-between mb-4">
+            <p class="text-title-medium font-weight-medium mb-0">{{ $t('billing.subscriptions.extras.balance') }}</p>
+            <v-chip
+              variant="tonal"
+              color="primary"
+              size="small"
+            >
+              {{ $t('billing.extras.balance', { units: meterExtras, n: meterExtras }) }}
+            </v-chip>
+          </div>
           <v-btn
             color="primary"
             variant="flat"
@@ -265,6 +293,7 @@
             @update:page="onLedgerPageChange"
           />
         </v-card>
+
       </template>
     </template>
 
@@ -850,10 +879,24 @@ export default {
 </script>
 
 <style scoped>
-.billing-subscriptions__status-row {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+/* Plan card: accent left-border on paid plans */
+.billing-subscriptions__plan-card--paid {
+  border: 1px solid rgb(var(--v-theme-on-surface) / 0.08);
+  border-left: 3px solid rgb(var(--v-theme-primary));
+}
+
+/* Free plan card: standard border, no accent */
+.billing-subscriptions__plan-card--free {
+  border: 1px solid rgb(var(--v-theme-on-surface) / 0.08);
+}
+
+/* Error card: error-tinted border */
+.billing-subscriptions__error-card {
+  border: 1px solid rgb(var(--v-theme-error) / 0.2);
+}
+
+/* Meter section cards: consistent surface border */
+.billing-subscriptions .v-card:not(.billing-subscriptions__plan-card):not(.billing-subscriptions__error-card) {
+  border: 1px solid rgb(var(--v-theme-on-surface) / 0.08);
 }
 </style>

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -226,7 +226,7 @@
         <!-- ── Usage overview card (UsageBar + MeterProgress merged) ─────── -->
         <v-card
           :class="config.vuetify.theme.rounded"
-          class="pa-6 mb-4"
+          class="billing-subscriptions__meter-card pa-6 mb-4"
           elevation="0"
         >
           <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.weekly') }}</p>
@@ -248,7 +248,7 @@
         <!-- ── Breakdown card ─────────────────────────────────────────────── -->
         <v-card
           :class="config.vuetify.theme.rounded"
-          class="pa-6 mb-4"
+          class="billing-subscriptions__meter-card pa-6 mb-4"
           elevation="0"
         >
           <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.breakdown') }}</p>
@@ -258,7 +258,7 @@
         <!-- ── Extras card ────────────────────────────────────────────────── -->
         <v-card
           :class="config.vuetify.theme.rounded"
-          class="pa-6 mb-4"
+          class="billing-subscriptions__meter-card pa-6 mb-4"
           elevation="0"
         >
           <!-- Header row: title + balance chip inline -->
@@ -896,7 +896,7 @@ export default {
 }
 
 /* Meter section cards: consistent surface border */
-.billing-subscriptions .v-card:not(.billing-subscriptions__plan-card):not(.billing-subscriptions__error-card) {
+.billing-subscriptions__meter-card {
   border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
 }
 </style>

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -413,6 +413,23 @@ describe('BillingSubscriptionsComponent — status and paid plan CTAs', () => {
     expect(chip.text()).toContain('En pause');
     wrapperFr.unmount();
   });
+
+  it('paid plan card has billing-subscriptions__plan-card--paid CSS class (primary accent border)', async () => {
+    store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    // The paid plan card carries the BEM modifier class used by the primary left-border accent rule
+    expect(wrapper.find('.billing-subscriptions__plan-card--paid').exists()).toBe(true);
+    expect(wrapper.find('.billing-subscriptions__plan-card--free').exists()).toBe(false);
+  });
+
+  it('free plan card has billing-subscriptions__plan-card--free CSS class (no accent border)', async () => {
+    store.subscription = null;
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    expect(wrapper.find('.billing-subscriptions__plan-card--free').exists()).toBe(true);
+    expect(wrapper.find('.billing-subscriptions__plan-card--paid').exists()).toBe(false);
+  });
 });
 
 // ─── Suite 5: Stripe success query handling ────────────────────────────────


### PR DESCRIPTION
## Summary
- Plan cards redesigned: `elevation="0"` + 1px surface border; paid plan gets 3px primary left-edge accent for visual hierarchy
- Status chip + action button moved to plan card header row (`justify-space-between`) — scannable in one glance, `v-list` wrapper removed
- Meter mode: `UsageBar` + `MeterProgress` merged into single "Usage overview" card with `v-divider` (4 cards → 3 cards in meter mode)
- Extras card: balance count promoted to primary `v-chip` in header row
- All cards match flat Profile/Organizations tab style (`elevation="0"`, `rgba()` CSS borders)
- Decorative icons have `aria-hidden="true"`; all card headers use `flex-wrap` for responsive wrapping
- CSS: uses `rgba(var(--v-theme-*), alpha)` comma convention — matches existing sibling convention

## Test plan
- [x] Unit tests: 77/77 pass (75 existing + 2 new for plan card BEM class assertions)
- [ ] Visual: sign in to trawl.me/users → Subscriptions tab — paid plan card has primary left accent, status chip inline in header
- [ ] Mobile: header rows wrap gracefully at ≤960px

## Visual expected outcome
**Paid plan card**: plan name + badge on left, status chip + action button on right, 3px primary left border accent.
**Free plan card**: plan name + badge, upgrade CTA, no accent border.
**Meter mode**: 3 cards (Usage overview with bar+progress / Breakdown chart / Extras with ledger) instead of 4.

## Zero logic changes
All script logic, store interactions, composables, i18n keys, and event handlers are unchanged. Template restructure + CSS only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the subscriptions panel layout with dedicated visual cards for free and paid plans.
  * Reorganized meter mode UI with combined usage display, breakdown, and extras sections.

* **Tests**
  * Added unit tests for plan card styling validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4127)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->