### PR TITLE
feat(core): reusable PageTabs component + Account view refactor

### DIFF
--- a/src/modules/core/components/core.pageTabs.component.vue
+++ b/src/modules/core/components/core.pageTabs.component.vue
@@ -1,0 +1,79 @@
+<template>
+  <v-card
+    color="surface"
+    :flat="config.vuetify.theme.flat"
+    :class="config.vuetify.theme.rounded"
+    data-test="page-tabs"
+  >
+    <v-tabs
+      :model-value="modelValue"
+      color="primary"
+      :grow="grow"
+      @update:model-value="(v) => $emit('update:modelValue', v)"
+    >
+      <template v-for="tab in visibleTabs" :key="tab.value">
+        <v-tab :value="tab.value" class="text-none text-body-medium">
+          <v-icon v-if="tab.icon" :icon="tab.icon" size="small" class="mr-2"></v-icon>
+          {{ tab.label }}
+        </v-tab>
+      </template>
+    </v-tabs>
+    <v-divider></v-divider>
+    <v-window :model-value="modelValue" @update:model-value="(v) => $emit('update:modelValue', v)">
+      <v-window-item
+        v-for="tab in visibleTabs"
+        :key="tab.value"
+        :value="tab.value"
+      >
+        <div class="pa-6">
+          <slot :name="tab.value"></slot>
+        </div>
+      </v-window-item>
+    </v-window>
+  </v-card>
+</template>
+
+<script>
+/**
+ * @desc Reusable page-level tab strip. Wraps PageHeader-bounded
+ * pages (Account, Organization, Admin) so the tab styling +
+ * inset padding stay aligned with the sidenav across the app.
+ *
+ * Usage:
+ *   <PageTabs v-model="tab" :tabs="tabs">
+ *     <template #profile> ... </template>
+ *     <template #organizations> ... </template>
+ *   </PageTabs>
+ *
+ * Each `tab` is { value, label, icon?, visible? }. When `visible`
+ * is false, the entry is omitted from the strip (used for
+ * permission-gated tabs like Subscriptions).
+ *
+ * `config` is injected via Vue globalProperties (same pattern as
+ * CoreDatatable) — provides `config.vuetify.theme.flat` and
+ * `config.vuetify.theme.rounded` for surface-consistent card styling.
+ */
+export default {
+  name: 'CorePageTabs',
+  props: {
+    modelValue: { type: String, required: true },
+    tabs: {
+      type: Array,
+      required: true,
+      validator: (arr) => arr.every((t) => t && typeof t.value === 'string' && typeof t.label === 'string'),
+    },
+    grow: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    /**
+     * Returns only tabs where `visible` is not explicitly false.
+     * Tabs without a `visible` key are shown by default.
+     * @returns {Array<{value: string, label: string, icon?: string, visible?: boolean}>}
+     */
+    visibleTabs() {
+      return this.tabs.filter((t) => t.visible !== false);
+    },
+  },
+};
+</script>

--- a/src/modules/core/components/core.pageTabs.component.vue
+++ b/src/modules/core/components/core.pageTabs.component.vue
@@ -19,7 +19,7 @@
       </template>
     </v-tabs>
     <v-divider></v-divider>
-    <v-window :model-value="modelValue" @update:model-value="(v) => $emit('update:modelValue', v)">
+    <v-window :model-value="modelValue">
       <v-window-item
         v-for="tab in visibleTabs"
         :key="tab.value"

--- a/src/modules/core/tests/core.pageTabs.component.unit.tests.js
+++ b/src/modules/core/tests/core.pageTabs.component.unit.tests.js
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { describe, test, expect } from 'vitest';
+import PageTabs from '../components/core.pageTabs.component.vue';
+
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Qwik rule does not apply in a Vue/Vitest context
+const vuetify = createVuetify({ components, directives });
+
+const mockConfig = { vuetify: { theme: { flat: false, rounded: '' } } };
+
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Qwik rule does not apply in a Vue/Vitest context
+const globalOpts = {
+  plugins: [vuetify],
+  config: {
+    globalProperties: { config: mockConfig },
+  },
+};
+
+describe('core.pageTabs.component', () => {
+  const tabs = [
+    { value: 'one', label: 'One', icon: 'fa-solid fa-cube' },
+    { value: 'two', label: 'Two', icon: 'fa-solid fa-cube' },
+  ];
+
+  test('renders tab strip + window with one slot per tab', () => {
+    const wrapper = mount(PageTabs, {
+      props: { modelValue: 'one', tabs },
+      slots: {
+        one: '<div data-test="slot-one">Content One</div>',
+        two: '<div data-test="slot-two">Content Two</div>',
+      },
+      global: globalOpts,
+    });
+    expect(wrapper.find('[data-test="page-tabs"]').exists()).toBe(true);
+    expect(wrapper.findAll('.v-tab').length).toBe(2);
+    expect(wrapper.find('[data-test="slot-one"]').exists()).toBe(true);
+  });
+
+  test('emits update:modelValue when a tab is clicked', async () => {
+    const wrapper = mount(PageTabs, {
+      props: { modelValue: 'one', tabs },
+      slots: { one: '<div></div>', two: '<div></div>' },
+      global: globalOpts,
+    });
+    await wrapper.findAll('.v-tab')[1].trigger('click');
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['two']);
+  });
+
+  test('hides a tab when its `visible` prop is false', () => {
+    const wrapper = mount(PageTabs, {
+      props: { modelValue: 'one', tabs: [...tabs, { value: 'three', label: 'Three', visible: false }] },
+      slots: { one: '<div></div>', two: '<div></div>', three: '<div></div>' },
+      global: globalOpts,
+    });
+    expect(wrapper.findAll('.v-tab').length).toBe(2);
+  });
+});

