### PR TITLE
feat(billing): Subscriptions view 2-column layout + single meter bar + buy-compute CTA

### DIFF
--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -92,209 +92,217 @@
 
     <!-- ── Main content ─────────────────────────────────────────────────── -->
     <template v-else>
+      <v-row>
 
-      <!-- ── Plan summary card (free) ──────────────────────────────────── -->
-      <v-card
-        v-if="!subscription || currentPlan === 'free'"
-        :class="config.vuetify.theme.rounded"
-        class="billing-subscriptions__plan-card billing-subscriptions__plan-card--free pa-6 mb-4"
-        elevation="0"
-      >
-        <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
-          <div class="d-flex align-center ga-3">
-            <span class="text-title-large font-weight-medium">{{ $t('billing.subscriptions.plan.current') }}</span>
-            <BillingPlanBadgeComponent plan="free" />
-          </div>
-        </div>
-        <p class="text-body-medium text-medium-emphasis mb-6">
-          {{ $t('billing.subscriptions.plan.free.description') }}
-        </p>
-        <v-btn
-          color="primary"
-          variant="flat"
-          :class="config.vuetify.theme.rounded"
-          class="text-none text-body-medium"
-          to="/pricing"
-        >
-          {{ $t('billing.subscriptions.cta.upgrade') }}
-        </v-btn>
-      </v-card>
+        <!-- ── LEFT COLUMN: Plan summary + meter ──────────────────────── -->
+        <v-col cols="12" :md="meterMode ? 5 : 12">
 
-      <!-- ── Plan summary card (paid) ───────────────────────────────────── -->
-      <v-card
-        v-else
-        :class="config.vuetify.theme.rounded"
-        class="billing-subscriptions__plan-card billing-subscriptions__plan-card--paid pa-6 mb-4"
-        elevation="0"
-      >
-        <!-- Header row: plan name + badge left, status chip + action right -->
-        <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
-          <div class="d-flex align-center ga-3">
-            <span class="text-title-large font-weight-medium">{{ $t('billing.subscriptions.plan.current') }}</span>
-            <BillingPlanBadgeComponent :plan="currentPlan" />
-          </div>
-          <div class="d-flex align-center ga-2">
-            <v-icon
-              :icon="subscriptionStatusIcon"
-              size="x-small"
-              :color="subscriptionStatusMeta.color"
-              aria-hidden="true"
-            />
-            <v-chip
-              :color="subscriptionStatusMeta.color"
-              variant="tonal"
-              size="small"
-              class="text-capitalize"
-            >
-              {{ subscriptionStatusMeta.label }}
-            </v-chip>
+          <!-- ── Plan summary card (free) ──────────────────────────────── -->
+          <v-card
+            v-if="!subscription || currentPlan === 'free'"
+            :class="config.vuetify.theme.rounded"
+            class="billing-subscriptions__plan-card billing-subscriptions__plan-card--free pa-6 mb-4"
+            elevation="0"
+          >
+            <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
+              <div class="d-flex align-center ga-3">
+                <span class="text-title-large font-weight-medium">{{ $t('billing.subscriptions.plan.current') }}</span>
+                <BillingPlanBadgeComponent plan="free" />
+              </div>
+            </div>
+            <p class="text-body-medium text-medium-emphasis mb-6">
+              {{ $t('billing.subscriptions.plan.free.description') }}
+            </p>
             <v-btn
-              v-if="subscriptionStatusAction"
-              :color="subscriptionStatusAction.color"
-              variant="tonal"
-              size="small"
+              color="primary"
+              variant="flat"
               :class="config.vuetify.theme.rounded"
               class="text-none text-body-medium"
-              :loading="portalLoading"
-              @click="manageSubscription"
+              to="/pricing"
             >
-              {{ subscriptionStatusAction.label }}
+              {{ $t('billing.subscriptions.cta.upgrade') }}
             </v-btn>
-          </div>
-        </div>
+          </v-card>
 
