### PR TITLE
feat(app): button-shape compute gauge in sidenav above sign-out

### DIFF
--- a/src/modules/billing/components/billing.navComputeGauge.component.vue
+++ b/src/modules/billing/components/billing.navComputeGauge.component.vue
@@ -1,0 +1,156 @@
+<!--
+  BillingNavComputeGaugeComponent
+  ================================
+  Compute usage mini-gauge for the navigation sidenav.
+  Renders as a v-list-item (button-shape, same as other nav items) ABOVE the
+  user/sign-out row. Only visible when meterMode is active.
+
+  Collapsed (rail) state : gauge bar only — no text label.
+  Expanded state         : gauge bar (prepend) + "62% · resets Sat May 17" text.
+
+  Click → navigates to /users?tab=subscriptions (locked per T5 spec).
+  NO inline tooltip / popover.
+
+  Gate: hidden when not logged in, meterMode false, or usageMeter null.
+
+  PROPS:
+  - rail (Boolean, default false): mirrors navigation drawer rail prop.
+    When true, only the gauge bar is shown — title/subtitle hidden.
+
+  USAGE:
+  <BillingNavComputeGaugeComponent :rail="isRail" />
+-->
+<template>
+  <v-list-item
+    v-if="show"
+    class="billing-nav-gauge px-2"
+    :to="'/users?tab=subscriptions'"
+    :aria-label="`Compute usage: ${pct}%`"
+  >
+    <template #prepend>
+      <div class="billing-nav-gauge__bar-wrap">
+        <v-progress-linear
+          :model-value="pct"
+          :color="thresholdColor"
+          rounded
+          height="4"
+          bg-color="surface-variant"
+        />
+      </div>
+    </template>
+    <template v-if="!rail">
+      <v-list-item-title class="text-body-small font-weight-medium">
+        {{ pct }}%
+      </v-list-item-title>
+      <v-list-item-subtitle v-if="resetLabel" class="text-caption text-medium-emphasis">
+        {{ resetLabel }}
+      </v-list-item-subtitle>
+    </template>
+  </v-list-item>
+</template>
+
+<script>
+/**
+ * Module dependencies.
+ */
+import { useBillingStore } from '../stores/billing.store.js';
+import { useAuthStore } from '../../auth/stores/auth.store.js';
+
+/**
+ * Component definition.
+ */
+export default {
+  name: 'BillingNavComputeGaugeComponent',
+
+  props: {
+    /**
+     * @desc Mirror of the navigation drawer's rail prop.
+     * When true, only the gauge bar is shown — no text labels.
+     */
+    rail: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  setup() {
+    const billingStore = useBillingStore();
+    const authStore = useAuthStore();
+    return { billingStore, authStore };
+  },
+
+  computed: {
+    /**
+     * @desc Render only when logged in, meterMode is active, and usage data is available.
+     * @returns {boolean}
+     */
+    show() {
+      if (!this.authStore.isLoggedIn) return false;
+      if (!this.authStore.serverConfig?.billing?.meterMode) return false;
+      return Boolean(this.billingStore.usageMeter);
+    },
+
+    /**
+     * @desc Proxy to usageMeter for clean template access.
+     * @returns {Object|null}
+     */
+    usageMeter() {
+      return this.billingStore.usageMeter;
+    },
+
+    /**
+     * @desc Percentage of weekly quota consumed, clamped [0, 100].
+     * @returns {number}
+     */
+    pct() {
+      const { meterUsed = 0, meterQuota = 0 } = this.usageMeter ?? {};
+      if (meterQuota === 0) return 0;
+      return Math.max(0, Math.min(100, Math.round((meterUsed / meterQuota) * 100)));
+    },
+
+    /**
+     * @desc Vuetify color token based on usage threshold.
+     * @returns {string}
+     */
+    thresholdColor() {
+      if (this.pct >= 100) return 'error';
+      if (this.pct >= 80) return 'warning';
+      return 'success';
+    },
+
+    /**
+     * @desc Human-readable reset date label (short weekday + month + day format).
+     * Example: "resets Sat May 17"
+     * @returns {string|null}
+     */
+    resetLabel() {
+      const resetAt = this.usageMeter?.weekResetAt;
+      if (!resetAt) return null;
+      try {
+        const d = new Date(resetAt);
+        const formatted = d.toLocaleDateString(undefined, {
+          weekday: 'short',
+          month: 'short',
+          day: 'numeric',
+        });
+        return `resets ${formatted}`;
+      } catch {
+        return null;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.billing-nav-gauge__bar-wrap {
+  width: 24px;
+  display: flex;
+  align-items: center;
+}
+
+.billing-nav-gauge__bar-wrap :deep(.v-progress-linear) {
+  width: 24px;
+  min-width: 24px;
+}
+</style>

--- a/src/modules/billing/tests/billing.navComputeGauge.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.navComputeGauge.component.unit.tests.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+import { useAuthStore } from '../../auth/stores/auth.store.js';
+import { useBillingStore } from '../stores/billing.store.js';
+import BillingNavComputeGaugeComponent from '../components/billing.navComputeGauge.component.vue';
+
+const vuetify = createVuetify();
+
+/**
+ * Mount BillingNavComputeGaugeComponent with Vuetify + Pinia installed.
+ * @param {Object} [opts]
+ * @param {boolean} [opts.rail=false] - mirror of drawer rail prop
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountComponent = ({ rail = false } = {}) =>
+  mount(BillingNavComputeGaugeComponent, {
+    props: { rail },
+    global: { plugins: [vuetify] },
+  });
+
+describe('BillingNavComputeGaugeComponent', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  // ── Visibility gate ──────────────────────────────────────────────────────
+
+  it('hides when user is not logged in', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    // cookieExpire = 0 → isLoggedIn = false
+    authStore.cookieExpire = 0;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 5, meterQuota: 10, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.find('.billing-nav-gauge').exists()).toBe(false);
+  });
+
+  it('hides when meterMode is false', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: false } };
+    billingStore.usageMeter = { meterUsed: 5, meterQuota: 10, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.find('.billing-nav-gauge').exists()).toBe(false);
+  });
+
+  it('hides when meterMode is true but usageMeter is null', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = null;
+
+    const wrapper = mountComponent();
+    expect(wrapper.find('.billing-nav-gauge').exists()).toBe(false);
+  });
+
+  // ── Button shape + gauge bar ─────────────────────────────────────────────
+
+  it('renders as a v-list-item (button-shape) when meterMode is active', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 400, meterQuota: 1600, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.findComponent({ name: 'VListItem' }).exists()).toBe(true);
+  });
+
+  it('renders a progress bar (not a FA icon) as the prepend slot content', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 400, meterQuota: 1600, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.findComponent({ name: 'VProgressLinear' }).exists()).toBe(true);
+    // No raw FA icon — gauge bar replaces the icon slot
+    expect(wrapper.html()).not.toContain('fa-solid');
+  });
+
+  it('navigates to /users?tab=subscriptions on click (locked interaction)', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 400, meterQuota: 1600, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    const listItem = wrapper.findComponent({ name: 'VListItem' });
+    expect(listItem.props('to')).toBe('/users?tab=subscriptions');
+  });
+
+  // ── Expanded state ───────────────────────────────────────────────────────
+
+  it('shows % and reset label when not in rail mode (expanded)', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 800, meterQuota: 1600, weekResetAt: '2026-05-19T00:00:00.000Z' };
+
+    const wrapper = mountComponent({ rail: false });
+    expect(wrapper.text()).toContain('50%');
+    // Reset label must contain "resets"
+    expect(wrapper.text()).toContain('resets');
+  });
+
+  it('does NOT show raw compute units inline (% only — no "X / Y" pattern)', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 800, meterQuota: 1600, weekResetAt: null };
+
+    const wrapper = mountComponent({ rail: false });
+    // Must show 50% but NOT "800 / 1600"
+    expect(wrapper.text()).toContain('50%');
+    expect(wrapper.text()).not.toContain('800');
+    expect(wrapper.text()).not.toContain('1600');
+  });
+
+  // ── Collapsed (rail) state ───────────────────────────────────────────────
+
+  it('hides text content in rail mode (gauge bar only)', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 800, meterQuota: 1600, weekResetAt: '2026-05-19T00:00:00.000Z' };
+
+    const wrapper = mountComponent({ rail: true });
+    // Text slots are not rendered in rail mode
+    expect(wrapper.findComponent({ name: 'VListItemTitle' }).exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'VListItemSubtitle' }).exists()).toBe(false);
+    // But the gauge bar must still exist
+    expect(wrapper.findComponent({ name: 'VProgressLinear' }).exists()).toBe(true);
+  });
+
+  // ── Percentage calculation ───────────────────────────────────────────────
+
+  it('computes 50% for meterUsed=800, meterQuota=1600', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 800, meterQuota: 1600, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.vm.pct).toBe(50);
+  });
+
+  it('clamps pct to 100 when meterUsed exceeds meterQuota', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 200, meterQuota: 100, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.vm.pct).toBe(100);
+  });
+
+  it('returns pct=0 when meterQuota is 0 (division-by-zero guard)', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 0, meterQuota: 0, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.vm.pct).toBe(0);
+  });
+
+  // ── Color thresholds ─────────────────────────────────────────────────────
+
+  it('uses success color when usage is below 80%', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 50, meterQuota: 100, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.vm.thresholdColor).toBe('success');
+  });
+
+  it('uses warning color when usage is at 80%', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 80, meterQuota: 100, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.vm.thresholdColor).toBe('warning');
+  });
+
+  it('uses error color when usage is at or above 100%', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 100, meterQuota: 100, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.vm.thresholdColor).toBe('error');
+  });
+
+  // ── Reset date formatting ────────────────────────────────────────────────
+
+  it('returns null resetLabel when weekResetAt is null', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 10, meterQuota: 100, weekResetAt: null };
+
+    const wrapper = mountComponent();
+    expect(wrapper.vm.resetLabel).toBeNull();
+  });
+
+  it('returns a non-null resetLabel starting with "resets" when weekResetAt is set', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    billingStore.usageMeter = { meterUsed: 10, meterQuota: 100, weekResetAt: '2026-05-19T00:00:00.000Z' };
+
+    const wrapper = mountComponent();
+    expect(wrapper.vm.resetLabel).not.toBeNull();
+    expect(wrapper.vm.resetLabel).toMatch(/^resets /);
+    expect(wrapper.vm.resetLabel.length).toBeGreaterThan('resets '.length);
+  });
+});

--- a/src/modules/core/components/core.navigation.component.vue
+++ b/src/modules/core/components/core.navigation.component.vue
@@ -96,8 +96,10 @@
             </v-list-item>
           </v-list>
         </template>
-        <!-- Compute usage gauge — visible only in meter-mode apps -->
-        <billingComputeGauge />
+        <!-- Compute gauge: button-shape above sign-out row (meterMode only) -->
+        <v-list v-if="meterMode" :style="listStyle" nav class="py-0">
+          <BillingNavComputeGaugeComponent :rail="isRail" />
+        </v-list>
         <v-divider :color="navColor" :thickness="isGlass ? 1 : 3" :style="isGlass ? { opacity: 0.15 } : {}"></v-divider>
         <!-- Sign out -->
         <v-list :style="listStyle" nav>
@@ -132,14 +134,14 @@ import { liquidGlassStyle } from '../../../lib/helpers/theme';
 // projects include it. This follows the same pattern as user.view.vue importing
 // BillingSubscriptionsComponent. A consolidated cross-module refactor is tracked
 // as tech debt; this PR does not introduce a new pattern.
-import billingComputeGauge from '../../billing/components/billing.computeGauge.component.vue';
+import BillingNavComputeGaugeComponent from '../../billing/components/billing.navComputeGauge.component.vue';
 /**
  * Component definition.
  */
 export default {
   name: 'DevkitNavigation',
   components: {
-    billingComputeGauge,
+    BillingNavComputeGaugeComponent,
   },
   data() {
     const theme = useTheme();
@@ -165,6 +167,22 @@ export default {
       const authStore = useAuthStore();
       if (!authStore.serverConfig?.organizations?.enabled) return true;
       return !!authStore.user?.currentOrganization;
+    },
+    /**
+     * @desc Whether the app is in meter mode (compute billing active).
+     * @returns {Boolean}
+     */
+    meterMode() {
+      const authStore = useAuthStore();
+      return authStore.serverConfig?.billing?.meterMode === true;
+    },
+    /**
+     * @desc Whether the navigation drawer is in rail (collapsed icon-only) mode.
+     * True when not on mobile and the drawer rail config is enabled.
+     * @returns {Boolean}
+     */
+    isRail() {
+      return !this.$vuetify.display.mobile && !!this.config.vuetify.theme.navigation.drawer.rail;
     },
     /**
      * @desc Logo file — header config takes priority, falls back to app.logoFile.

--- a/src/modules/core/tests/core.navigation.component.unit.tests.js
+++ b/src/modules/core/tests/core.navigation.component.unit.tests.js
@@ -226,6 +226,41 @@ describe('core.navigation.component — template rendering', () => {
   });
 });
 
+describe('core.navigation.component — compute gauge slot', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    coreStoreState.nav = [];
+    coreStoreState.navBottom = [];
+  });
+
+  it('meterMode computed returns false when serverConfig has no billing.meterMode', () => {
+    // The global mock returns serverConfig: { organizations: { enabled: false } }
+    // — no billing key → meterMode must be false
+    const wrapper = mountNav();
+    expect(wrapper.vm.meterMode).toBe(false);
+  });
+
+  it('isRail returns false when config.vuetify.theme.navigation.drawer.rail is false', () => {
+    const wrapper = mountNav();
+    expect(wrapper.vm.isRail).toBe(false);
+  });
+
+  it('isRail reflects the drawer rail config — false when rail=false', () => {
+    // Default mountNav has rail: false in config — isRail must be false
+    const wrapper = mountNav();
+    // isRail = !$vuetify.display.mobile && !!config.navigation.drawer.rail
+    // $vuetify.display.mobile = false (mocked), rail = false → isRail = false
+    expect(wrapper.vm.isRail).toBe(false);
+  });
+
+  it('does not render BillingNavComputeGaugeComponent when meterMode is false', () => {
+    // Global auth mock has no billing.meterMode — gauge must be absent
+    const wrapper = mountNav();
+    const gauge = wrapper.findComponent({ name: 'BillingNavComputeGaugeComponent' });
+    expect(gauge.exists()).toBe(false);
+  });
+});
+
 describe('core.navigation.component — sidenav logo', () => {
   beforeEach(() => {
     setActivePinia(createPinia());


### PR DESCRIPTION
## Summary
T5 of `docs/superpowers/plans/2026-05-12-subscriptions-pricing-feedback-batch.md` — user feedback #2.

`BillingComputeGaugeComponent` rewired as a `v-list-item` button matching other sidenav items. Gauge bar replaces the FA icon in the `prepend` slot. **Collapsed state** = bar only, no text. **Expanded state** = "62% · resets Sat May 17" at label position. Click navigates to `/users?tab=subscriptions` (LOCKED interaction).

Mounted **above sign-out row**.

## Test plan
- [x] 17 new component tests + 4 navigation tests, 35 total green
- [ ] Post-deploy on meter-mode app: confirm button-shape, collapsed/expanded states, click → Subs tab

## Depends on
- PR #4139 (T4 % display) — merged, this PR rebased on the new master