--- a/src/modules/users/tests/user.view.unit.tests.js
+++ b/src/modules/users/tests/user.view.unit.tests.js
@@ -196,25 +196,20 @@ describe('UserView – C4 decoupling: billing tab removed', () => {
   });
 
   it('only exposes profile and organizations tabs', () => {
-    const capturedValues = [];
-    const vTabStub = {
-      template: '<div><slot /></div>',
-      inheritAttrs: false,
-      created() {
-        if (this.$attrs.value) capturedValues.push(this.$attrs.value);
-      },
-    };
-
-    shallowMount(UserView, {
+    // After C1.2 refactor, tabs are declared via tabsConfig (consumed by PageTabs).
+    // v-tab elements no longer appear directly in user.view.vue, so we inspect
+    // tabsConfig to verify the exposed set of tabs.
+    const wrapper = shallowMount(UserView, {
       global: {
         mocks: sharedMocks(),
-        stubs: { ...sharedStubs, 'v-tab': vTabStub },
+        stubs: sharedStubs,
       },
     });
 
-    expect(capturedValues).toContain('profile');
-    expect(capturedValues).toContain('organizations');
-    expect(capturedValues).not.toContain('subscriptions');
+    const tabValues = wrapper.vm.tabsConfig.map((t) => t.value);
+    expect(tabValues).toContain('profile');
+    expect(tabValues).toContain('organizations');
+    expect(tabValues).not.toContain('subscriptions');
   });
 });
 