-        <!-- Next billing date -->
-        <div v-if="nextBillingDate" class="d-flex align-center ga-2 mb-6 text-body-medium text-medium-emphasis">
-          <v-icon icon="fa-solid fa-calendar" size="x-small" aria-hidden="true" />
-          <span>{{ $t('billing.subscriptions.plan.nextBilling', { date: nextBillingDate }) }}</span>
-        </div>
-
-        <!-- Portal error -->
-        <v-alert
-          v-if="portalError"
-          type="error"
-          variant="tonal"
-          closable
-          class="mb-4"
-          @click:close="portalError = null"
-        >
-          {{ portalError }}
-        </v-alert>
-
-        <!-- CTAs -->
-        <div class="d-flex ga-3 flex-wrap" :class="{ 'mt-6': !nextBillingDate && !portalError }">
-          <v-btn
-            color="primary"
-            variant="flat"
+          <!-- ── Plan summary card (paid) ───────────────────────────────── -->
+          <v-card
+            v-else
             :class="config.vuetify.theme.rounded"
-            class="text-none text-body-medium"
-            :loading="portalLoading"
-            @click="manageSubscription"
+            class="billing-subscriptions__plan-card billing-subscriptions__plan-card--paid pa-6 mb-4"
+            elevation="0"
           >
-            {{ $t('billing.subscriptions.portal') }}
-          </v-btn>
-          <v-btn
-            v-if="canUpgrade"
-            variant="outlined"
-            :class="config.vuetify.theme.rounded"
-            class="text-none text-body-medium"
-            to="/pricing"
-          >
-            {{ $t('billing.subscriptions.changePlan') }}
-          </v-btn>
-        </div>
-      </v-card>
+            <!-- Header row: plan name + badge left, status chip + action right -->
+            <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
+              <div class="d-flex align-center ga-3">
+                <span class="text-title-large font-weight-medium">{{ $t('billing.subscriptions.plan.current') }}</span>
+                <BillingPlanBadgeComponent :plan="currentPlan" />
+              </div>
+              <div class="d-flex align-center ga-2">
+                <v-icon
+                  :icon="subscriptionStatusIcon"
+                  size="x-small"
+                  :color="subscriptionStatusMeta.color"
+                  aria-hidden="true"
+                />
+                <v-chip
+                  :color="subscriptionStatusMeta.color"
+                  variant="tonal"
+                  size="small"
+                  class="text-capitalize"
+                >
+                  {{ subscriptionStatusMeta.label }}
+                </v-chip>
+                <v-btn
+                  v-if="subscriptionStatusAction"
+                  :color="subscriptionStatusAction.color"
+                  variant="tonal"
+                  size="small"
+                  :class="config.vuetify.theme.rounded"
+                  class="text-none text-body-medium"
+                  :loading="portalLoading"
+                  @click="manageSubscription"
+                >
+                  {{ subscriptionStatusAction.label }}
+                </v-btn>
+              </div>
+            </div>
 
-      <!-- ── Meter mode sections (gated) ──────────────────────────────── -->
-      <template v-if="meterMode">
+            <!-- Next billing date -->
+            <div v-if="nextBillingDate" class="d-flex align-center ga-2 mb-6 text-body-medium text-medium-emphasis">
+              <v-icon icon="fa-solid fa-calendar" size="x-small" aria-hidden="true" />
+              <span>{{ $t('billing.subscriptions.plan.nextBilling', { date: nextBillingDate }) }}</span>
+            </div>
 
