### PR TITLE
feat(billing): combined pool gauge + linear breakdown bars + alerts cleanup

### DIFF
--- a/src/modules/billing/components/billing.meterBreakdownChart.component.vue
+++ b/src/modules/billing/components/billing.meterBreakdownChart.component.vue
@@ -1,62 +1,37 @@
 <!--
   BillingMeterBreakdownChartComponent
-  =====================================
-  Horizontal stacked-bar showing per-bucket meter usage.
-  Buckets with 0 value are not rendered. Colors cycle through
-  Vuetify theme tokens for deterministic visual mapping.
+  ====================================
+  Per-bucket compute consumption — one v-progress-linear per bucket, same
+  height/rounded/bg-color as the Weekly compute bar for visual consistency.
 
   USAGE:
-  <BillingMeterBreakdownChartComponent :breakdown="{ scrap: 100, autofix: 50, wizard: 200 }" />
-  <BillingMeterBreakdownChartComponent :breakdown="breakdown" :total="500" />
-
-  PROPS:
-  - breakdown (Object, required) : map of bucket → credit count (e.g. { scrap: 100, autofix: 50 })
-  - total     (Number, optional) : override total; defaults to sum of breakdown values
-
-  SLOTS: none
+  <BillingMeterBreakdownChartComponent :breakdown="{ scrap: 60, autofix: 40 }" />
 -->
 <template>
   <div class="billing-meter-breakdown-chart">
-    <!-- Empty state -->
     <div
       v-if="activeBuckets.length === 0"
       class="text-caption text-medium-emphasis text-center py-2"
+      :aria-label="ariaLabel"
     >
       No usage data
     </div>
 
-    <template v-else>
-      <!-- Stacked bar -->
-      <div
-        class="billing-meter-breakdown-chart__bar d-flex rounded overflow-hidden"
-        role="img"
-        :aria-label="stackedBarAriaLabel"
-      >
-        <div
-          v-for="bucket in activeBuckets"
-          :key="bucket.key"
-          :class="'bg-' + bucket.color"
-          :style="{ width: bucket.pct + '%' }"
-          :title="`${bucket.key}: ${bucket.value} (${bucket.pct}%)`"
-        />
-      </div>
-
-      <!-- Legend -->
-      <div class="billing-meter-breakdown-chart__legend d-flex flex-wrap ga-2 mt-2">
-        <div
-          v-for="bucket in activeBuckets"
-          :key="bucket.key"
-          class="d-flex align-center ga-1 text-caption"
-        >
-          <div
-            class="breakdown-legend-dot"
-            :class="'bg-' + bucket.color"
-          />
-          <span class="text-medium-emphasis">{{ bucket.key }}</span>
+    <div v-else :aria-label="ariaLabel">
+      <div v-for="bucket in activeBuckets" :key="bucket.key" class="mb-2">
+        <div class="d-flex justify-space-between text-caption text-medium-emphasis mb-1">
+          <span>{{ bucket.key }}</span>
           <span class="font-weight-medium">{{ bucket.pct }}%</span>
         </div>
+        <v-progress-linear
+          :model-value="bucket.pct"
+          :color="bucket.color"
+          rounded
+          height="10"
+          bg-color="surface-variant"
+        />
       </div>
-    </template>
+    </div>
   </div>
 </template>
 
@@ -64,17 +39,12 @@
 /** Ordered palette of Vuetify theme color tokens used for buckets. */
 const PALETTE = ['primary', 'secondary', 'info', 'warning', 'success', 'error'];
 
