### PR TITLE
fix(users): re-apply route tab when serverConfig.billing arrives async

### DIFF
--- a/src/modules/users/tests/user.view.unit.tests.js
+++ b/src/modules/users/tests/user.view.unit.tests.js
@@ -370,13 +370,14 @@ describe('UserView – billing refetch on auth state change', () => {
 
 describe('UserView – serverConfig watcher activates subs tab', () => {
   let authStore;
-  let billingStore;
   let organizationsStore;
 
   beforeEach(() => {
     setActivePinia(createPinia());
     authStore = useAuthStore();
-    billingStore = useBillingStore();
+    // billing store is initialized in the component's setup chain via useBillingStore();
+    // we only need to drive serverConfig + organizations from this test suite.
+    useBillingStore();
     organizationsStore = useOrganizationsStore();
     organizationsStore.fetchOrganizations = vi.fn().mockResolvedValue([]);
   });

--- a/src/modules/users/tests/user.view.unit.tests.js
+++ b/src/modules/users/tests/user.view.unit.tests.js
@@ -365,3 +365,111 @@ describe('UserView – billing refetch on auth state change', () => {
     expect(wrapper.vm).toBeTruthy();
   });
 });
+
+// ── UserView – serverConfig watcher re-applies tab (Bug #1 subs tab race) ────
+
+describe('UserView – serverConfig watcher activates subs tab', () => {
+  let authStore;
+  let billingStore;
+  let organizationsStore;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    authStore = useAuthStore();
+    billingStore = useBillingStore();
+    organizationsStore = useOrganizationsStore();
+    organizationsStore.fetchOrganizations = vi.fn().mockResolvedValue([]);
+  });
+
+  it('activates subscriptions tab from ?tab=subscriptions when serverConfig.billing arrives after mount', async () => {
+    // At mount: serverConfig is null → showSubscriptionsTab is false → applyTabFromRoute() is a no-op
+    authStore.serverConfig = null;
+    organizationsStore.organizations = [{ id: 'o1', role: 'owner' }];
+
+    const wrapper = shallowMount(UserView, {
+      global: {
+        mocks: sharedMocks({ push: vi.fn() }, { query: { tab: 'subscriptions' }, hash: '' }),
+        stubs: sharedStubs,
+      },
+    });
+
+    // Tab must NOT be set yet — billing config not available
+    expect(wrapper.vm.tab).toBe('profile');
+
+    // Simulate serverConfig arriving after mount (auth store server config fetch resolves)
+    authStore.serverConfig = { billing: { enabled: true, meterMode: true } };
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Watcher on serverConfig must have re-called applyTabFromRoute() → tab flips
+    expect(wrapper.vm.tab).toBe('subscriptions');
+  });
+
+  it('re-applies tab when serverConfig refreshes but showSubscriptionsTab was already true (no false→true flip)', async () => {
+    // Start with billing enabled (showSubscriptionsTab already true) but tab not yet set
+    authStore.serverConfig = { billing: { enabled: true, meterMode: true } };
+    organizationsStore.organizations = [{ id: 'o1', role: 'owner' }];
+
+    // Mount WITHOUT a route tab query so tab stays on 'profile'
+    const wrapper = shallowMount(UserView, {
+      global: {
+        mocks: sharedMocks({ push: vi.fn() }, { query: {}, hash: '' }),
+        stubs: sharedStubs,
+      },
+    });
+
+    expect(wrapper.vm.tab).toBe('profile');
+
+    // Now simulate a serverConfig refresh arriving — billing still enabled.
+    // showSubscriptionsTab stays true (no false→true transition), so the
+    // showSubscriptionsTab watcher will NOT fire. Only the serverConfig watcher
+    // would call applyTabFromRoute() — but since no tab is in the route, the
+    // result is the same (profile stays). This validates the watcher runs without error.
+    authStore.serverConfig = { billing: { enabled: true, meterMode: false } };
+    await new Promise((r) => setTimeout(r, 0));
+
+    // No route tab → still profile
+    expect(wrapper.vm.tab).toBe('profile');
+
+    // Now explicitly verify the watcher exists by checking the component's $options.watch
+    expect(wrapper.vm.$options.watch).toHaveProperty('authStore.serverConfig');
+  });
+
+  it('does not change tab when serverConfig arrives but billing is disabled', async () => {
+    authStore.serverConfig = null;
+    organizationsStore.organizations = [{ id: 'o1', role: 'owner' }];
+
+    const wrapper = shallowMount(UserView, {
+      global: {
+        mocks: sharedMocks({ push: vi.fn() }, { query: { tab: 'subscriptions' }, hash: '' }),
+        stubs: sharedStubs,
+      },
+    });
+
+    expect(wrapper.vm.tab).toBe('profile');
+
+    // serverConfig arrives but billing disabled
+    authStore.serverConfig = { billing: { enabled: false } };
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(wrapper.vm.tab).toBe('profile');
+  });
+
+  it('does not change tab when serverConfig arrives but route has no tab query', async () => {
+    authStore.serverConfig = null;
+    organizationsStore.organizations = [{ id: 'o1', role: 'owner' }];
+
+    const wrapper = shallowMount(UserView, {
+      global: {
+        mocks: sharedMocks({ push: vi.fn() }, { query: {}, hash: '' }),
+        stubs: sharedStubs,
+      },
+    });
+
+    expect(wrapper.vm.tab).toBe('profile');
+
+    authStore.serverConfig = { billing: { enabled: true, meterMode: true } };
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(wrapper.vm.tab).toBe('profile');
+  });
+});

--- a/src/modules/users/views/user.view.vue
+++ b/src/modules/users/views/user.view.vue
@@ -273,6 +273,16 @@ export default {
       if (val) this.applyTabFromRoute();
     },
     /**
+     * @desc Re-apply the route tab when serverConfig arrives or changes.
+     * Fixes the race where `showSubscriptionsTab` was already true (orgs cached)
+     * but serverConfig hadn't populated yet — no false→true flip on
+     * `showSubscriptionsTab` occurs, so only this watcher catches the update.
+     * Also handles serverConfig refresh (re-fetch) without a full page reload.
+     */
+    'authStore.serverConfig'() {
+      this.applyTabFromRoute();
+    },
+    /**
      * @desc Refetch organizations + billing subscription whenever the auth
      * state changes. Tab visibility (`showSubscriptionsTab`) depends on both
      * `hasOwnerOrAdminRole` (organizations) and the billing feature flag, so


### PR DESCRIPTION
## Summary
T3 of `docs/superpowers/plans/2026-05-12-subscriptions-pricing-feedback-batch.md` — fixes user feedback #1.

`user.view.vue` watcher from PR #4125 watched `authStore.isLoggedIn` but `serverConfig.billing.enabled` populates separately via a delayed server-config fetch. When it arrives after mount, `showSubscriptionsTab` computed flips but `applyTabFromRoute()` was never re-called → Subs tab hidden until manual refresh. Adds a watcher on `authStore.serverConfig` that re-applies the route tab on every config update.

## Test plan
- [x] 20/20 user.view unit tests pass (+1 new watcher-existence assertion)
- [ ] Post-deploy: signout → `/users?tab=subscriptions` → signin → Subs tab active without refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscriptions tab can now be properly accessed via URL parameters (?tab=subscriptions) once billing features become available, even when initially accessed before the feature was enabled.

* **Tests**
  * Added comprehensive test coverage for subscriptions tab handling with server configuration changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4138)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->