-        <!-- Meter polling error -->
-        <v-alert
-          v-if="meterError"
-          type="warning"
-          variant="tonal"
-          density="compact"
-          closable
-          class="mb-4"
-          :icon="'fa-solid fa-triangle-exclamation'"
-          aria-live="polite"
-          @click:close="meterError = null"
-        >
-          {{ $t('billing.meter.error.refreshFailed') }}
-        </v-alert>
-
-        <!-- ── Usage overview card (UsageBar + MeterProgress merged) ─────── -->
-        <v-card
-          :class="config.vuetify.theme.rounded"
-          class="billing-subscriptions__meter-card pa-6 mb-4"
-          elevation="0"
-        >
-          <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.weekly') }}</p>
-          <BillingUsageBarComponent
-            mode="meter"
-            class="mb-4"
-          />
-          <v-divider class="mb-4" />
-          <BillingMeterProgressComponent
-            :used="meterUsed"
-            :quota="meterQuota"
-            :extras="meterExtras"
-            :overage="meterOverage"
-            :net-remaining-raw="meterNetRemainingRaw"
-            label=""
-          />
-        </v-card>
-
-        <!-- ── Breakdown card ─────────────────────────────────────────────── -->
-        <v-card
-          :class="config.vuetify.theme.rounded"
-          class="billing-subscriptions__meter-card pa-6 mb-4"
-          elevation="0"
-        >
-          <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.breakdown') }}</p>
-          <BillingMeterBreakdownChartComponent :breakdown="meterBreakdown" />
-        </v-card>
-
-        <!-- ── Extras card ────────────────────────────────────────────────── -->
-        <v-card
-          :class="config.vuetify.theme.rounded"
-          class="billing-subscriptions__meter-card pa-6 mb-4"
-          elevation="0"
-        >
-          <!-- Header row: title + balance chip inline -->
-          <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
-            <p class="text-title-medium font-weight-medium mb-0">{{ $t('billing.subscriptions.extras.balance') }}</p>
-            <v-chip
+            <!-- Portal error -->
+            <v-alert
+              v-if="portalError"
+              type="error"
               variant="tonal"
-              color="primary"
-              size="small"
+              closable
+              class="mb-4"
+              @click:close="portalError = null"
             >
-              {{ $t('billing.extras.balance', { units: meterExtras, n: meterExtras }) }}
-            </v-chip>
-          </div>
-          <v-btn
-            color="primary"
-            variant="flat"
+              {{ portalError }}
+            </v-alert>
+
+            <!-- CTAs -->
+            <div class="d-flex ga-3 flex-wrap" :class="{ 'mt-6': !nextBillingDate && !portalError }">
+              <v-btn
+                color="primary"
+                variant="flat"
+                :class="config.vuetify.theme.rounded"
+                class="text-none text-body-medium"
+                :loading="portalLoading"
+                @click="manageSubscription"
+              >
+                {{ $t('billing.subscriptions.portal') }}
+              </v-btn>
+              <v-btn
+                v-if="canUpgrade"
+                variant="outlined"
+                :class="config.vuetify.theme.rounded"
+                class="text-none text-body-medium"
+                to="/pricing"
+              >
+                {{ $t('billing.subscriptions.changePlan') }}
+              </v-btn>
+            </div>
+          </v-card>
+
+          <!-- ── Meter section (single bar — no duplicate) ──────────────── -->
+          <template v-if="meterMode">
+
+            <!-- Meter polling error -->
+            <v-alert
+              v-if="meterError"
+              type="warning"
+              variant="tonal"
+              density="compact"
+              closable
+              class="mb-4"
+              :icon="'fa-solid fa-triangle-exclamation'"
+              aria-live="polite"
+              @click:close="meterError = null"
+            >
+              {{ $t('billing.meter.error.refreshFailed') }}
+            </v-alert>
+
+            <!-- ── Usage meter card (T4 % bar — single source, no BillingUsageBarComponent) -->
+            <v-card
+              :class="config.vuetify.theme.rounded"
+              class="billing-subscriptions__meter-card pa-6 mb-4"
+              elevation="0"
+            >
+              <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.weekly') }}</p>
+              <BillingMeterProgressComponent
+                :used="meterUsed"
+                :quota="meterQuota"
+                :extras="meterExtras"
+                :overage="meterOverage"
+                :net-remaining-raw="meterNetRemainingRaw"
+                label=""
+              />
+            </v-card>
+
+            <!-- ── Breakdown card ─────────────────────────────────────────── -->
+            <v-card
+              :class="config.vuetify.theme.rounded"
+              class="billing-subscriptions__meter-card--breakdown pa-6 mb-4"
+              elevation="0"
+            >
+              <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.breakdown') }}</p>
+              <BillingMeterBreakdownChartComponent :breakdown="meterBreakdown" />
+            </v-card>
+
+          </template>
+        </v-col>
+
+        <!-- ── RIGHT COLUMN: Extras + ledger (meterMode only) ─────────── -->
+        <v-col v-if="meterMode" cols="12" md="7">
+
+          <!-- ── Extras card ──────────────────────────────────────────────── -->
+          <v-card
             :class="config.vuetify.theme.rounded"
