### PR TITLE
feat(billing): % primary display on meter bars + compute units in overage tooltip

### DIFF
--- a/src/modules/billing/components/billing.meterProgress.component.vue
+++ b/src/modules/billing/components/billing.meterProgress.component.vue
@@ -4,6 +4,18 @@
   Compact meter usage widget (bar or donut variant).
   Emits `click` for parent-driven drilldown (e.g. open a usage drawer).
 
+  DISPLAY CONTRACT (Task 4 — T5/T6 consumers):
+  - % is always the primary visible value (summary row + donut center).
+  - Raw compute units (used / quota) are surfaced ONLY via tooltip on hover/focus,
+    and ONLY when overage > 0 (overflow state). In normal state there is no tooltip.
+  - Extras badge (+N compute) renders inline in summary when extras > 0 and not in overage.
+  - Overage state: error-colored % + exclamation icon that activates the raw-units tooltip.
+
+  STABLE API for T5 (BillingNavComputeGaugeComponent) and T6 (billing.subscriptions.component.vue):
+  - Props are unchanged; callers continue passing used/quota/extras/overage/netRemainingRaw/label/variant.
+  - clampedProgress (Number 0-100) is accessible for parent reads.
+  - thresholdColor ('success'|'warning'|'error') is accessible for parent reads.
+
   USAGE:
   <BillingMeterProgressComponent :used="120" :quota="200" :extras="30" label="Compute" />
   <BillingMeterProgressComponent :used="180" :quota="200" variant="donut" />
@@ -44,22 +56,13 @@
       >{{ clampedProgress }}%</span>
     </div>
 
-    <!-- Overage badge -->
+    <!-- Overage ARIA signal (visually hidden, aria-live region for assistive tech) -->
     <div
       v-if="overage > 0"
       class="billing-meter-progress__overage d-flex align-center mb-1"
       aria-live="assertive"
       aria-atomic="true"
-    >
-      <v-chip
-        color="error"
-        size="x-small"
-        variant="tonal"
-        prepend-icon="fa-solid fa-triangle-exclamation"
-      >
-        {{ $t('billing.meterProgress.over', { count: overage }) }}
-      </v-chip>
-    </div>
+    />
 
     <!-- Bar variant -->
     <template v-if="variant === 'bar'">
@@ -86,18 +89,49 @@
       </div>
     </template>
 
-    <!-- Summary text -->
+    <!-- Summary text: % is primary, compute units in tooltip on overflow only -->
     <div
-      class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1"
-      aria-live="polite"
+      class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1 d-flex align-center ga-1"
+      :aria-live="overage > 0 ? 'assertive' : 'polite'"
     >
-      <span>{{ used }} / {{ quota }}</span>
-      <template v-if="overage > 0">
-        <span class="text-error"> {{ $t('billing.meterProgress.remaining', { count: computedNetRemainingRaw, n: computedNetRemainingRaw }) }}</span>
-      </template>
-      <template v-else>
-        <span v-if="extras > 0"> {{ $t('billing.meterProgress.extras', { count: extras }) }}</span>
-      </template>
+      <!-- Primary value: always percentage -->
+      <span
+        class="font-weight-medium"
+        :class="overage > 0 ? 'text-error' : ''"
+      >
+        {{ clampedProgress }}%
+      </span>
+
+      <!-- Compute detail tooltip — shown only when in overage (overflow state) -->
+      <v-tooltip
+        v-if="overage > 0"
+        :text="`${used} / ${quota} ${$t('billing.meterProgress.overDetail', { overage })}`"
+        location="top"
+      >
+        <template #activator="{ props: tp }">
+          <v-icon
+            v-bind="tp"
+            icon="fa-solid fa-circle-exclamation"
+            color="error"
+            size="x-small"
+            tabindex="0"
+            role="img"
+            :aria-label="$t('billing.meterProgress.ariaOver', { base: '', used, quota, overage })"
+            style="cursor: help"
+          />
+        </template>
+      </v-tooltip>
+
+      <!-- Extras badge when present and not in overage -->
+      <v-chip
+        v-else-if="extras > 0"
+        size="x-small"
+        color="info"
+        variant="tonal"
+        class="ml-1"
+      >
+        +{{ extras }} {{ $t('billing.usageBar.compute') }}
+      </v-chip>
     </div>
   </div>
 </template>

