### PR TITLE
fix(billing): send empty body to portal endpoint (closes 422)

### DIFF
--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -279,7 +279,7 @@ export const useBillingStore = defineStore('billing', {
       this.loading = true;
       try {
         const api = apiBase();
-        const res = await axios.post(`${api}/${config.api.endPoints.billing}/portal`);
+        const res = await axios.post(`${api}/${config.api.endPoints.billing}/portal`, {});
         const url = res?.data?.data?.url;
         if (!url) {
           throw new Error('Billing portal URL is missing from the API response');

--- a/src/modules/billing/tests/billing.store.unit.tests.js
+++ b/src/modules/billing/tests/billing.store.unit.tests.js
@@ -258,6 +258,22 @@ describe('Billing Store', () => {
       expect(store.loading).toBe(false);
       spy.mockRestore();
     });
+
+    it('sends an empty object body to POST /portal (not undefined)', async () => {
+      const store = useBillingStore();
+      const portalUrl = 'https://billing.stripe.com/session/test_123';
+      axios.post.mockResolvedValueOnce({ data: { data: { url: portalUrl } } });
+      const originalLocation = window.location;
+      delete window.location;
+      window.location = { ...originalLocation, href: '' };
+      await store.openPortal();
+      // Second argument must be {} (empty object), not undefined
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining('/portal'),
+        {},
+      );
+      window.location = originalLocation;
+    });
   });
 
   describe('fetchUsageMeter', () => {


### PR DESCRIPTION
## Summary
T1 of `docs/superpowers/plans/2026-05-12-subscriptions-pricing-feedback-batch.md` — fixes user feedback #8.

`billing.store.js openPortal()` was sending `axios.post(url)` with no body. Server's Zod `.strict()` schema rejected `req.body = undefined` with "Invalid input: expected object, received undefined" → 422. Fix: pass `{}` as 2nd arg. Schema already accepts `returnUrl` as optional.

## Test plan
- [x] 61/61 store unit tests pass (1 new asserts `axios.post` called with `({}, ...)`)
- [x] 515/515 billing suite green
- [ ] Post-deploy: click "Manage subscription" → Stripe portal redirect (no 422)