-/**
- * Component definition.
- */
 export default {
   name: 'BillingMeterBreakdownChartComponent',
 
   props: {
     /**
      * @desc Per-bucket credit consumption map.
-     * Keys are bucket names (e.g. 'scrap', 'autofix'); values are credit counts.
-     * Buckets with value 0 are filtered out.
      * @type {Object.<string, number>}
      */
     breakdown: {
@@ -83,8 +53,6 @@ export default {
     },
     /**
      * @desc Optional total override. Defaults to sum of all breakdown values.
-     * Useful when the parent wants percentages relative to a quota rather than
-     * the sum of visible buckets.
      */
     total: {
       type: Number,
@@ -93,27 +61,14 @@ export default {
   },
 
   computed: {
-    /**
-     * @desc Effective total: prop override or sum of all breakdown values.
-     * @returns {number}
-     */
     effectiveTotal() {
       if (this.total !== null && this.total > 0) return this.total;
       return Object.values(this.breakdown).reduce((sum, v) => sum + (v || 0), 0);
     },
 
-    /**
-     * @desc Non-zero buckets enriched with color assignment and percentage.
-     * Color is assigned by stable index position in the sorted key list across
-     * ALL provided bucket names (zero or not), so the palette is deterministic
-     * for a given set of bucket names — toggling a zero bucket never shifts the
-     * colors of other buckets.
-     * @returns {Array<{ key: string, value: number, pct: number, color: string }>}
-     */
     activeBuckets() {
       const total = this.effectiveTotal;
       if (total === 0) return [];
-
       const allKeys = Object.keys(this.breakdown).sort();
       return allKeys
         .map((key) => ({ key, value: this.breakdown[key] || 0, paletteIdx: allKeys.indexOf(key) }))
@@ -126,28 +81,10 @@ export default {
         }));
     },
 
-    /**
-     * @desc ARIA label describing the stacked bar contents.
-     * @returns {string}
-     */
-    stackedBarAriaLabel() {
+    ariaLabel() {
       if (this.activeBuckets.length === 0) return 'No usage data';
-      const parts = this.activeBuckets.map((b) => `${b.key} ${b.pct}%`).join(', ');
-      return `Meter usage breakdown: ${parts}`;
+      return `Meter usage breakdown: ${this.activeBuckets.map((b) => `${b.key} ${b.pct}%`).join(', ')}`;
     },
   },
 };
 </script>
-
-<style scoped>
-.billing-meter-breakdown-chart__bar {
-  height: 0.75rem;
-}
-
-.breakdown-legend-dot {
-  width: 0.625rem;
-  height: 0.625rem;
-  border-radius: 2px;
-  flex-shrink: 0;
-}
-</style>

--- a/src/modules/billing/components/billing.packs.component.vue
+++ b/src/modules/billing/components/billing.packs.component.vue
@@ -11,6 +11,9 @@
   On click → calls `billingStore.createExtrasCheckout(packId)` which initiates a
   Stripe Checkout session and redirects the user.
 
+  Purchase errors are surfaced via the centralized snackbar (lib/services/axios.js
+  interceptor) — no inline error alert rendered here.
+
   USAGE:
   <BillingPacksComponent />
 -->
@@ -74,18 +77,6 @@
         </v-card>
       </v-col>
     </v-row>
-
-    <!-- Purchase error -->
-    <v-alert
-      v-if="purchaseError"
-      type="error"
-      variant="tonal"
-      class="mt-4"
-      closable
-      @click:close="purchaseError = null"
-    >
-      {{ purchaseError }}
-    </v-alert>
   </div>
 </template>
 
@@ -125,8 +116,6 @@ export default {
     return {
       /** @type {string|null} packId currently being purchased (drives loading state) */
       purchasingId: null,
-      /** @type {string|null} User-facing error when checkout initiation fails */
-      purchaseError: null,
     };
   },
 
@@ -152,7 +141,8 @@ export default {
      * Reuses the same auth/org guard as onSelectPlan() in billing.pricing.view.vue:
      * unauthenticated users are redirected to sign-in; logged-in users without a
      * current organization are redirected to org setup. On success Stripe redirects;
-     * failures surface a user-facing banner for retry.
+     * failures are surfaced via the centralized snackbar (lib/services/axios.js
+     * interceptor) — no inline error alert.
      * @param {{ packId: string, label: string }} pack
      * @returns {Promise<void>}
      */
@@ -172,12 +162,12 @@ export default {
       }
 
       this.purchasingId = pack.packId;
-      this.purchaseError = null;
       try {
         await this.billingStore.createExtrasCheckout(pack.packId);
       } catch (err) {
+        // Centralized snackbar (lib/services/axios.js interceptor) surfaces
+        // backend error.description automatically. Console log for debug only.
         console.error('Failed to initiate extras checkout:', err);
-        this.purchaseError = this.$t('billing.pricing.error.checkoutFailed');
       } finally {
         this.purchasingId = null;
       }

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -15,7 +15,7 @@
   - none
 -->
 <template>
-  <v-container class="billing-subscriptions py-6 px-0" :style="{ 'max-width': config.vuetify.theme.maxWidth }">
+  <v-container class="billing-subscriptions py-6 px-6" style="max-width: none; width: 100%;">
 
     <!-- ── Status banners ────────────────────────────────────────────────── -->
     <v-alert
@@ -173,20 +173,8 @@
               <span>{{ $t('billing.subscriptions.plan.nextBilling', { date: nextBillingDate }) }}</span>
             </div>
 
-            <!-- Portal error -->
-            <v-alert
-              v-if="portalError"
-              type="error"
-              variant="tonal"
-              closable
-              class="mb-4"
-              @click:close="portalError = null"
-            >
-              {{ portalError }}
-            </v-alert>
-
-            <!-- CTAs -->
-            <div class="d-flex ga-3 flex-wrap" :class="{ 'mt-6': !nextBillingDate && !portalError }">
+            <!-- CTAs (portal error surfaced via centralized snackbar — see lib/services/axios.js) -->
+            <div class="d-flex ga-3 flex-wrap" :class="{ 'mt-6': !nextBillingDate }">
               <v-btn
                 color="primary"
                 variant="flat"
@@ -212,34 +200,21 @@
           <!-- ── Meter section (single bar — no duplicate) ──────────────── -->
           <template v-if="meterMode">
 
-            <!-- Meter polling error -->
-            <v-alert
-              v-if="meterError"
-              type="warning"
-              variant="tonal"
-              density="compact"
-              closable
-              class="mb-4"
-              :icon="'fa-solid fa-triangle-exclamation'"
-              aria-live="polite"
-              @click:close="meterError = null"
-            >
-              {{ $t('billing.meter.error.refreshFailed') }}
-            </v-alert>
+            <!-- Meter polling error surfaced via centralized snackbar (lib/services/axios.js) -->
 
             <!-- ── Usage meter card (T4 % bar — single source, no BillingUsageBarComponent) -->
             <v-card
               :class="config.vuetify.theme.rounded"
-              class="billing-subscriptions__meter-card pa-6 mb-4"
+              class="billing-subscriptions__meter-card px-6 py-3 mb-0"
               elevation="0"
             >
-              <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.weekly') }}</p>
+              <p class="text-title-medium font-weight-medium mb-2">{{ $t('billing.usage.weekly') }}</p>
               <BillingMeterProgressComponent
                 :used="meterUsed"
-                :quota="meterQuota"
-                :extras="meterExtras"
-                :overage="meterOverage"
-                :net-remaining-raw="meterNetRemainingRaw"
+                :quota="combinedPool"
+                :extras="0"
+                :overage="0"
+                :net-remaining-raw="combinedPool - meterUsed"
                 label=""
               />
             </v-card>
@@ -247,10 +222,10 @@
             <!-- ── Breakdown card ─────────────────────────────────────────── -->
             <v-card
               :class="config.vuetify.theme.rounded"
-              class="billing-subscriptions__meter-card--breakdown pa-6 mb-4"
+              class="billing-subscriptions__meter-card--breakdown px-6 py-3 mb-0"
               elevation="0"
             >
-              <p class="text-title-medium font-weight-medium mb-4">{{ $t('billing.usage.breakdown') }}</p>
+              <p class="text-title-medium font-weight-medium mb-2">{{ $t('billing.usage.breakdown') }}</p>
               <BillingMeterBreakdownChartComponent :breakdown="meterBreakdown" />
             </v-card>
 
@@ -379,7 +354,6 @@ export default {
       breakdown: meterBreakdown,
       overage: meterOverage,
       netRemainingRaw: meterNetRemainingRaw,
-      meterError,
     } = meter;
 
     const meterMode = computed(() => authStore.serverConfig?.billing?.meterMode === true);
@@ -406,13 +380,11 @@ export default {
       meterBreakdown,
       meterOverage,
       meterNetRemainingRaw,
-      meterError,
     };
   },
   data() {
     return {
       portalLoading: false,
-      portalError: null,
       extrasCheckoutDialog: false,
       paymentSuccessMessage: null,
       successCleanupTimer: null,
@@ -431,6 +403,15 @@ export default {
     };
   },
   computed: {
+    /**
+     * @desc Combined compute pool = subscription quota + extras + already-used.
+     * Used as denominator for "Weekly compute" % so Free plan (quota=0) doesn't
+     * false-alarm 100% red. Matches the sidenav gauge formula.
+     * @returns {number}
+     */
+    combinedPool() {
+      return this.meterQuota + this.meterExtras + this.meterUsed;
+    },
     fetchLoading() {
       return this.billingStore.loading;
     },
@@ -851,18 +832,17 @@ export default {
     },
 
     /**
-     * @desc Open the Stripe customer portal.
+     * @desc Open the Stripe customer portal in a new tab.
      * @returns {Promise<void>}
      */
     async manageSubscription() {
       this.portalLoading = true;
-      this.portalError = null;
       try {
-        await this.billingStore.openPortal();
-        this.portalError = null;
+        const url = await this.billingStore.openPortal();
+        if (url) window.open(url, '_blank', 'noopener,noreferrer');
       } catch (err) {
+        // Centralized snackbar (lib/services/axios.js) surfaces backend error.
         console.error('Failed to open billing portal:', err);
-        this.portalError = this.$t('billing.subscriptions.error.portalFailed');
       } finally {
         this.portalLoading = false;
       }

--- a/src/modules/billing/stores/billing.store.js
+++ b/src/modules/billing/stores/billing.store.js
@@ -272,8 +272,9 @@ export const useBillingStore = defineStore('billing', {
     },
 
     /**
-     * @desc Open Stripe Customer Portal by redirecting to the portal URL.
-     * @returns {Promise<void>}
+     * @desc Fetch the Stripe Customer Portal URL and return it.
+     * Caller decides the redirect target (new tab vs same tab).
+     * @returns {Promise<string>} Validated Stripe portal URL
      */
     async openPortal() {
       this.loading = true;
@@ -284,7 +285,7 @@ export const useBillingStore = defineStore('billing', {
         if (!url) {
           throw new Error('Billing portal URL is missing from the API response');
         }
-        window.location.href = validateStripeUrl(url);
+        return validateStripeUrl(url);
       } catch (err) {
         console.error(err);
         throw err;

--- a/src/modules/billing/tests/billing.meterBreakdownChart.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.meterBreakdownChart.component.unit.tests.js
@@ -131,24 +131,51 @@ describe('BillingMeterBreakdownChartComponent', () => {
     expect(colorD2).toBe(colorD1);
   });
 
-  // ── Rendering ─────────────────────────────────────────────────────────────
+  // ── Linear bar rendering (new v-progress-linear design) ──────────────────
 
-  it('renders the stacked bar when there are active buckets', () => {
-    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 50 } });
-    const bar = wrapper.find('.billing-meter-breakdown-chart__bar');
-    expect(bar.exists()).toBe(true);
+  it('renders one v-progress-linear per non-zero bucket', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 50, wizard: 0 } });
+    const bars = wrapper.findAllComponents({ name: 'v-progress-linear' });
+    // Only scrap and autofix are non-zero → 2 bars
+    expect(bars).toHaveLength(2);
   });
 
-  it('renders legend entries for active buckets', () => {
+  it('v-progress-linear bars have height="10" and rounded props', () => {
     const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 50 } });
-    const legend = wrapper.find('.billing-meter-breakdown-chart__legend');
-    expect(legend.exists()).toBe(true);
-    expect(legend.text()).toContain('scrap');
-    expect(legend.text()).toContain('autofix');
+    const bars = wrapper.findAllComponents({ name: 'v-progress-linear' });
+    for (const bar of bars) {
+      expect(bar.props('height')).toBe('10');
+      expect(bar.props('rounded')).toBe(true);
+    }
   });
 
-  it('does not render zero-value bucket in legend', () => {
+  it('v-progress-linear bars have bg-color="surface-variant"', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100 } });
+    const bar = wrapper.findComponent({ name: 'v-progress-linear' });
+    expect(bar.props('bgColor')).toBe('surface-variant');
+  });
+
+  it('renders bucket label and percentage above each bar', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 100 } });
+    const text = wrapper.text();
+    // Both keys visible
+    expect(text).toContain('scrap');
+    expect(text).toContain('autofix');
+    // Percentages (50% each for equal split)
+    expect(text).toContain('50%');
+  });
+
+  it('does not render zero-value bucket bar or label', () => {
     const wrapper = mountComponent({ breakdown: { scrap: 100, autofix: 0 } });
-    expect(wrapper.find('.billing-meter-breakdown-chart__legend').text()).not.toContain('autofix');
+    // autofix is zero → not in active buckets → no label rendered
+    expect(wrapper.text()).not.toContain('autofix');
+    // Only 1 bar for scrap
+    expect(wrapper.findAllComponents({ name: 'v-progress-linear' })).toHaveLength(1);
+  });
+
+  it('does not render any bar when all buckets are zero', () => {
+    const wrapper = mountComponent({ breakdown: { scrap: 0 } });
+    expect(wrapper.findAllComponents({ name: 'v-progress-linear' })).toHaveLength(0);
+    expect(wrapper.text()).toContain('No usage data');
   });
 });