--- a/src/modules/billing/components/billing.usageBar.component.vue
+++ b/src/modules/billing/components/billing.usageBar.component.vue
@@ -287,15 +287,17 @@ export default {
 
     /**
      * @desc Usage summary text shown in standard meter mode.
-     * When in overage shows the negative net remaining; otherwise "{used} / {quota} +{extras}".
-     * @returns {string}
+     * Task 4 (% primary display): always returns a percentage string.
+     * Raw compute units are surfaced by BillingMeterProgressComponent's
+     * overflow tooltip — not duplicated here.
+     * Consumed by T5 (BillingNavComputeGaugeComponent) and T6 (billing.subscriptions.component.vue)
+     * which read the % value from the summary span.
+     * @returns {string} e.g. "50%" or "100%"
      */
     meterDisplay() {
-      if (this.meterOverage > 0) {
-        return `${this.meterUsed} / ${this.meterQuota} ${this.$t('billing.usageBar.remaining', { count: this.meterNetRemainingRaw, n: this.meterNetRemainingRaw })}`;
-      }
-      const base = `${this.meterUsed} / ${this.meterQuota}`;
-      return this.meterExtras > 0 ? `${base} +${this.meterExtras}` : base;
+      if (this.meterQuota <= 0) return '0%';
+      const pct = Math.max(0, Math.min(100, Math.round((this.meterUsed / this.meterQuota) * 100)));
+      return `${pct}%`;
     },
   },
 };

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -101,6 +101,8 @@ export const billingEn = {
       remaining: '(no remaining) | ({count} remaining) | ({count} remaining)',
       /** i18n key: billing.meterProgress.extras — interpolate {count} */
       extras: '+{count} extras',
+      /** i18n key: billing.meterProgress.overDetail — interpolate {overage} — shown in tooltip when in overage */
+      overDetail: 'over by {overage} compute',
       /** i18n key: billing.meterProgress.ariaOver — interpolate {base}, {used}, {quota}, {overage} */
       ariaOver: '{base}{used} of {quota} used, {overage} over quota',
       /** i18n key: billing.meterProgress.ariaUsed — interpolate {base}, {used}, {quota}, {percent} */

--- a/src/modules/billing/tests/__snapshots__/billing.meterProgress.component.unit.tests.js.snap
+++ b/src/modules/billing/tests/__snapshots__/billing.meterProgress.component.unit.tests.js.snap
@@ -4,16 +4,8 @@ exports[`BillingMeterProgressComponent > matches the overage snapshot 1`] = `
 "<div data-v-f7f25334="" class="billing-meter-progress" aria-label="120 of 100 used, 20 over quota">
   <!-- Label row -->
   <!--v-if-->
-  <!-- Overage badge -->
-  <div data-v-f7f25334="" class="billing-meter-progress__overage d-flex align-center mb-1" aria-live="assertive" aria-atomic="true"><span data-v-f7f25334="" class="v-chip v-theme--light text-error v-chip--density-default v-chip--size-x-small v-chip--variant-tonal" draggable="false"><!----><span class="v-chip__underlay"></span>
-    <!---->
-    <div class="v-chip__prepend"><i class="fa-solid fa-triangle-exclamation mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--start" aria-hidden="true"></i>
-      <!---->
-    </div>
-    <div class="v-chip__content" data-no-activator="">+20 over</div>
-    <!---->
-    <!----></span>
-  </div><!-- Bar variant -->
+  <!-- Overage ARIA signal (visually hidden, aria-live region for assistive tech) -->
+  <div data-v-f7f25334="" class="billing-meter-progress__overage d-flex align-center mb-1" aria-live="assertive" aria-atomic="true"></div><!-- Bar variant -->
   <div data-v-f7f25334="" class="v-progress-linear v-progress-linear--rounded v-progress-linear--rounded v-theme--light v-locale--is-ltr" style="top: 0px; height: 10px; --v-progress-linear-height: 10px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
     <!---->
     <div class="v-progress-linear__background bg-surface-variant" style="opacity: NaN;"></div>
@@ -22,7 +14,11 @@ exports[`BillingMeterProgressComponent > matches the overage snapshot 1`] = `
       <div class="v-progress-linear__determinate bg-error" style="width: 100%;"></div>
     </transition-stub>
     <!---->
-  </div><!-- Summary text -->
-  <div data-v-f7f25334="" class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1" aria-live="polite"><span data-v-f7f25334="">120 / 100</span><span data-v-f7f25334="" class="text-error">(-20 remaining)</span></div>
+  </div><!-- Summary text: % is primary, compute units in tooltip on overflow only -->
+  <div data-v-f7f25334="" class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1 d-flex align-center ga-1" aria-live="assertive">
+    <!-- Primary value: always percentage --><span data-v-f7f25334="" class="font-weight-medium text-error">100% </span><!-- Compute detail tooltip — shown only when in overage (overflow state) --><i data-v-f7f25334="" class="fa-solid fa-circle-exclamation mdi v-icon notranslate v-theme--light v-icon--size-x-small text-error" style="cursor: help;" role="img" aria-hidden="true" tabindex="0" aria-describedby="v-tooltip-v-0" aria-label="120 of 100 used, 20 over quota"></i>
+    <!--teleport start-->
+    <!--teleport end-->
+  </div>
 </div>"
 `;

--- a/src/modules/billing/tests/__snapshots__/billing.usageBar.component.unit.tests.js.snap
+++ b/src/modules/billing/tests/__snapshots__/billing.usageBar.component.unit.tests.js.snap
@@ -4,20 +4,12 @@ exports[`BillingUsageBarComponent > matches the meter overage snapshot 1`] = `
 "<div data-v-621d4e81="" class="billing-usage-bar billing-usage-bar--meter billing-usage-bar--standard">
   <!-- Admin display: rainbow gradient, show total consumed with no cap -->
   <!-- Standard display: current behaviour, with overage indicator when over quota -->
-  <div data-v-621d4e81="" class="billing-usage-bar__summary d-flex justify-space-between text-body-medium text-medium-emphasis mb-1" aria-live="polite"><span data-v-621d4e81="">Weekly usage</span><span data-v-621d4e81="" class="font-weight-medium text-error">1100 / 1000 (-100 remaining)</span></div>
+  <div data-v-621d4e81="" class="billing-usage-bar__summary d-flex justify-space-between text-body-medium text-medium-emphasis mb-1" aria-live="polite"><span data-v-621d4e81="">Weekly usage</span><span data-v-621d4e81="" class="font-weight-medium text-error">100%</span></div>
   <div data-v-f7f25334="" data-v-621d4e81="" class="billing-meter-progress" aria-label="1100 of 1000 used, 100 over quota">
     <!-- Label row -->
     <!--v-if-->
-    <!-- Overage badge -->
-    <div data-v-f7f25334="" class="billing-meter-progress__overage d-flex align-center mb-1" aria-live="assertive" aria-atomic="true"><span data-v-f7f25334="" class="v-chip v-theme--light text-error v-chip--density-default v-chip--size-x-small v-chip--variant-tonal" draggable="false"><!----><span class="v-chip__underlay"></span>
-      <!---->
-      <div class="v-chip__prepend"><i class="fa-solid fa-triangle-exclamation mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--start" aria-hidden="true"></i>
-        <!---->
-      </div>
-      <div class="v-chip__content" data-no-activator="">+100 over</div>
-      <!---->
-      <!----></span>
-    </div><!-- Bar variant -->
+    <!-- Overage ARIA signal (visually hidden, aria-live region for assistive tech) -->
+    <div data-v-f7f25334="" class="billing-meter-progress__overage d-flex align-center mb-1" aria-live="assertive" aria-atomic="true"></div><!-- Bar variant -->
     <div data-v-f7f25334="" class="v-progress-linear v-progress-linear--rounded v-progress-linear--rounded v-theme--light v-locale--is-ltr" style="top: 0px; height: 10px; --v-progress-linear-height: 10px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
       <!---->
       <div class="v-progress-linear__background bg-surface-variant" style="opacity: NaN;"></div>
@@ -26,8 +18,12 @@ exports[`BillingUsageBarComponent > matches the meter overage snapshot 1`] = `
         <div class="v-progress-linear__determinate bg-error" style="width: 100%;"></div>
       </transition-stub>
       <!---->
-    </div><!-- Summary text -->
-    <div data-v-f7f25334="" class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1" aria-live="polite"><span data-v-f7f25334="">1100 / 1000</span><span data-v-f7f25334="" class="text-error">(-100 remaining)</span></div>
+    </div><!-- Summary text: % is primary, compute units in tooltip on overflow only -->
+    <div data-v-f7f25334="" class="billing-meter-progress__summary text-caption text-medium-emphasis mt-1 d-flex align-center ga-1" aria-live="assertive">
+      <!-- Primary value: always percentage --><span data-v-f7f25334="" class="font-weight-medium text-error">100% </span><!-- Compute detail tooltip — shown only when in overage (overflow state) --><i data-v-f7f25334="" class="fa-solid fa-circle-exclamation mdi v-icon notranslate v-theme--light v-icon--size-x-small text-error" style="cursor: help;" role="img" aria-hidden="true" tabindex="0" aria-describedby="v-tooltip-v-0" aria-label="1100 of 1000 used, 100 over quota"></i>
+      <!--teleport start-->
+      <!--teleport end-->
+    </div>
   </div>
 </div>"
 `;

--- a/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterProgress.component.unit.tests.js
@@ -142,20 +142,23 @@ describe('BillingMeterProgressComponent', () => {
 
   // ── Extras display ───────────────────────────────────────────────────────
 
-  it('shows extras credits in summary text when extras > 0', () => {
+  it('shows extras credits in summary text when extras > 0 (as "+N compute" chip)', () => {
     const wrapper = mountComponent({ used: 50, quota: 100, extras: 30 });
-    expect(wrapper.text()).toContain('+30 extras');
+    // Task 4: extras shown as "+30 compute" chip (not "+30 extras" anymore)
+    expect(wrapper.text()).toContain('+30 compute');
   });
 
-  it('does not show extras text when extras is 0', () => {
+  it('does not show extras chip when extras is 0', () => {
     const wrapper = mountComponent({ used: 50, quota: 100, extras: 0 });
     expect(wrapper.text()).not.toContain('extras');
+    expect(wrapper.text()).not.toContain('compute');
   });
 
-  it('shows used/quota in summary text', () => {
+  it('shows percentage in summary text (not raw used/quota)', () => {
     const wrapper = mountComponent({ used: 50, quota: 100 });
-    expect(wrapper.text()).toContain('50');
-    expect(wrapper.text()).toContain('100');
+    // Task 4: primary value is % — summary shows "50%", not raw "50 / 100"
+    expect(wrapper.text()).toContain('50%');
+    expect(wrapper.text()).not.toContain('50 / 100');
   });
 
   // ── Label ────────────────────────────────────────────────────────────────
@@ -181,18 +184,24 @@ describe('BillingMeterProgressComponent', () => {
     expect(wrapper.vm.thresholdColor).toBe('success');
   });
 
-  it('shows overage badge and error color when overage > 0', () => {
+  it('shows error color and tooltip icon when overage > 0 (no chip in summary)', () => {
     const wrapper = mountComponent({ used: 120, quota: 100, overage: 20, netRemainingRaw: -20 });
     expect(wrapper.vm.thresholdColor).toBe('error');
-    const chip = wrapper.findComponent({ name: 'v-chip' });
-    expect(chip.exists()).toBe(true);
-    expect(wrapper.text()).toContain('+20 over');
-    expect(wrapper.text()).toContain('-20 remaining');
+    // Task 4: no v-chip in the summary anymore — tooltip replaces it
+    const summary = wrapper.find('.billing-meter-progress__summary');
+    expect(summary.text()).not.toContain('+20 over');
+    // Tooltip icon must exist in overflow state
+    const tooltip = wrapper.findComponent({ name: 'v-tooltip' });
+    expect(tooltip.exists()).toBe(true);
+    // Summary % is error-colored and shows 100%
+    expect(summary.text()).toContain('100%');
   });
 
   it('adds aria-live regions for summary and overage updates', () => {
     const wrapper = mountComponent({ used: 120, quota: 100, overage: 20, netRemainingRaw: -20 });
-    expect(wrapper.find('.billing-meter-progress__summary').attributes('aria-live')).toBe('polite');
+    // Task 4: summary is assertive when in overage (merged into one region)
+    expect(wrapper.find('.billing-meter-progress__summary').attributes('aria-live')).toBe('assertive');
+    // Hidden overage div still exists for backward compat (aria-live assertive + aria-atomic)
     expect(wrapper.find('.billing-meter-progress__overage').attributes('aria-live')).toBe('assertive');
     expect(wrapper.find('.billing-meter-progress__overage').attributes('aria-atomic')).toBe('true');
   });
@@ -200,5 +209,48 @@ describe('BillingMeterProgressComponent', () => {
   it('matches the overage snapshot', () => {
     const wrapper = mountComponent({ used: 120, quota: 100, overage: 20, netRemainingRaw: -20 });
     expect(wrapper.find('.billing-meter-progress').html()).toMatchSnapshot();
+  });
+
+  // ── % primary display (Task 4) ────────────────────────────────────────────
+
+  describe('% primary display', () => {
+    it('shows "62%" as the primary summary text when used=62 quota=100', async () => {
+      const wrapper = mountComponent({ used: 62, quota: 100, label: 'Compute' });
+      await wrapper.vm.$nextTick();
+      // Primary value in summary row must show the percentage
+      const summary = wrapper.find('.billing-meter-progress__summary');
+      expect(summary.text()).toContain('62%');
+      // Raw compute units must NOT appear inline (only in tooltip)
+      expect(summary.text()).not.toContain('62 / 100');
+    });
+
+    it('does not show raw compute units in summary when not in overage', async () => {
+      const wrapper = mountComponent({ used: 46, quota: 1600 });
+      await wrapper.vm.$nextTick();
+      const summary = wrapper.find('.billing-meter-progress__summary');
+      // 46/1600 = 2.875 → rounds to 3%
+      expect(summary.text()).toContain('3%');
+      expect(summary.text()).not.toContain('46 / 1600');
+    });
+
+    it('shows tooltip with compute units when overage > 0', async () => {
+      const wrapper = mountComponent({ used: 120, quota: 100, overage: 20, netRemainingRaw: -20, label: 'Compute' });
+      await wrapper.vm.$nextTick();
+      // Tooltip activator (v-icon) must exist when in overage
+      const tooltipEl = wrapper.findComponent({ name: 'v-tooltip' });
+      expect(tooltipEl.exists()).toBe(true);
+      // tooltip text prop must contain the raw compute breakdown
+      const tooltipText = tooltipEl.props('text');
+      expect(tooltipText).toContain('120 / 100');
+    });
+
+    it('does NOT show overage chip in summary (replaced by tooltip icon)', async () => {
+      const wrapper = mountComponent({ used: 120, quota: 100, overage: 20, netRemainingRaw: -20 });
+      await wrapper.vm.$nextTick();
+      // Old behavior: v-chip with "+20 over" was in the summary; new: only tooltip icon
+      const summary = wrapper.find('.billing-meter-progress__summary');
+      // The chip for overage details should be gone from summary (only tooltip icon remains)
+      expect(summary.text()).not.toContain('+20 over');
+    });
   });
 });

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -159,8 +159,9 @@ describe('BillingSubscriptionsComponent — meter mode (meterMode: true)', () =>
   it('renders meter usage values', async () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    expect(wrapper.text()).toContain('120');
-    expect(wrapper.text()).toContain('500');
+    // Task 4: primary display is %, raw units are in aria-label / tooltip only
+    // 120 / 500 = 24%
+    expect(wrapper.text()).toContain('24%');
   });
 
   it('renders Buy units CTA in meter mode', async () => {

--- a/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.usageBar.component.unit.tests.js
@@ -184,27 +184,30 @@ describe('BillingUsageBarComponent', () => {
     expect(meterRoot.exists()).toBe(true);
   });
 
-  it('displays used / quota text in meter mode (standard)', () => {
+  it('displays % in summary header in meter mode (standard) — not raw units', () => {
     const store = useBillingStore();
     store.subscription = { status: 'active', plan: 'starter' };
     store.usageMeter = { meterUsed: 300, meterQuota: 1000 };
     const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
-    expect(wrapper.text()).toContain('300');
-    expect(wrapper.text()).toContain('1000');
+    // Task 4: meterDisplay is now "30%" — raw units in tooltip only
+    expect(wrapper.vm.meterDisplay).toBe('30%');
+    expect(wrapper.text()).toContain('30%');
+    expect(wrapper.text()).not.toContain('300 / 1000');
   });
 
-  it('appends +extras to meter display when extras > 0', () => {
+  it('meterDisplay returns % string (extras handled by child component chip)', () => {
     const store = useBillingStore();
     store.usageMeter = { meterUsed: 300, meterQuota: 1000, extrasRemaining: 75 };
     const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
-    expect(wrapper.vm.meterDisplay).toContain('+75');
+    // Task 4: extras are no longer part of meterDisplay string — child renders the chip
+    expect(wrapper.vm.meterDisplay).toBe('30%');
   });
 
-  it('does not append +extras when extras is 0', () => {
+  it('meterDisplay returns "0%" when quota is 0', () => {
     const store = useBillingStore();
-    store.usageMeter = { meterUsed: 300, meterQuota: 1000, extrasRemaining: 0 };
+    store.usageMeter = { meterUsed: 0, meterQuota: 0, extrasRemaining: 0 };
     const wrapper = mountComponent({ resource: '', action: '', mode: 'meter' });
-    expect(wrapper.vm.meterDisplay).not.toContain('+');
+    expect(wrapper.vm.meterDisplay).toBe('0%');
   });
 
   it('does not emit open-drawer on click in meter mode (informational only)', async () => {
@@ -308,14 +311,15 @@ describe('BillingUsageBarComponent', () => {
     expect(wrapper.vm.displayMode).toBe('standard');
   });
 
-  it('standard display shows used / quota via meterDisplay', () => {
+  it('standard display shows % via meterDisplay (not raw used/quota)', () => {
     authState.user = { roles: ['user'] };
     const store = useBillingStore();
     store.subscription = { status: 'active', plan: 'starter' };
     store.usageMeter = { meterUsed: 200, meterQuota: 1000, extrasRemaining: 0 };
     const wrapper = mountComponent({ mode: 'meter' });
-    expect(wrapper.text()).toContain('200');
-    expect(wrapper.text()).toContain('1000');
+    // Task 4: summary header shows % not raw units
+    expect(wrapper.text()).toContain('20%');
+    expect(wrapper.text()).not.toContain('200 / 1000');
   });
 
   // ── Meter mode: overage display ──────────────────────────────────────────
@@ -334,7 +338,7 @@ describe('BillingUsageBarComponent', () => {
     expect(wrapper.text()).not.toContain('over');
   });
 
-  it('shows overage badge and error color when used exceeds quota (overage > 0)', () => {
+  it('shows error color when used exceeds quota (overage > 0), % primary in header', () => {
     authState.user = { roles: ['user'] };
     const store = useBillingStore();
     store.subscription = { status: 'active', plan: 'starter' };
@@ -342,9 +346,10 @@ describe('BillingUsageBarComponent', () => {
     const wrapper = mountComponent({ mode: 'meter' });
     expect(wrapper.vm.meterOverage).toBe(100);
     expect(wrapper.vm.meterNetRemainingRaw).toBe(-100);
-    // meterDisplay shows negative remaining in header
-    expect(wrapper.text()).toContain('-100');
-    // meterProgress child renders the overage badge
+    // Task 4: meterDisplay is "100%" — raw units are in the child tooltip only
+    expect(wrapper.vm.meterDisplay).toBe('100%');
+    expect(wrapper.text()).toContain('100%');
+    // meterProgress child receives correct overage props
     const meterProgress = wrapper.findComponent({ name: 'BillingMeterProgressComponent' });
     expect(meterProgress.exists()).toBe(true);
     expect(meterProgress.props('overage')).toBe(100);
@@ -371,5 +376,47 @@ describe('BillingUsageBarComponent', () => {
     const wrapper = mountComponent({ mode: 'meter' });
 
     expect(wrapper.find('.billing-usage-bar--meter').html()).toMatchSnapshot();
+  });
+
+  // ── Meter mode: % primary display (Task 4) ────────────────────────────────
+
+  it('standard meter mode shows % in summary header, not raw units', async () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = { status: 'active', plan: 'growth' };
+    store.usageMeter = { meterUsed: 800, meterQuota: 1600, extrasRemaining: 0 };
+    const wrapper = mountComponent({ mode: 'meter' });
+    await wrapper.vm.$nextTick();
+
+    // meterDisplay should now return '%' string, not raw units
+    expect(wrapper.vm.meterDisplay).toBe('50%');
+    const summary = wrapper.find('.billing-usage-bar__summary');
+    expect(summary.text()).toContain('50%');
+    expect(summary.text()).not.toContain('800 / 1600');
+  });
+
+  it('standard meter mode shows 0% when used=0', async () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = { status: 'active', plan: 'growth' };
+    store.usageMeter = { meterUsed: 0, meterQuota: 1600, extrasRemaining: 0 };
+    const wrapper = mountComponent({ mode: 'meter' });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.meterDisplay).toBe('0%');
+  });
+
+  it('standard meter mode shows 100% when in overage', async () => {
+    authState.user = { roles: ['user'] };
+    const store = useBillingStore();
+    store.subscription = { status: 'active', plan: 'growth' };
+    store.usageMeter = { meterUsed: 1100, meterQuota: 1000, extrasRemaining: 0 };
+    const wrapper = mountComponent({ mode: 'meter' });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.meterDisplay).toBe('100%');
+    // Raw units should not be in the summary header
+    const summary = wrapper.find('.billing-usage-bar__summary');
+    expect(summary.text()).not.toContain('1100 / 1000');
   });
 });


### PR DESCRIPTION
## Summary
T4 of `docs/superpowers/plans/2026-05-12-subscriptions-pricing-feedback-batch.md` — cross-cutting refactor for user feedback #3.

All meter components (`BillingUsageBarComponent`, `BillingMeterProgressComponent`) now display **% as primary** value in summary header. Compute units (`N / M compute`) move to a `v-tooltip` triggered on hover/focus of the `fa-circle-exclamation` icon, **rendered only when `overage > 0`**.

## Test plan
- [x] 521/521 billing tests green (incl. updated snapshots for both bar components)
- [ ] Post-deploy: navigate to /users/subscriptions → confirm % visible in summary header. Trigger overage state → hover exclamation icon → tooltip shows "N / M compute — over by X compute"

## Foundation for T5 + T6
- T5 (sidenav gauge) and T6 (Subs view 2-col) branch off this and consume the new % display API