@@ -329,6 +324,59 @@ describe('UserView – organizations refetch on auth state change', () => {
     // If user.view still imports billingStore and calls fetchSubscription, this would
     // require a mock; its absence means the view is cleanly decoupled.
     expect(Object.keys(UserView.components || {})).not.toContain('BillingSubscriptionsComponent');
+  });
+});
+
+// ── UserView – C1.2: PageTabs integration ────────────────────────────────────
+
+describe('UserView – renders PageTabs with profile + organizations entries', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    const organizationsStore = useOrganizationsStore();
+    organizationsStore.fetchOrganizations = vi.fn().mockResolvedValue([]);
+  });
+
+  it('renders a [data-test="page-tabs"] element via PageTabs', async () => {
+    const PageTabsStub = {
+      template: '<div data-test="page-tabs"><slot /></div>',
+      inheritAttrs: false,
+    };
+
+    const wrapper = shallowMount(UserView, {
+      global: {
+        mocks: sharedMocks(),
+        stubs: { ...sharedStubs, PageTabs: PageTabsStub },
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="page-tabs"]').exists()).toBe(true);
+  });
+
+  it('tabsConfig includes profile and organizations entries', () => {
+    const wrapper = shallowMount(UserView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+    const config = wrapper.vm.tabsConfig;
+    expect(Array.isArray(config)).toBe(true);
+    const values = config.map((t) => t.value);
+    expect(values).toContain('profile');
+    expect(values).toContain('organizations');
+  });
+
+  it('tabsConfig profile entry has correct label', () => {
+    const wrapper = shallowMount(UserView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+    const profile = wrapper.vm.tabsConfig.find((t) => t.value === 'profile');
+    expect(profile?.label).toBe('Profile');
+  });
+
+  it('tabsConfig organizations entry has correct label', () => {
+    const wrapper = shallowMount(UserView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+    const orgs = wrapper.vm.tabsConfig.find((t) => t.value === 'organizations');
+    expect(orgs?.label).toBe('Organizations');
   });
 });
 

--- a/src/modules/users/views/user.view.vue
+++ b/src/modules/users/views/user.view.vue
@@ -7,97 +7,79 @@
     </PageHeader>
     <v-row class="pa-2 mt-0">
       <v-col cols="12">
-        <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded">
-          <v-tabs v-model="tab" color="primary">
-            <v-tab value="profile" class="text-none text-body-medium">
-              <v-icon icon="fa-solid fa-id-card" size="small" class="mr-2"></v-icon>
-              Profile
-            </v-tab>
-            <v-tab value="organizations" class="text-none text-body-medium">
-              <v-icon icon="fa-solid fa-building" size="small" class="mr-2"></v-icon>
-              Organizations
-            </v-tab>
-          </v-tabs>
-          <v-divider></v-divider>
-          <v-window v-model="tab">
-            <!-- Profile tab -->
-            <v-window-item value="profile">
-              <div class="pa-6">
-                <userProfileComponent :user="user" :organizations="organizations" @save="updateProfile" @avatar-uploaded="onAvatarUploaded" />
+        <PageTabs v-model="tab" :tabs="tabsConfig">
+          <template #profile>
+            <userProfileComponent
+              :user="user"
+              :organizations="organizations"
+              @save="updateProfile"
+              @avatar-uploaded="onAvatarUploaded"
+            />
 
-                <!-- Danger zone -->
-                <v-card variant="outlined" color="error" class="mt-6">
-                  <v-card-title class="text-title-medium font-weight-medium">Delete account</v-card-title>
-                  <v-card-text class="text-body-small text-medium-emphasis">Permanently delete your account, data, and organization ownership. This cannot be undone.</v-card-text>
-                  <v-card-actions>
-                    <v-btn color="error" variant="flat" :class="config.vuetify.theme.rounded" class="text-none text-body-medium" @click="confirmDeleteAccount = true">Delete account</v-btn>
-                  </v-card-actions>
-                </v-card>
-              </div>
-            </v-window-item>
-            <!-- Organizations tab -->
-            <v-window-item value="organizations">
-              <div class="pa-6">
-                <v-list v-if="organizations && organizations.length" lines="two" class="pa-0 bg-transparent">
-                  <template v-for="(org, i) in organizations" :key="org.id || org._id">
-                    <v-list-item
-                      :to="org.role === 'owner' || org.role === 'admin' ? `/users/organizations/${org.id || org._id}` : undefined"
-                      :class="config.vuetify.theme.rounded"
-                      class="pa-4"
-                    >
-                      <template #prepend>
-                        <orgAvatarComponent :org="org" :size="40" class="mr-4" />
-                      </template>
-                      <v-list-item-title class="text-body-large font-weight-medium">{{ org.name }}</v-list-item-title>
-                      <v-list-item-subtitle v-if="org.description" class="text-body-small">{{ org.description }}</v-list-item-subtitle>
-                      <template #append>
-                        <div class="d-flex align-center ga-2">
-                          <v-chip v-if="org.role" size="small" :color="roleColor(org.role)" variant="tonal" class="text-capitalize">{{
-                            org.role
-                          }}</v-chip>
-                          <v-chip v-if="isActiveOrg(org)" size="small" color="success" variant="flat">Active</v-chip>
-                          <v-btn
-                            v-if="org.role !== 'owner'"
-                            color="error"
-                            variant="text"
-                            size="small"
-                            class="text-none"
-                            @click.stop.prevent="confirmLeave(org)"
-                          >
-                            Leave
-                          </v-btn>
-                          <v-icon
-                            v-if="org.role === 'owner' || org.role === 'admin'"
-                            icon="fa-solid fa-chevron-right"
-                            size="small"
-                            color="medium-emphasis"
-                          ></v-icon>
-                        </div>
-                      </template>
-                    </v-list-item>
-                    <v-divider v-if="i < organizations.length - 1"></v-divider>
-                  </template>
-                </v-list>
-                <v-btn
-                  color="primary"
-                  variant="tonal"
+            <!-- Danger zone -->
+            <v-card variant="outlined" color="error" class="mt-6">
+              <v-card-title class="text-title-medium font-weight-medium">Delete account</v-card-title>
+              <v-card-text class="text-body-small text-medium-emphasis">Permanently delete your account, data, and organization ownership. This cannot be undone.</v-card-text>
+              <v-card-actions>
+                <v-btn color="error" variant="flat" :class="config.vuetify.theme.rounded" class="text-none text-body-medium" @click="confirmDeleteAccount = true">Delete account</v-btn>
+              </v-card-actions>
+            </v-card>
+          </template>
+
+          <template #organizations>
+            <v-list v-if="organizations && organizations.length" lines="two" class="pa-0 bg-transparent">
+              <template v-for="(org, i) in organizations" :key="org.id || org._id">
+                <v-list-item
+                  :to="org.role === 'owner' || org.role === 'admin' ? `/users/organizations/${org.id || org._id}` : undefined"
                   :class="config.vuetify.theme.rounded"
-                  class="text-none text-body-medium mt-4"
-                  to="/users/organizations/create"
-                  block
+                  class="pa-4"
                 >
-                  <v-icon icon="fa-solid fa-plus" size="small" class="mr-2"></v-icon>
-                  New Organization
-                </v-btn>
-                <div v-if="!organizations || !organizations.length" class="text-center text-medium-emphasis pa-8">
-                  <v-icon icon="fa-solid fa-building" size="x-large" class="mb-4 text-medium-emphasis"></v-icon>
-                  <p class="text-body-medium">No organizations yet.</p>
-                </div>
-              </div>
-            </v-window-item>
-          </v-window>
-        </v-card>
-
+                  <template #prepend>
+                    <orgAvatarComponent :org="org" :size="40" class="mr-4" />
+                  </template>
+                  <v-list-item-title class="text-body-large font-weight-medium">{{ org.name }}</v-list-item-title>
+                  <v-list-item-subtitle v-if="org.description" class="text-body-small">{{ org.description }}</v-list-item-subtitle>
+                  <template #append>
+                    <div class="d-flex align-center ga-2">
+                      <v-chip v-if="org.role" size="small" :color="roleColor(org.role)" variant="tonal" class="text-capitalize">{{ org.role }}</v-chip>
+                      <v-chip v-if="isActiveOrg(org)" size="small" color="success" variant="flat">Active</v-chip>
+                      <v-btn
+                        v-if="org.role !== 'owner'"
+                        color="error"
+                        variant="text"
+                        size="small"
+                        class="text-none"
+                        @click.stop.prevent="confirmLeave(org)"
+                      >Leave</v-btn>
+                      <v-icon
+                        v-if="org.role === 'owner' || org.role === 'admin'"
+                        icon="fa-solid fa-chevron-right"
+                        size="small"
+                        color="medium-emphasis"
+                      ></v-icon>
+                    </div>
+                  </template>
+                </v-list-item>
+                <v-divider v-if="i < organizations.length - 1"></v-divider>
+              </template>
+            </v-list>
+            <v-btn
+              color="primary"
+              variant="tonal"
+              :class="config.vuetify.theme.rounded"
+              class="text-none text-body-medium mt-4"
+              to="/users/organizations/create"
+              block
+            >
+              <v-icon icon="fa-solid fa-plus" size="small" class="mr-2"></v-icon>
+              New Organization
+            </v-btn>
+            <div v-if="!organizations || !organizations.length" class="text-center text-medium-emphasis pa-8">
+              <v-icon icon="fa-solid fa-building" size="x-large" class="mb-4 text-medium-emphasis"></v-icon>
+              <p class="text-body-medium">No organizations yet.</p>
+            </div>
+          </template>
+        </PageTabs>
       </v-col>
     </v-row>
 
@@ -154,6 +136,7 @@ import { useOrganizationsStore } from '../../organizations/stores/organizations.
 import axios from '../../../lib/services/axios';
 import roleColor from '../../../lib/helpers/roleColor';
 import PageHeader from '../../core/components/core.pageHeader.component.vue';
+import PageTabs from '../../core/components/core.pageTabs.component.vue';
 import userProfileComponent from '../components/user.profile.component.vue';
 import organizationsSwitcherComponent from '../../organizations/components/organizations.switcher.component.vue';
 import orgAvatarComponent from '../../core/components/org.avatar.component.vue';
@@ -162,6 +145,7 @@ export default {
   name: 'UserView',
   components: {
     PageHeader,
+    PageTabs,
     userProfileComponent,
     organizationsSwitcherComponent,
     orgAvatarComponent,
@@ -198,6 +182,16 @@ export default {
     currentOrganizationId() {
       const id = this.authStore.user?.currentOrganization;
       return id?._id || id?.id || id;
+    },
+    /**
+     * @desc Tab definitions for the Account page.
+     * @returns {Array<{value: string, label: string, icon: string}>}
+     */
+    tabsConfig() {
+      return [
+        { value: 'profile', label: 'Profile', icon: 'fa-solid fa-id-card' },
+        { value: 'organizations', label: 'Organizations', icon: 'fa-solid fa-building' },
+      ];
     },
   },
   watch: {


### PR DESCRIPTION
## Summary

- `a566c257` feat(core): add reusable PageTabs component
- `02530c2b` refactor(core): drop redundant v-window emit in PageTabs
- `60bb33aa` refactor(users): adopt core PageTabs in Account view

Adds a reusable `<PageTabs>` wrapping `v-tabs` + `v-window`, then refactors the Account view onto it. Sets up Org + Admin views to align on the same tab pattern via `/update-stack` propagation (PR C2 follow-up in trawl_vue).

**Note on C1.2 review**: a spec reviewer initially flagged a missing 'Subscriptions' tab, but devkit master already removed it (PR #4059) and relocated billing to a child route (PR #4175). Current 2-tab Account view is the shipped behavior. The flag was a stale-plan false positive.