--- a/src/modules/billing/tests/billing.packs.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.packs.component.unit.tests.js
@@ -70,7 +70,12 @@ const vuetify = createVuetify();
  * @returns {import('@vue/test-utils').VueWrapper}
  */
 function mountPacks(overrides = {}) {
-  Object.assign(authState, overrides);
+  Object.assign(authState, {
+    isLoggedIn: true,
+    user: { currentOrganization: 'org_test_123' },
+    serverConfig: { organizations: { enabled: true } },
+    ...overrides,
+  });
   return mount(BillingPacksComponent, {
     global: {
       plugins: [vuetify, i18n],
@@ -191,16 +196,16 @@ describe('BillingPacksComponent — purchase flow', () => {
     expect(store.createExtrasCheckout).toHaveBeenCalledWith('pack_500');
   });
 
-  it('shows an error banner when createExtrasCheckout rejects (failure path)', async () => {
+  it('does NOT render inline purchaseError alert on checkout failure (centralized snackbar)', async () => {
     vi.spyOn(store, 'createExtrasCheckout').mockRejectedValue(new Error('Network error'));
     wrapper = mountPacks();
     await flushPromises();
     const buyBtn = wrapper.findAllComponents({ name: 'v-btn' }).find((b) => b.text().includes('500 units'));
     await buyBtn.trigger('click');
     await flushPromises();
-    const alert = wrapper.find('.v-alert');
-    expect(alert.exists()).toBe(true);
-    expect(wrapper.text()).toContain('Failed to start checkout. Please try again.');
+    // Error surfaced via centralized snackbar — no inline v-alert rendered
+    expect(wrapper.find('.v-alert').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Failed to start checkout. Please try again.');
   });
 
   it('disables all Buy buttons while a purchase is in progress', async () => {

--- a/src/modules/billing/tests/billing.store.unit.tests.js
+++ b/src/modules/billing/tests/billing.store.unit.tests.js
@@ -207,26 +207,19 @@ describe('Billing Store', () => {
         loadingDuringPortal = store.loading;
         return Promise.resolve({ data: { data: { url: portalUrl } } });
       });
-      const originalLocation = window.location;
-      delete window.location;
-      window.location = { ...originalLocation, href: '' };
       await store.openPortal();
       expect(loadingDuringPortal).toBe(true);
       expect(store.loading).toBe(false);
-      window.location = originalLocation;
     });
 
-    it('should call portal endpoint and redirect', async () => {
+    it('should call portal endpoint and return the validated URL', async () => {
       const store = useBillingStore();
       const portalUrl = 'https://billing.stripe.com/session456';
       axios.post.mockResolvedValueOnce({ data: { data: { url: portalUrl } } });
-      const originalLocation = window.location;
-      delete window.location;
-      window.location = { ...originalLocation, href: '' };
-      await store.openPortal();
-      expect(window.location.href).toBe(portalUrl);
+      const result = await store.openPortal();
+      // openPortal returns the URL — caller is responsible for window.open
+      expect(result).toBe(portalUrl);
       expect(store.loading).toBe(false);
-      window.location = originalLocation;
     });
 
     it('should throw when portal URL is missing from API response', async () => {
@@ -263,16 +256,22 @@ describe('Billing Store', () => {
       const store = useBillingStore();
       const portalUrl = 'https://billing.stripe.com/session/test_123';
       axios.post.mockResolvedValueOnce({ data: { data: { url: portalUrl } } });
-      const originalLocation = window.location;
-      delete window.location;
-      window.location = { ...originalLocation, href: '' };
       await store.openPortal();
       // Second argument must be {} (empty object), not undefined
       expect(axios.post).toHaveBeenCalledWith(
         expect.stringContaining('/portal'),
         {},
       );
-      window.location = originalLocation;
+    });
+
+    it('does NOT mutate window.location (caller is responsible for navigation)', async () => {
+      const store = useBillingStore();
+      const portalUrl = 'https://billing.stripe.com/session/no_redirect';
+      axios.post.mockResolvedValueOnce({ data: { data: { url: portalUrl } } });
+      const hrefBefore = window.location.href;
+      await store.openPortal();
+      // window.location.href must not have changed
+      expect(window.location.href).toBe(hrefBefore);
     });
   });
 

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -156,12 +156,12 @@ describe('BillingSubscriptionsComponent — meter mode (meterMode: true)', () =>
     expect(wrapper.find('.billing-meter-breakdown-chart').exists()).toBe(true);
   });
 
-  it('renders meter usage values', async () => {
+  it('renders meter usage values against combinedPool denominator', async () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    // Task 4: primary display is %, raw units are in aria-label / tooltip only
-    // 120 / 500 = 24%
-    expect(wrapper.text()).toContain('24%');
+    // combinedPool = meterQuota(500) + meterExtras(50) + meterUsed(120) = 670
+    // used(120) / combinedPool(670) = ~18%
+    expect(wrapper.text()).toContain('18%');
   });
 
   it('renders "Buy compute extras" CTA in meter mode (T6 redesign: /pricing#units redirect)', async () => {
@@ -262,7 +262,7 @@ describe('BillingSubscriptionsComponent — Manage Subscription', () => {
     store = useBillingStore();
     seedMeterStore(store);
     store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
-    vi.spyOn(store, 'openPortal').mockResolvedValue(undefined);
+    vi.spyOn(store, 'openPortal').mockResolvedValue('https://billing.stripe.com/session/test');
   });
 
   afterEach(() => {
@@ -283,7 +283,23 @@ describe('BillingSubscriptionsComponent — Manage Subscription', () => {
     expect(store.openPortal).toHaveBeenCalled();
   });
 
-  it('shows a portal error alert when openPortal rejects', async () => {
+  it('manageSubscription calls window.open with the URL from openPortal', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    await wrapper.vm.manageSubscription();
+    await flushPromises();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://billing.stripe.com/session/test',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    openSpy.mockRestore();
+  });
+
+  it('does NOT render inline portal error alert when openPortal rejects (centralized snackbar handles it)', async () => {
     store.openPortal.mockRejectedValueOnce(new Error('Portal failed'));
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
     await flushPromises();
@@ -291,7 +307,8 @@ describe('BillingSubscriptionsComponent — Manage Subscription', () => {
     await wrapper.vm.manageSubscription();
     await flushPromises();
 
-    expect(wrapper.text()).toContain('Unable to open the billing portal');
+    // Error is surfaced via centralized snackbar — no inline alert in this component
+    expect(wrapper.text()).not.toContain('Unable to open the billing portal');
   });
 });
 
@@ -782,74 +799,52 @@ describe('BillingSubscriptionsComponent — checkout success polling (P1-2)', ()
   });
 });
 
-// ─── Suite 9: meterError surfacing via v-alert (gated to meterMode) ──────────
+// ─── Suite 9: meterError — centralized snackbar (no inline v-alert) ──────────
+// meterError is now surfaced via lib/services/axios.js interceptor → centralized snackbar.
+// The subscriptions component no longer renders an inline v-alert for meter errors.
 
-describe('BillingSubscriptionsComponent — meterError surfacing', () => {
+describe('BillingSubscriptionsComponent — meterError (centralized snackbar, no inline alert)', () => {
   let wrapper;
   let store;
-  let useMeter;
-  let __resetUseMeterForTests;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
     sessionStorage.clear();
     store = useBillingStore();
     seedMeterStore(store);
     store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
-    // Import via composable so we mutate the shared meterError ref the component consumes.
-    ({ useMeter, __resetUseMeterForTests } = await import('../composables/billing.useMeter.js'));
-    __resetUseMeterForTests();
   });
 
   afterEach(() => {
     wrapper?.unmount();
     wrapper = null;
-    __resetUseMeterForTests?.();
   });
 
-  it('renders v-alert with refreshFailed copy when meterError is set and meterMode is true', async () => {
+  it('does NOT render inline meter error alert (meterError surfaced via centralized snackbar)', async () => {
+    // Even when meter fetch fails, no inline v-alert appears in this component.
+    vi.spyOn(store, 'fetchUsageMeter').mockRejectedValueOnce(new Error('meter fetch failed'));
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    // Mutate AFTER mount + initial fetch resolves — fetchMissingMeterData clears
-    // meterError on success, so setting it before mount would be wiped.
-    const { meterError } = useMeter({ pollIntervalMs: 0 });
-    meterError.value = new Error('refresh failed');
-    await flushPromises();
-    const alert = wrapper.find('.v-alert');
-    expect(alert.exists()).toBe(true);
-    expect(alert.text()).toContain('Could not refresh usage');
+    // Only status-banner alerts are acceptable (checkoutProcessing/timeout/paymentSuccess)
+    // No "Could not refresh usage" inline alert
+    expect(wrapper.text()).not.toContain('Could not refresh usage');
   });
 
-  it('does not render v-alert when meterError is null', async () => {
-    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
-    await flushPromises();
-    const { meterError } = useMeter({ pollIntervalMs: 0 });
-    expect(meterError.value).toBeNull();
-    expect(wrapper.find('.v-alert').exists()).toBe(false);
-  });
-
-  it('does not render v-alert when meterError is set but meterMode is false (gated)', async () => {
+  it('does NOT render inline v-alert on meter error in meterMode=false', async () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
     await flushPromises();
-    const { meterError } = useMeter({ pollIntervalMs: 0 });
-    meterError.value = new Error('refresh failed');
-    await flushPromises();
-    expect(wrapper.find('.v-alert').exists()).toBe(false);
+    // No meter-related alert should render in legacy mode
+    expect(wrapper.text()).not.toContain('Could not refresh usage');
   });
 
-  it('clears meterError on close click and the alert disappears', async () => {
+  it('combinedPool computed equals meterQuota + meterExtras + meterUsed', async () => {
+    // useMeter returns values seeded from billingStore.usageMeter
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    const { meterError } = useMeter({ pollIntervalMs: 0 });
-    meterError.value = new Error('refresh failed');
-    await flushPromises();
-    expect(wrapper.find('.v-alert').exists()).toBe(true);
-    // Simulate the v-alert close emit by mutating the bound ref the same way the
-    // template handler does (`meterError = null`).
-    meterError.value = null;
-    await flushPromises();
-    expect(wrapper.find('.v-alert').exists()).toBe(false);
+    // mockUsageMeterNormal: meterUsed=120, meterQuota=500, extrasRemaining=50
+    // combinedPool = 500 + 50 + 120 = 670
+    expect(wrapper.vm.combinedPool).toBe(670);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Combined pool denominator**: `combinedPool = meterQuota + meterExtras + meterUsed` used as Weekly compute bar quota — consistent with sidenav gauge formula; free plan no longer shows 100% red when quota=0
- **Linear breakdown chart**: `BillingMeterBreakdownChartComponent` refactored from stacked SVG to one `v-progress-linear` per non-zero bucket (`height="10"`, `rounded`, `bg-color="surface-variant"`) — same visual language as Weekly compute bar
- **Alerts cleanup**: inline `portalError` / `meterError` (subscriptions) and `purchaseError` (packs) v-alerts removed; backend errors now surfaced exclusively via centralized snackbar (`lib/services/axios.js` interceptor)
- **`openPortal()` returns URL**: store action returns validated Stripe URL; `manageSubscription` calls `window.open(url, '_blank', 'noopener,noreferrer')` — caller owns the navigation target

## Files changed (4 components + 4 test files)

| File | Change |
|------|--------|
| `billing.subscriptions.component.vue` | combinedPool computed, no inline alerts, manageSubscription window.open |
| `billing.meterBreakdownChart.component.vue` | v-progress-linear linear bars design |
| `billing.store.js` | openPortal returns URL, no window.location mutation |
| `billing.packs.component.vue` | remove purchaseError inline alert |
| `billing.subscriptions.component.unit.tests.js` | Suite 3 portal, Suite 9 meterError, combinedPool, 18% pct |
| `billing.meterBreakdownChart.component.unit.tests.js` | full rewrite: linear bar structure |
| `billing.store.unit.tests.js` | openPortal returns URL, no redirect |
| `billing.packs.component.unit.tests.js` | no purchaseError assertion |

## Test plan

- [x] `billing.subscriptions.component.unit.tests.js` — 82/82 pass
- [x] `billing.store.unit.tests.js` — 62/62 pass
- [x] `billing.meterBreakdownChart.component.unit.tests.js` — 20/20 pass
- [x] `billing.packs.component.unit.tests.js` — 11/11 pass
- [x] Full billing module — 549/549 pass
- [x] Full unit suite — 1681/1681 pass
- [x] ESLint — 0 errors