-            class="text-none text-body-medium mb-6"
-            @click="extrasCheckoutDialog = true"
+            class="billing-subscriptions__extras-card pa-6 mb-4"
+            elevation="0"
           >
-            {{ $t('billing.extras.cta') }}
-          </v-btn>
+            <!-- Header row: title + balance chip inline -->
+            <div class="d-flex align-center justify-space-between flex-wrap ga-3 mb-4">
+              <p class="text-title-medium font-weight-medium mb-0">{{ $t('billing.subscriptions.extras.balance') }}</p>
+              <v-chip
+                variant="tonal"
+                color="primary"
+                size="small"
+              >
+                {{ $t('billing.extras.balance', { units: meterExtras, n: meterExtras }) }}
+              </v-chip>
+            </div>
+            <!-- CTA: /pricing#units — single source of truth for pack pricing (feedback #7) -->
+            <v-btn
+              color="primary"
+              variant="flat"
+              :class="config.vuetify.theme.rounded"
+              class="text-none text-body-medium mb-6"
+              to="/pricing#units"
+            >
+              {{ $t('billing.subscriptions.extras.buyExtra') }}
+            </v-btn>
 
-          <!-- Ledger: last 20 entries -->
-          <v-divider class="mb-4" />
-          <p class="text-body-medium font-weight-medium mb-3">{{ $t('billing.subscriptions.extras.ledger') }}</p>
-          <BillingExtrasLedgerComponent
-            :entries="extrasLedger.entries"
-            :total="extrasLedger.total"
-            :page="extrasLedger.page"
-            :limit="extrasLedger.limit"
-            @update:page="onLedgerPageChange"
-          />
-        </v-card>
+            <!-- Ledger: last 20 entries -->
+            <v-divider class="mb-4" />
+            <p class="text-body-medium font-weight-medium mb-3">{{ $t('billing.subscriptions.extras.ledger') }}</p>
+            <BillingExtrasLedgerComponent
+              :entries="extrasLedger.entries"
+              :total="extrasLedger.total"
+              :page="extrasLedger.page"
+              :limit="extrasLedger.limit"
+              @update:page="onLedgerPageChange"
+            />
+          </v-card>
 
-      </template>
+        </v-col>
+
+      </v-row>
     </template>
 
     <BillingExtrasCheckoutModalComponent
@@ -317,7 +325,6 @@ import BillingPlanBadgeComponent from './billing.planBadge.component.vue';
 import BillingMeterProgressComponent from './billing.meterProgress.component.vue';
 import BillingMeterBreakdownChartComponent from './billing.meterBreakdownChart.component.vue';
 import BillingExtrasLedgerComponent from './billing.extrasLedger.component.vue';
-import BillingUsageBarComponent from './billing.usageBar.component.vue';
 import BillingExtrasCheckoutModalComponent from './billing.extrasCheckoutModal.component.vue';
 
 /** Maximum number of polling attempts after checkout success (2s × 8 = 16s max). */
@@ -353,7 +360,6 @@ export default {
     BillingMeterProgressComponent,
     BillingMeterBreakdownChartComponent,
     BillingExtrasLedgerComponent,
-    BillingUsageBarComponent,
     BillingExtrasCheckoutModalComponent,
   },
   /**
@@ -897,6 +903,16 @@ export default {
 
 /* Meter section cards: consistent surface border */
 .billing-subscriptions__meter-card {
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
+}
+
+/* Breakdown card: same surface border as meter card */
+.billing-subscriptions__meter-card--breakdown {
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
+}
+
+/* Extras card (right column): consistent surface border */
+.billing-subscriptions__extras-card {
   border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
 }
 </style>

--- a/src/modules/billing/lang/en.js
+++ b/src/modules/billing/lang/en.js
@@ -150,6 +150,8 @@ export const billingEn = {
         balance: 'Extra units',
         /** i18n key: billing.subscriptions.extras.ledger */
         ledger: 'Transaction history',
+        /** i18n key: billing.subscriptions.extras.buyExtra — CTA redirecting to /pricing#units */
+        buyExtra: 'Buy compute extras',
       },
       cta: {
         /** i18n key: billing.subscriptions.cta.upgrade */

--- a/src/modules/billing/lang/fr.js
+++ b/src/modules/billing/lang/fr.js
@@ -142,6 +142,8 @@ export const billingFr = {
         balance: 'Unités supplémentaires',
         /** i18n key: billing.subscriptions.extras.ledger */
         ledger: 'Historique des transactions',
+        /** i18n key: billing.subscriptions.extras.buyExtra — CTA redirecting to /pricing#units */
+        buyExtra: 'Acheter du compute supplémentaire',
       },
       cta: {
         /** i18n key: billing.subscriptions.cta.upgrade */

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -164,32 +164,32 @@ describe('BillingSubscriptionsComponent — meter mode (meterMode: true)', () =>
     expect(wrapper.text()).toContain('24%');
   });
 
-  it('renders Buy units CTA in meter mode', async () => {
+  it('renders "Buy compute extras" CTA in meter mode (T6 redesign: /pricing#units redirect)', async () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    const buyBtns = wrapper.findAll('.v-btn').filter((b) => b.text().includes('Buy units'));
+    const buyBtns = wrapper.findAllComponents({ name: 'v-btn' }).filter((b) => b.text().includes('Buy compute extras'));
     expect(buyBtns.length).toBeGreaterThan(0);
   });
 
-  it('Buy units CTA opens the inline extras checkout modal', async () => {
+  it('"Buy compute extras" CTA navigates to /pricing#units (not opens modal) — T6 redesign', async () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    const buyBtn = wrapper.findAllComponents({ name: 'v-btn' }).find((b) => b.text().includes('Buy units'));
+    const buyBtn = wrapper.findAllComponents({ name: 'v-btn' }).find((b) => b.text().includes('Buy compute extras'));
     expect(buyBtn).toBeDefined();
-    await buyBtn.trigger('click');
-    expect(wrapper.vm.extrasCheckoutDialog).toBe(true);
-    const modal = wrapper.findComponent({ name: 'BillingExtrasCheckoutModalComponent' });
-    expect(modal.props('modelValue')).toBe(true);
-    expect(modal.props('packs')).toEqual(mockUsageMeterNormal.packsAvailable);
+    // Must have `to="/pricing#units"` prop — never opens the inline checkout modal
+    const toProp = buyBtn?.props('to') ?? buyBtn?.attributes('to');
+    expect(String(toProp)).toContain('/pricing');
+    expect(String(toProp)).toContain('#units');
+    // Dialog must remain closed — this is not a modal trigger
+    expect(wrapper.vm.extrasCheckoutDialog).toBe(false);
   });
 
-  it('renders informational usage bar in meter mode (no click handler)', async () => {
+  it('does NOT render BillingUsageBarComponent in meter mode (T6: single bar only)', async () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    const meterBar = wrapper.find('.billing-usage-bar--meter');
-    expect(meterBar.exists()).toBe(true);
-    // Bar is informational — no role=button, no cursor pointer
-    expect(meterBar.attributes('role')).toBeUndefined();
+    // T6 drops BillingUsageBarComponent — only BillingMeterProgressComponent remains
+    const usageBars = wrapper.findAllComponents({ name: 'BillingUsageBarComponent' });
+    expect(usageBars.length).toBe(0);
   });
 
   it('fetches extras ledger when meterMode is true', async () => {
@@ -1417,5 +1417,75 @@ describe('BillingSubscriptionsComponent — pollAborted abort flag', () => {
     vi.advanceTimersByTime(10000);
     // fetchSubscription call count must not grow beyond what was already in-flight
     expect(store.fetchSubscription.mock.calls.length).toBe(fetchCallCount);
+  });
+});
+
+// ─── Suite T6: 2-column layout + drop dup bar + CTA redirect ─────────────────
+
+describe('BillingSubscriptionsComponent — T6: 2-col layout, single meter bar, CTA to /pricing#units', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    store = useBillingStore();
+    seedMeterStore(store);
+    store.subscription = { status: 'active', plan: 'growth', currentPeriodEnd: new Date().toISOString() };
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+  });
+
+  it('renders two v-col children inside the meter mode section (2-col layout)', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
+    await flushPromises();
+    const cols = wrapper.findAllComponents({ name: 'v-col' });
+    expect(cols.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders only one meter component — no duplicate bar (BillingUsageBarComponent dropped)', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
+    await flushPromises();
+    // After 2-col redesign: only BillingMeterProgressComponent remains; BillingUsageBarComponent is removed
+    const usageBars = wrapper.findAllComponents({ name: 'BillingUsageBarComponent' });
+    const meterProgress = wrapper.findAllComponents({ name: 'BillingMeterProgressComponent' });
+    // Either usageBar OR meterProgress, not both — total must be ≤ 1
+    expect(usageBars.length + meterProgress.length).toBeLessThanOrEqual(1);
+  });
+
+  it('CTA "Buy compute extras" button navigates to /pricing#units (not a modal trigger)', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
+    await flushPromises();
+    // Find btn that contains "extra" or "compute" keyword in its text
+    const buyCtaBtn = wrapper.findAllComponents({ name: 'v-btn' })
+      .find((b) => b.text().toLowerCase().includes('extra') || b.text().toLowerCase().includes('buy compute'));
+    expect(buyCtaBtn).toBeDefined();
+    // Must use router `to` prop (not @click modal), pointing to /pricing#units
+    const toProp = buyCtaBtn?.props('to') ?? buyCtaBtn?.attributes('to');
+    expect(toProp).toContain('/pricing');
+    expect(String(toProp)).toContain('#units');
+  });
+
+  it('does NOT open extrasCheckoutDialog when clicking the buy-compute CTA', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
+    await flushPromises();
+    expect(wrapper.vm.extrasCheckoutDialog).toBe(false);
+    // CTA is a router link, not a click handler — dialog stays false
+    const buyCtaBtn = wrapper.findAllComponents({ name: 'v-btn' })
+      .find((b) => b.text().toLowerCase().includes('extra') || b.text().toLowerCase().includes('buy compute'));
+    if (buyCtaBtn) await buyCtaBtn.trigger('click');
+    await flushPromises();
+    expect(wrapper.vm.extrasCheckoutDialog).toBe(false);
+  });
+
+  it('billing-subscriptions__meter-card count is exactly 1 (single bar card, no dup card)', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
+    await flushPromises();
+    const meterCards = wrapper.findAll('.billing-subscriptions__meter-card');
+    // Left col has 1 meter card; extras is in right col with its own class
+    expect(meterCards.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
T6 of `docs/superpowers/plans/2026-05-12-subscriptions-pricing-feedback-batch.md` — user feedbacks #4 + #7.

- **2-col layout** (`v-row > v-col md=5` plan+meter, `v-col md=7` extras+ledger)
- **Drop duplicate meter bar** — kept the T4 % bar; `BillingUsageBarComponent` removed from this view
- **Buy-compute CTA** → `<router-link to="/pricing#units">Buy compute extras</router-link>` (single source of truth on /pricing, per feedback #7)

## Test plan
- [x] 1650/1650 tests pass
- [ ] Post-deploy: /users → Subscriptions tab → confirm 2-col, single bar, "Buy compute extras" redirects to /pricing#units

## Depends on
- PR #4139 (T4 % display) — merged, this PR rebased on the new master