### PR TITLE
fix(ui): chrome convergence — restore section title + surface backgrounds + homogeneous gutter

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,158 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## Account / Organization / Admin chrome convergence (2026-05-21)
+
+**Non-breaking for default consumers.** Builds on #4183 (`corePageTabs`), #4184 (org tabs), #4185 (Account chrome), and #4187 (Admin chrome + `coreConfirmDialog` + `coreAvatarUploader`). Locks in one chrome convention across all "section + tab bar + routed children" layouts.
+
+### The convention
+
+Layouts (Account, Organization detail, Admin) use the same shape:
+
+```vue
+<template>
+  <v-container fluid>
+    <PageHeader icon="fa-solid fa-X" title="Section">
+      <template #actions v-if="...">...</template>
+    </PageHeader>
+    <CoreSurfaceTabBar :tabs="..." :can="..." :base-path="..." />
+  </v-container>
+  <router-view />
+</template>
+```
+
+- `PageHeader` and `CoreSurfaceTabBar` are **siblings inside the container** — NEVER pass tabs via PageHeader's `#tabs` slot. That slot replaces the icon+title row and is reserved for future cases that intentionally suppress the title (none in this codebase today).
+- `<router-view />` is **outside** the layout's `<v-container fluid>` — children supply their own gutter.
+
+Routed children wrap their primary content like this:
+
+```vue
+<template>
+  <v-container fluid>
+    <v-row class="pa-2 mt-0">
+      <v-col cols="12">
+        <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-6">
+          <!-- primary content -->
+        </v-card>
+        <!-- optional sibling cards (e.g. danger zone) -->
+      </v-col>
+    </v-row>
+    <coreConfirmDialog ... />
+  </v-container>
+</template>
+```
+
+The `<v-card color="surface">` provides the visible pane background. Content that already provides its own surface (e.g. `coreDataTableComponent`) skips the wrap card to avoid double-surface — wrap the data table directly in `<v-col cols="12">` without an inner `<v-card>`.
+
+### Detail-page breadcrumb (admin only)
+
+Admin sub-views that drill into a single record publish a breadcrumb to the layout instead of carrying their own header:
+
+```javascript
+import { useAdminStore } from '../stores/admin.store';
+// ...
+watch: {
+  user: { immediate: true, handler(u) { this.publishBreadcrumb(u); } },
+},
+beforeUnmount() { useAdminStore().clearBreadcrumb(); },
+methods: {
+  publishBreadcrumb(u) {
+    if (!u || (!u.firstName && !u.lastName && !u.email)) return;
+    const title = [u.firstName, u.lastName].filter(Boolean).join(' ') || u.email;
+    useAdminStore().setBreadcrumb({ title, titleClass: 'text-capitalize' });
+  },
+},
+```
+
+In breadcrumb mode the layout hides `<CoreSurfaceTabBar>` (user is "drilled in") and renders `Section › <title>` via `<PageHeader>`'s `#breadcrumb` slot.
+
+### Shared destructive-confirm dialog
+
+`<coreConfirmDialog>` (from `src/modules/core/components/core.confirmDialog.component.vue`) replaces inline `<v-dialog>` blocks for destructive actions:
+
+```vue
+<coreConfirmDialog
+  v-model="confirmDelete"
+  title="Delete X"
+  :confirm-text="confirmTarget"
+  confirm-label="Delete"
+  confirm-color="error"
+  @confirm="remove"
+>
+  <!-- optional default slot for rich body content -->
+</coreConfirmDialog>
+```
+
+Supports a simple yes/no (no `confirm-text`) OR a typed-gate (`confirm-text="DELETE"` or `:confirm-text="orgName"` — confirm button stays disabled until the user types the exact string).
+
+### Avatar uploader
+
+`<coreAvatarUploader>` (`src/modules/core/components/core.avatarUploader.component.vue`) replaces hand-rolled `position-absolute` camera-button overlays:
+
+```vue
+<coreAvatarUploader :user="user" :size="200" @uploaded="$emit('avatar-uploaded')" />
+```
+
+Posts to `/users/avatar` by default; `endpoint` and `field` props let it serve other upload contracts (logos, banners) without forking.
+
+### Action for downstream projects
+
+**Default consumers (no admin extras, no custom account chrome):** no action required. The convention is applied uniformly inside devkit.
+
+**Projects with `config.admin.tabs` extras:** no structural change — extras are merged with the canonical `BUILT_IN_TABS` (Users, Organizations, Readiness, Activity) and passed through `CoreSurfaceTabBar`, which handles validation + CASL filtering via `resolveSurfaceTabs`. Existing tab descriptors (`{ value, label, icon, route, action?, subject? }`) work as-is.
+
+**Projects with module-specific tabs under a page title** (e.g. trawl_vue's `/developers`, `/scraps`, custom dashboards): you can now adopt the homogeneous `PageHeader + CoreSurfaceTabBar` sibling pattern instead of the legacy `<v-card><v-tabs><v-window>` in-card pattern. Migration is opt-in — the legacy pattern still works, but the new pattern integrates visually with Account / Organization / Admin and gets CASL gating for free.
+
+Before:
+
+```vue
+<v-container fluid>
+  <PageHeader icon="fa-solid fa-code" title="Developers" />
+  <v-row class="pa-2 mt-0">
+    <v-col cols="12">
+      <v-card color="surface">
+        <v-tabs v-model="tab">
+          <v-tab value="keys">...</v-tab>
+          <v-tab value="webhooks">...</v-tab>
+        </v-tabs>
+        <v-divider />
+        <v-window v-model="tab">
+          <v-window-item value="keys"><developersKeysTab :keys="..." /></v-window-item>
+          <v-window-item value="webhooks"><developersWebhooksTab :webhooks="..." /></v-window-item>
+        </v-window>
+      </v-card>
+    </v-col>
+  </v-row>
+</v-container>
+```
+
+After (route-driven, homogeneous with Account / Org / Admin):
+
+```vue
+<!-- developers.layout.vue -->
+<template>
+  <v-container fluid>
+    <PageHeader icon="fa-solid fa-code" title="Developers" />
+    <CoreSurfaceTabBar
+      :tabs="config.developers.tabs"
+      :can="developersCan"
+      :base-path="basePath"
+    />
+  </v-container>
+  <router-view />
+</template>
+```
+
+Plus `config.developers.tabs = [{ value: 'keys', label: 'API Keys', icon: 'fa-solid fa-key', route: 'keys' }, { value: 'webhooks', label: 'Webhooks', icon: 'fa-solid fa-globe', route: 'webhooks' }]`, then split the keys / webhooks tabs into routed children (`developers.keys.view.vue`, `developers.webhooks.view.vue`) each wrapping its content per the child-view shape above. Dialogs (`showCreateKeyDialog`, `showPlainKeyDialog`, etc.) move into the child views that own them.
+
+This migration is **opt-in per module** — coordinate with the maintainer of each module before applying.
+
+### Why
+
+`/admin/users`, `/users/profile`, `/users/organizations` looked visually disconnected from `/developers`, `/tasks` after #4187 (no surface background on routed panes, no section title on admin, ad-hoc padding). Locking in one convention makes every "section + tabs + content" layout in the app visually identical and lets downstream projects opt their own modules in cheaply.
+
+---
+
 ## Legal module + cookie consent banner (2026-05-07)
 
 **Non-breaking for default consumers.** New `modules/legal/` ships:

--- a/src/modules/admin/tests/admin.activity.view.unit.tests.js
+++ b/src/modules/admin/tests/admin.activity.view.unit.tests.js
@@ -187,11 +187,13 @@ import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
 describe('admin.activity.view — template chrome', () => {
-  it('does NOT wrap its template in <v-container> (admin layout owns chrome)', () => {
+  it('wraps its template in <v-container fluid> + <v-row class="pa-2 mt-0"> + <v-col cols="12">', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const sfc = readFileSync(resolve(here, '../views/admin.activity.view.vue'), 'utf8');
     const tmpl = sfc.split('<script>')[0];
-    expect(tmpl).not.toMatch(/<v-container/);
+    expect(tmpl).toMatch(/<v-container\s+fluid/);
+    expect(tmpl).toMatch(/<v-row[^>]*class="[^"]*pa-2\s+mt-0/);
+    expect(tmpl).toMatch(/<v-col\s+cols="12"/);
   });
 
   it('has zero inline style="…" attributes in its template', () => {

--- a/src/modules/admin/tests/admin.layout.unit.tests.js
+++ b/src/modules/admin/tests/admin.layout.unit.tests.js
@@ -45,8 +45,10 @@ const mountLayout = (configOverrides = {}, routePath = '/admin/users') =>
         RouterLink: true,
         RouterView: { template: '<div class="router-view-stub" />' },
         PageHeader: {
+          name: 'PageHeader',
+          props: ['title', 'icon'],
           template: `
-            <div class="page-header-stub">
+            <div class="page-header-stub" :data-title="title" :data-icon="icon">
               <slot name="avatar" />
               <slot name="breadcrumb" />
               <slot name="tabs" />
@@ -150,10 +152,51 @@ describe('admin.layout', () => {
     expect(wrapper.html()).not.toContain('No mailer configured');
   });
 
-  it('renders a single .admin-content wrapper around <router-view>', () => {
+  it('renders <CoreSurfaceTabBar> as a SIBLING of <PageHeader> (not inside its #tabs slot)', () => {
     const wrapper = mountLayout();
-    expect(wrapper.findAll('.admin-content').length).toBe(1);
-    expect(wrapper.find('.admin-content .router-view-stub').exists()).toBe(true);
+    const pageHeaderEl = wrapper.find('.page-header-stub');
+    const surfaceTabBarEl = wrapper.find('.surface-tab-bar-stub');
+    expect(pageHeaderEl.exists()).toBe(true);
+    expect(surfaceTabBarEl.exists()).toBe(true);
+    // Sibling layout: the tab-bar element is NOT inside the page-header-stub element.
+    expect(pageHeaderEl.element.contains(surfaceTabBarEl.element)).toBe(false);
+  });
+
+  it('renders <router-view> OUTSIDE the layout <v-container>', () => {
+    const wrapper = mountLayout();
+    const layoutContainer = wrapper.find('.v-container');
+    const routerViewEl = wrapper.find('.router-view-stub');
+    expect(layoutContainer.exists()).toBe(true);
+    expect(routerViewEl.exists()).toBe(true);
+    expect(layoutContainer.element.contains(routerViewEl.element)).toBe(false);
+  });
+
+  it('PageHeader receives title="Admin" + icon="fa-solid fa-user-tie" in list mode', () => {
+    const wrapper = mountLayout();
+    const ph = wrapper.findComponent({ name: 'PageHeader' });
+    expect(ph.props('title')).toBe('Admin');
+    expect(ph.props('icon')).toBe('fa-solid fa-user-tie');
+  });
+
+  it('PageHeader receives title="" + icon stays in breadcrumb mode', async () => {
+    adminStoreState.currentBreadcrumb = { title: 'Jane Doe' };
+    const wrapper = mountLayout({}, '/admin/users/u1');
+    await wrapper.vm.$nextTick();
+    const ph = wrapper.findComponent({ name: 'PageHeader' });
+    expect(ph.props('title')).toBe('');
+    expect(ph.props('icon')).toBe('fa-solid fa-user-tie');
+  });
+
+  it('does NOT render <CoreSurfaceTabBar> when currentBreadcrumb is set (detail mode)', async () => {
+    adminStoreState.currentBreadcrumb = { title: 'Jane Doe' };
+    const wrapper = mountLayout({}, '/admin/users/u1');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findComponent({ name: 'CoreSurfaceTabBar' }).exists()).toBe(false);
+  });
+
+  it('renders <CoreSurfaceTabBar> when currentBreadcrumb is null (list mode)', () => {
+    const wrapper = mountLayout();
+    expect(wrapper.findComponent({ name: 'CoreSurfaceTabBar' }).exists()).toBe(true);
   });
 
   it('renders the breadcrumb when useAdminStore().currentBreadcrumb is set', async () => {
@@ -163,15 +206,4 @@ describe('admin.layout', () => {
     expect(wrapper.text()).toContain('Jane Doe');
   });
 
-  it('does NOT render CoreSurfaceTabBar when currentBreadcrumb is set (detail mode)', async () => {
-    adminStoreState.currentBreadcrumb = { title: 'Jane Doe' };
-    const wrapper = mountLayout({}, '/admin/users/u1');
-    await wrapper.vm.$nextTick();
-    expect(wrapper.findComponent({ name: 'CoreSurfaceTabBar' }).exists()).toBe(false);
-  });
-
-  it('renders CoreSurfaceTabBar when currentBreadcrumb is null (list mode)', () => {
-    const wrapper = mountLayout();
-    expect(wrapper.findComponent({ name: 'CoreSurfaceTabBar' }).exists()).toBe(true);
-  });
 });

--- a/src/modules/admin/tests/admin.organizations.view.unit.tests.js
+++ b/src/modules/admin/tests/admin.organizations.view.unit.tests.js
@@ -75,11 +75,12 @@ import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
 describe('admin.organizations.view — template chrome', () => {
-  it('does NOT wrap its template in <v-container> (admin layout owns chrome)', () => {
+  it('wraps its template in <v-container fluid> + <v-row class="pa-2 mt-0"> + <v-col cols="12">', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const sfc = readFileSync(resolve(here, '../views/admin.organizations.view.vue'), 'utf8');
-    // Extract only the top-level <template>…</template> block (before <script>)
-    const tmpl = sfc.split('<script>')[0] || '';
-    expect(tmpl).not.toMatch(/<v-container/);
+    const tmpl = sfc.split('<script>')[0];
+    expect(tmpl).toMatch(/<v-container\s+fluid/);
+    expect(tmpl).toMatch(/<v-row[^>]*class="[^"]*pa-2\s+mt-0/);
+    expect(tmpl).toMatch(/<v-col\s+cols="12"/);
   });
 });

--- a/src/modules/admin/tests/admin.readiness.view.unit.tests.js
+++ b/src/modules/admin/tests/admin.readiness.view.unit.tests.js
@@ -99,11 +99,12 @@ import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
 describe('admin.readiness.view — template chrome', () => {
-  it('does NOT wrap its template in <v-container> (admin layout owns chrome)', () => {
+  it('wraps its template in <v-container fluid> + <v-row class="pa-2 mt-0"> + <v-col cols="12">', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const sfc = readFileSync(resolve(here, '../views/admin.readiness.view.vue'), 'utf8');
-    // Extract only the top-level <template>…</template> block (before <script>)
-    const tmpl = sfc.split('<script>')[0] || '';
-    expect(tmpl).not.toMatch(/<v-container/);
+    const tmpl = sfc.split('<script>')[0];
+    expect(tmpl).toMatch(/<v-container\s+fluid/);
+    expect(tmpl).toMatch(/<v-row[^>]*class="[^"]*pa-2\s+mt-0/);
+    expect(tmpl).toMatch(/<v-col\s+cols="12"/);
   });
 });

--- a/src/modules/admin/tests/admin.user.view.unit.tests.js
+++ b/src/modules/admin/tests/admin.user.view.unit.tests.js
@@ -63,11 +63,13 @@ const mountView = (routeId = 'u1', initialUser = null) => {
 };
 
 describe('admin.user.view — template chrome', () => {
-  it('does NOT render its own <v-container> (admin layout owns chrome)', () => {
+  it('wraps its template in <v-container fluid> + <v-row class="pa-2 mt-0"> + <v-col cols="12">', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const sfc = readFileSync(resolve(here, '../views/admin.user.view.vue'), 'utf8');
     const tmpl = sfc.split('<script>')[0];
-    expect(tmpl).not.toMatch(/<v-container/);
+    expect(tmpl).toMatch(/<v-container\s+fluid/);
+    expect(tmpl).toMatch(/<v-row[^>]*class="[^"]*pa-2\s+mt-0/);
+    expect(tmpl).toMatch(/<v-col\s+cols="12"/);
   });
 
   it('does NOT render its own <PageHeader> (admin layout supplies breadcrumb)', () => {

--- a/src/modules/admin/tests/admin.users.view.unit.tests.js
+++ b/src/modules/admin/tests/admin.users.view.unit.tests.js
@@ -128,12 +128,13 @@ import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
 describe('admin.users.view — template chrome', () => {
-  it('does NOT wrap its template in <v-container> (admin layout owns chrome)', () => {
+  it('wraps its template in <v-container fluid> + <v-row class="pa-2 mt-0"> + <v-col cols="12">', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const sfc = readFileSync(resolve(here, '../views/admin.users.view.vue'), 'utf8');
-    // Extract only the top-level <template>…</template> block (before <script>)
-    const tmpl = sfc.split('<script>')[0] || '';
-    expect(tmpl).not.toMatch(/<v-container/);
+    const tmpl = sfc.split('<script>')[0];
+    expect(tmpl).toMatch(/<v-container\s+fluid/);
+    expect(tmpl).toMatch(/<v-row[^>]*class="[^"]*pa-2\s+mt-0/);
+    expect(tmpl).toMatch(/<v-col\s+cols="12"/);
   });
 });
 

--- a/src/modules/admin/views/admin.activity.view.vue
+++ b/src/modules/admin/views/admin.activity.view.vue
@@ -1,16 +1,19 @@
 <template>
-  <!-- Audit disabled info state -->
-  <v-alert
-    v-if="config.audit && config.audit.enabled === false"
-    type="info"
-    variant="tonal"
-    density="compact"
-    :class="config.vuetify.theme.rounded"
-    icon="fa-solid fa-circle-info"
-  >
-    <span class="text-body-medium">Audit logging is disabled. Enable it in configuration to start tracking activity.</span>
-  </v-alert>
-  <v-card v-else width="100%" color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded">
+  <v-container fluid>
+    <v-row class="pa-2 mt-0">
+      <v-col cols="12">
+        <!-- Audit disabled info state -->
+        <v-alert
+          v-if="config.audit && config.audit.enabled === false"
+          type="info"
+          variant="tonal"
+          density="compact"
+          :class="config.vuetify.theme.rounded"
+          icon="fa-solid fa-circle-info"
+        >
+          <span class="text-body-medium">Audit logging is disabled. Enable it in configuration to start tracking activity.</span>
+        </v-alert>
+        <v-card v-else width="100%" color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded">
     <v-card-title>
       <v-row dense align="center">
         <v-col cols="12" sm="auto">
@@ -131,7 +134,10 @@
         <v-icon icon="fa-solid fa-angle-right" size="small"></v-icon>
       </v-btn>
     </v-card-actions>
-  </v-card>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 <script>
 /**

--- a/src/modules/admin/views/admin.layout.vue
+++ b/src/modules/admin/views/admin.layout.vue
@@ -10,8 +10,9 @@
       :class="config.vuetify.theme.rounded"
       icon="fa-solid fa-circle-exclamation"
       @click:close="clearError"
-      ><span class="text-body-medium">{{ error }}</span></v-alert
     >
+      <span class="text-body-medium">{{ error }}</span>
+    </v-alert>
     <v-alert
       v-if="showMailerWarning"
       type="warning"
@@ -20,13 +21,14 @@
       class="mx-2 mt-2"
       :class="config.vuetify.theme.rounded"
       icon="fa-solid fa-triangle-exclamation"
-      ><span class="text-body-medium"
-        >No mailer configured. Users can register with any email without verification. Set up SMTP to enable email verification.</span
-      ></v-alert
     >
+      <span class="text-body-medium">
+        No mailer configured. Users can register with any email without verification. Set up SMTP to enable email verification.
+      </span>
+    </v-alert>
 
     <PageHeader
-      :icon="currentBreadcrumb ? '' : 'fa-solid fa-user-tie'"
+      icon="fa-solid fa-user-tie"
       :title="currentBreadcrumb ? '' : 'Admin'"
     >
       <template v-if="currentBreadcrumb" #breadcrumb>
@@ -34,15 +36,16 @@
         <v-icon icon="fa-solid fa-chevron-right" size="x-small" class="mx-2 text-medium-emphasis"></v-icon>
         <span :class="currentBreadcrumb.titleClass || ''">{{ currentBreadcrumb.title }}</span>
       </template>
-      <template v-if="!currentBreadcrumb" #tabs>
-        <CoreSurfaceTabBar :tabs="allTabs" :can="adminCan" :base-path="basePath" />
-      </template>
     </PageHeader>
-
-    <div class="admin-content pa-4">
-      <router-view />
-    </div>
+    <CoreSurfaceTabBar
+      v-if="!currentBreadcrumb"
+      :tabs="allTabs"
+      :can="adminCan"
+      :base-path="basePath"
+    />
   </v-container>
+
+  <router-view />
 </template>
 <script>
 /**

--- a/src/modules/admin/views/admin.organizations.view.vue
+++ b/src/modules/admin/views/admin.organizations.view.vue
@@ -1,13 +1,19 @@
 <template>
-  <coreDataTableComponent :headers="orgHeaders" :items="organizations" :fetch-action="fetchOrganizations">
-    <template #orgName="{ item }">
-      <router-link
-        :to="'/admin/organizations/' + (item.id || item._id)"
-        class="text-capitalize text-primary text-decoration-none font-weight-medium"
-        >{{ item.name }}</router-link
-      >
-    </template>
-  </coreDataTableComponent>
+  <v-container fluid>
+    <v-row class="pa-2 mt-0">
+      <v-col cols="12">
+        <coreDataTableComponent :headers="orgHeaders" :items="organizations" :fetch-action="fetchOrganizations">
+          <template #orgName="{ item }">
+            <router-link
+              :to="'/admin/organizations/' + (item.id || item._id)"
+              class="text-capitalize text-primary text-decoration-none font-weight-medium"
+              >{{ item.name }}</router-link
+            >
+          </template>
+        </coreDataTableComponent>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 <script>
 /**

--- a/src/modules/admin/views/admin.readiness.view.vue
+++ b/src/modules/admin/views/admin.readiness.view.vue
@@ -1,29 +1,35 @@
 <template>
-  <v-card width="100%" color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded">
-    <v-progress-linear :active="readinessLoading" indeterminate color="primary"></v-progress-linear>
-    <v-table v-if="!readinessLoading && readiness.length">
-      <thead>
-        <tr>
-          <th class="text-left text-label-medium">Category</th>
-          <th class="text-left text-label-medium">Status</th>
-          <th class="text-left text-label-medium">Message</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="item in readiness" :key="item.category">
-          <td class="text-body-medium text-capitalize">{{ item.category }}</td>
-          <td>
-            <v-icon :icon="readinessIcon(item.status)" :color="readinessColor(item.status)" size="small" class="mr-2"></v-icon>
-            <v-chip :color="readinessColor(item.status)" size="small" variant="tonal">{{ item.status }}</v-chip>
-          </td>
-          <td class="text-body-medium">{{ item.message }}</td>
-        </tr>
-      </tbody>
-    </v-table>
-    <div v-if="!readinessLoading && !readiness.length" class="pa-4 text-medium-emphasis text-body-medium">
-      No readiness data available.
-    </div>
-  </v-card>
+  <v-container fluid>
+    <v-row class="pa-2 mt-0">
+      <v-col cols="12">
+        <v-card width="100%" color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded">
+          <v-progress-linear :active="readinessLoading" indeterminate color="primary"></v-progress-linear>
+          <v-table v-if="!readinessLoading && readiness.length">
+            <thead>
+              <tr>
+                <th class="text-left text-label-medium">Category</th>
+                <th class="text-left text-label-medium">Status</th>
+                <th class="text-left text-label-medium">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in readiness" :key="item.category">
+                <td class="text-body-medium text-capitalize">{{ item.category }}</td>
+                <td>
+                  <v-icon :icon="readinessIcon(item.status)" :color="readinessColor(item.status)" size="small" class="mr-2"></v-icon>
+                  <v-chip :color="readinessColor(item.status)" size="small" variant="tonal">{{ item.status }}</v-chip>
+                </td>
+                <td class="text-body-medium">{{ item.message }}</td>
+              </tr>
+            </tbody>
+          </v-table>
+          <div v-if="!readinessLoading && !readiness.length" class="pa-4 text-medium-emphasis text-body-medium">
+            No readiness data available.
+          </div>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 <script>
 /**

--- a/src/modules/admin/views/admin.user.view.vue
+++ b/src/modules/admin/views/admin.user.view.vue
@@ -1,18 +1,24 @@
 <template>
-  <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-6">
-    <div class="d-flex align-center justify-end mb-4">
-      <v-btn
-        v-if="id"
-        color="error"
-        variant="tonal"
-        :class="config.vuetify.theme.rounded"
-        class="text-none text-body-medium"
-        @click="removeConfirm = true"
-      >
-        <v-icon icon="fa-solid fa-trash" size="small" class="mr-2"></v-icon>Delete
-      </v-btn>
-    </div>
-    <accountUserProfileComponent :user="user" @save="update" @avatar-uploaded="onAvatarUploaded" />
+  <v-container fluid>
+    <v-row class="pa-2 mt-0">
+      <v-col cols="12">
+        <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-6">
+          <div class="d-flex align-center justify-end mb-4">
+            <v-btn
+              v-if="id"
+              color="error"
+              variant="tonal"
+              :class="config.vuetify.theme.rounded"
+              class="text-none text-body-medium"
+              @click="removeConfirm = true"
+            >
+              <v-icon icon="fa-solid fa-trash" size="small" class="mr-2"></v-icon>Delete
+            </v-btn>
+          </div>
+          <accountUserProfileComponent :user="user" @save="update" @avatar-uploaded="onAvatarUploaded" />
+        </v-card>
+      </v-col>
+    </v-row>
     <coreConfirmDialog
       v-model="removeConfirm"
       title="Delete this user?"
@@ -22,7 +28,7 @@
       :loading="removing"
       @confirm="remove"
     />
-  </v-card>
+  </v-container>
 </template>
 
 <script>

--- a/src/modules/admin/views/admin.users.view.vue
+++ b/src/modules/admin/views/admin.users.view.vue
@@ -1,55 +1,60 @@
 <template>
-  <coreDataTableComponent :headers="userHeaders" :items="users" :fetch-action="fetchUsers">
-      <template #name="{ item }"
-        ><router-link
-          :to="'/admin/users/' + (item.id || item._id)"
-          class="text-capitalize text-primary text-decoration-none font-weight-medium"
-          >{{ item.firstName }} {{ item.lastName }}</router-link
-        ></template
-      >
-      <template #organizations="{ item }"
-        ><template v-for="m in item.memberships || []" :key="m._id || m.id"
-          ><v-chip
-            size="small"
-            :variant="isUserActiveOrg(item, m) ? 'flat' : 'tonal'"
-            :color="orgColor(m.organizationId)"
-            class="mr-1 text-capitalize"
-            :class="membershipOrgId(m) ? 'cursor-pointer' : ''"
-            @click="navigateToMembershipOrg(m)"
-            >{{ (m.organizationId && m.organizationId.name) || '—' }} ({{ m.role || '—' }})</v-chip
-          ></template
-        ><span v-if="!item.memberships || !item.memberships.length" class="text-medium-emphasis">—</span></template
-      >
-      <template #roles="{ item }"
-        ><v-chip
-          v-for="(role, index) in item.roles || []"
-          :key="index"
-          size="small"
-          variant="tonal"
-          :color="roleColor(role)"
-          class="mr-1 text-capitalize"
-          >{{ role }}</v-chip
-        ><span v-if="!item.roles || !item.roles.length" class="text-medium-emphasis">—</span></template
-      >
-      <template #actions="{ item }"
-        ><v-menu location="bottom end"
-          ><template #activator="{ props }"
-            ><v-btn v-bind="props" icon variant="text" size="small" class="mr-1"
-              ><v-icon icon="fa-solid fa-user-pen" size="small"></v-icon></v-btn></template
-          ><v-list density="compact" min-width="160" :class="config.vuetify.theme.rounded"
-            ><v-list-subheader class="text-label-small">APP ROLES</v-list-subheader
-            ><v-list-item
-              v-for="role in config.whitelists.users.roles"
-              :key="role"
-              :active="(item.roles || []).includes(role)"
-              @click="toggleUserRole(item, role)"
-              ><v-list-item-title class="text-body-medium text-capitalize">{{ role }}</v-list-item-title></v-list-item
-            ></v-list
-          ></v-menu
-        ><v-btn icon variant="text" size="small" color="error" @click="openDeleteDialog(item)"
-          ><v-icon icon="fa-solid fa-trash" size="small"></v-icon></v-btn
-      ></template>
-    </coreDataTableComponent>
+  <v-container fluid>
+    <v-row class="pa-2 mt-0">
+      <v-col cols="12">
+        <coreDataTableComponent :headers="userHeaders" :items="users" :fetch-action="fetchUsers">
+          <template #name="{ item }"
+            ><router-link
+              :to="'/admin/users/' + (item.id || item._id)"
+              class="text-capitalize text-primary text-decoration-none font-weight-medium"
+              >{{ item.firstName }} {{ item.lastName }}</router-link
+            ></template
+          >
+          <template #organizations="{ item }"
+            ><template v-for="m in item.memberships || []" :key="m._id || m.id"
+              ><v-chip
+                size="small"
+                :variant="isUserActiveOrg(item, m) ? 'flat' : 'tonal'"
+                :color="orgColor(m.organizationId)"
+                class="mr-1 text-capitalize"
+                :class="membershipOrgId(m) ? 'cursor-pointer' : ''"
+                @click="navigateToMembershipOrg(m)"
+                >{{ (m.organizationId && m.organizationId.name) || '—' }} ({{ m.role || '—' }})</v-chip
+              ></template
+            ><span v-if="!item.memberships || !item.memberships.length" class="text-medium-emphasis">—</span></template
+          >
+          <template #roles="{ item }"
+            ><v-chip
+              v-for="(role, index) in item.roles || []"
+              :key="index"
+              size="small"
+              variant="tonal"
+              :color="roleColor(role)"
+              class="mr-1 text-capitalize"
+              >{{ role }}</v-chip
+            ><span v-if="!item.roles || !item.roles.length" class="text-medium-emphasis">—</span></template
+          >
+          <template #actions="{ item }"
+            ><v-menu location="bottom end"
+              ><template #activator="{ props }"
+                ><v-btn v-bind="props" icon variant="text" size="small" class="mr-1"
+                  ><v-icon icon="fa-solid fa-user-pen" size="small"></v-icon></v-btn></template
+              ><v-list density="compact" min-width="160" :class="config.vuetify.theme.rounded"
+                ><v-list-subheader class="text-label-small">APP ROLES</v-list-subheader
+                ><v-list-item
+                  v-for="role in config.whitelists.users.roles"
+                  :key="role"
+                  :active="(item.roles || []).includes(role)"
+                  @click="toggleUserRole(item, role)"
+                  ><v-list-item-title class="text-body-medium text-capitalize">{{ role }}</v-list-item-title></v-list-item
+                ></v-list
+              ></v-menu
+            ><v-btn icon variant="text" size="small" color="error" @click="openDeleteDialog(item)"
+              ><v-icon icon="fa-solid fa-trash" size="small"></v-icon></v-btn
+          ></template>
+        </coreDataTableComponent>
+      </v-col>
+    </v-row>
     <coreConfirmDialog
       v-model="deleteDialog.show"
       title="Delete this user?"
@@ -58,6 +63,7 @@
       confirm-color="error"
       @confirm="confirmDeleteUser"
     />
+  </v-container>
 </template>
 <script>
 /**

--- a/src/modules/users/tests/user.organizations.view.unit.tests.js
+++ b/src/modules/users/tests/user.organizations.view.unit.tests.js
@@ -22,6 +22,9 @@ const sharedStubs = {
   orgAvatarComponent: { template: '<div />' },
   coreConfirmDialog: { template: '<div data-test="core-confirm-dialog" />', name: 'CoreConfirmDialog' },
   'v-container': { template: '<div><slot /></div>' },
+  'v-row': { template: '<div><slot /></div>' },
+  'v-col': { template: '<div><slot /></div>' },
+  'v-card': { template: '<div><slot /></div>' },
   'v-list': { template: '<div><slot /></div>' },
   'v-list-item': { template: '<div><slot /></div>' },
   'v-list-item-title': { template: '<div><slot /></div>' },
@@ -124,6 +127,17 @@ describe('user.organizations.view', () => {
 
     expect(store.leaveOrganization).toHaveBeenCalledWith(orgId);
     expect(routerPush).toHaveBeenCalledWith('/organization-required');
+  });
+});
+
+describe('user.organizations.view — template chrome', () => {
+  it('wraps content in <v-row class="pa-2 mt-0"> + <v-col cols="12"> + <v-card color="surface">', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const sfc = readFileSync(resolve(here, '../views/user.organizations.view.vue'), 'utf8');
+    const tmpl = sfc.split('<script>')[0];
+    expect(tmpl).toMatch(/<v-row[^>]*class="[^"]*pa-2\s+mt-0/);
+    expect(tmpl).toMatch(/<v-col\s+cols="12"/);
+    expect(tmpl).toMatch(/<v-card[^>]*color="surface"/);
   });
 });
 

--- a/src/modules/users/tests/user.profile.view.unit.tests.js
+++ b/src/modules/users/tests/user.profile.view.unit.tests.js
@@ -30,6 +30,8 @@ const sharedStubs = {
   userProfileComponent: { template: '<div data-test="user-profile-component" />', name: 'UserProfileComponent' },
   coreConfirmDialog: { template: '<div data-test="core-confirm-dialog" />', name: 'CoreConfirmDialog' },
   'v-container': { template: '<div><slot /></div>' },
+  'v-row': { template: '<div><slot /></div>' },
+  'v-col': { template: '<div><slot /></div>' },
   'v-card': { template: '<div><slot /></div>' },
   'v-card-title': { template: '<div><slot /></div>' },
   'v-card-text': { template: '<div><slot /></div>' },
@@ -121,6 +123,17 @@ describe('user.profile.view', () => {
     await wrapper.vm.deleteAccount();
 
     expect(wrapper.vm.confirmDeleteAccount).toBe(false);
+  });
+});
+
+describe('user.profile.view — template chrome', () => {
+  it('wraps content in <v-row class="pa-2 mt-0"> + <v-col cols="12"> + <v-card color="surface">', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const sfc = readFileSync(resolve(here, '../views/user.profile.view.vue'), 'utf8');
+    const tmpl = sfc.split('<script>')[0];
+    expect(tmpl).toMatch(/<v-row[^>]*class="[^"]*pa-2\s+mt-0/);
+    expect(tmpl).toMatch(/<v-col\s+cols="12"/);
+    expect(tmpl).toMatch(/<v-card[^>]*color="surface"/);
   });
 });
 

--- a/src/modules/users/views/user.organizations.view.vue
+++ b/src/modules/users/views/user.organizations.view.vue
@@ -1,57 +1,63 @@
 <template>
   <v-container fluid>
-    <v-list v-if="organizations && organizations.length" lines="two" class="pa-0 bg-transparent">
-      <template v-for="(org, i) in organizations" :key="org.id || org._id">
-        <v-list-item
-          :to="org.role === 'owner' || org.role === 'admin' ? `/users/organizations/${org.id || org._id}/general` : undefined"
-          :class="config.vuetify.theme.rounded"
-          class="pa-4"
-        >
-          <template #prepend>
-            <orgAvatarComponent :org="org" :size="40" class="mr-4" />
-          </template>
-          <v-list-item-title class="text-body-large font-weight-medium">{{ org.name }}</v-list-item-title>
-          <v-list-item-subtitle v-if="org.description" class="text-body-small">{{ org.description }}</v-list-item-subtitle>
-          <template #append>
-            <div class="d-flex align-center ga-2">
-              <v-chip v-if="org.role" size="small" :color="roleColor(org.role)" variant="tonal" class="text-capitalize">{{ org.role }}</v-chip>
-              <v-chip v-if="isActiveOrg(org)" size="small" color="success" variant="flat">Active</v-chip>
-              <v-btn
-                v-if="org.role !== 'owner'"
-                color="error"
-                variant="text"
-                size="small"
-                class="text-none"
-                @click.stop.prevent="confirmLeave(org)"
-              >Leave</v-btn>
-              <v-icon
-                v-if="org.role === 'owner' || org.role === 'admin'"
-                icon="fa-solid fa-chevron-right"
-                size="small"
-                color="medium-emphasis"
-              ></v-icon>
-            </div>
-          </template>
-        </v-list-item>
-        <v-divider v-if="i < organizations.length - 1"></v-divider>
-      </template>
-    </v-list>
-    <v-btn
-      color="primary"
-      variant="tonal"
-      :class="config.vuetify.theme.rounded"
-      class="text-none text-body-medium mt-4"
-      to="/users/organizations/create"
-      block
-      data-test="users-orgs-new"
-    >
-      <v-icon icon="fa-solid fa-plus" size="small" class="mr-2"></v-icon>
-      New Organization
-    </v-btn>
-    <div v-if="!organizations || !organizations.length" class="text-center text-medium-emphasis pa-8">
-      <v-icon icon="fa-solid fa-building" size="x-large" class="mb-4 text-medium-emphasis"></v-icon>
-      <p class="text-body-medium">No organizations yet.</p>
-    </div>
+    <v-row class="pa-2 mt-0">
+      <v-col cols="12">
+        <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-4">
+          <v-list v-if="organizations && organizations.length" lines="two" class="pa-0 bg-transparent">
+            <template v-for="(org, i) in organizations" :key="org.id || org._id">
+              <v-list-item
+                :to="org.role === 'owner' || org.role === 'admin' ? `/users/organizations/${org.id || org._id}/general` : undefined"
+                :class="config.vuetify.theme.rounded"
+                class="pa-4"
+              >
+                <template #prepend>
+                  <orgAvatarComponent :org="org" :size="40" class="mr-4" />
+                </template>
+                <v-list-item-title class="text-body-large font-weight-medium">{{ org.name }}</v-list-item-title>
+                <v-list-item-subtitle v-if="org.description" class="text-body-small">{{ org.description }}</v-list-item-subtitle>
+                <template #append>
+                  <div class="d-flex align-center ga-2">
+                    <v-chip v-if="org.role" size="small" :color="roleColor(org.role)" variant="tonal" class="text-capitalize">{{ org.role }}</v-chip>
+                    <v-chip v-if="isActiveOrg(org)" size="small" color="success" variant="flat">Active</v-chip>
+                    <v-btn
+                      v-if="org.role !== 'owner'"
+                      color="error"
+                      variant="text"
+                      size="small"
+                      class="text-none"
+                      @click.stop.prevent="confirmLeave(org)"
+                    >Leave</v-btn>
+                    <v-icon
+                      v-if="org.role === 'owner' || org.role === 'admin'"
+                      icon="fa-solid fa-chevron-right"
+                      size="small"
+                      color="medium-emphasis"
+                    ></v-icon>
+                  </div>
+                </template>
+              </v-list-item>
+              <v-divider v-if="i < organizations.length - 1"></v-divider>
+            </template>
+          </v-list>
+          <v-btn
+            color="primary"
+            variant="tonal"
+            :class="config.vuetify.theme.rounded"
+            class="text-none text-body-medium mt-4"
+            to="/users/organizations/create"
+            block
+            data-test="users-orgs-new"
+          >
+            <v-icon icon="fa-solid fa-plus" size="small" class="mr-2"></v-icon>
+            New Organization
+          </v-btn>
+          <div v-if="!organizations || !organizations.length" class="text-center text-medium-emphasis pa-8">
+            <v-icon icon="fa-solid fa-building" size="x-large" class="mb-4 text-medium-emphasis"></v-icon>
+            <p class="text-body-medium">No organizations yet.</p>
+          </div>
+        </v-card>
+      </v-col>
+    </v-row>
 
     <coreConfirmDialog
       v-model="leaveDialog"

--- a/src/modules/users/views/user.profile.view.vue
+++ b/src/modules/users/views/user.profile.view.vue
@@ -1,20 +1,38 @@
 <template>
   <v-container fluid>
-    <userProfileComponent
-      :user="user"
-      :organizations="organizations"
-      @save="updateProfile"
-      @avatar-uploaded="onAvatarUploaded"
-    />
+    <v-row class="pa-2 mt-0">
+      <v-col cols="12">
+        <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-6">
+          <userProfileComponent
+            :user="user"
+            :organizations="organizations"
+            @save="updateProfile"
+            @avatar-uploaded="onAvatarUploaded"
+          />
+        </v-card>
 
-    <!-- Danger zone -->
-    <v-card variant="outlined" color="error" class="mt-6">
-      <v-card-title class="text-title-medium font-weight-medium">Delete Account</v-card-title>
-      <v-card-text class="text-body-small text-medium-emphasis">Permanently delete your account, data, and organization ownership. This cannot be undone.</v-card-text>
-      <v-card-actions>
-        <v-btn color="error" variant="flat" :class="config.vuetify.theme.rounded" class="text-none text-body-medium" @click="confirmDeleteAccount = true">Delete Account</v-btn>
-      </v-card-actions>
-    </v-card>
+        <!-- Danger zone -->
+        <v-card variant="outlined" color="error" class="mt-4 pa-6" :class="config.vuetify.theme.rounded">
+          <div class="d-flex align-center flex-wrap ga-4">
+            <div class="flex-grow-1">
+              <h3 class="text-title-medium font-weight-medium mb-1">Delete Account</h3>
+              <p class="text-body-small text-medium-emphasis mb-0">
+                Permanently delete your account, data, and organization ownership. This cannot be undone.
+              </p>
+            </div>
+            <v-btn
+              color="error"
+              variant="tonal"
+              :class="config.vuetify.theme.rounded"
+              class="text-none text-body-medium"
+              @click="confirmDeleteAccount = true"
+            >
+              Delete Account
+            </v-btn>
+          </div>
+        </v-card>
+      </v-col>
+    </v-row>
 
     <coreConfirmDialog
       v-model="confirmDeleteAccount"


### PR DESCRIPTION
## Summary

Fixes three regressions reported by the user after #4187 (homogenization) shipped to production:

1. `/users/profile` + `/users/organizations` had **transparent content** with no surface card, tabs flush against the sidenav (no gutter).
2. `/admin/users` lost the **"Admin" section title with icon** above the tabs.
3. **Spacing inconsistency** between tabs ↔ content ↔ sidenav vs. the reference `/developers` + `/tasks`.

Plus a documentation gap raised at the same time:

4. `MIGRATIONS.md` needed to explain the new chrome convention to downstream projects (admin extras + tabs-under-title modules).

## Root cause

#4187 misread `corePageHeader`'s `#tabs` slot — that slot is **mutually exclusive** with the icon+title row, so putting `CoreSurfaceTabBar` inside it hid the section title. The established pattern (used by `user.view.vue` since #4185 and `organization.detail.component.vue` since #4184) is **PageHeader and CoreSurfaceTabBar as siblings** inside `<v-container fluid>`, with `<router-view />` outside the container. The upstream PR #4185 also moved chrome from the monolithic `user.view.vue` to the layout, but the routed children (`user.profile.view`, `user.organizations.view`) never got their `<v-card color="surface">` wrap back — leaving transparent panes.

## The fix

**`admin.layout.vue`** (commit `8dc68af3`)
- Drop `<template v-if="!currentBreadcrumb" #tabs>` slot wrapping. PageHeader + CoreSurfaceTabBar are siblings.
- Drop `<div class="admin-content pa-4">` wrapper.
- Move `<router-view />` outside `<v-container fluid>` — children own their gutter.
- `icon="fa-solid fa-user-tie"` is unconditional (shows in both list + breadcrumb mode).

**5 admin sub-views** (commits `37bb4bc5`, `dad8bd3d`, `703c9637`, `7cb8f6e0`, `9efc4239`)
- Re-add `<v-container fluid>` + `<v-row class="pa-2 mt-0">` + `<v-col cols="12">` chrome.
- `coreDataTableComponent` consumers (users, organizations) skip the wrap-card — data table already provides a surface.
- `v-card`-based views (readiness, activity, user form) keep their card INSIDE the `<v-col>`.

**2 account child views** (commits `7591fb2b`, `1efec145`)
- Wrap content in `<v-row class="pa-2 mt-0">` + `<v-col cols="12">` + `<v-card color="surface">` inside `<v-container fluid>`.
- `user.profile.view`: danger zone restructured to flex row (heading + description + button inline) for visual coherence. All 3 info pieces preserved.

**MIGRATIONS.md** (commit `469994d6`)
- New top section "Account / Organization / Admin chrome convergence (2026-05-21)" documents the 4 conventions (layout shape, breadcrumb mode, child wrap, downstream opt-in for tabs-under-title modules with a concrete `/developers` before/after example).

## Tests

All 8 affected unit-test files updated in lockstep:
- 5 admin sub-view tests had their `not.toMatch(/<v-container/)` source-grep assertion REVERSED to `toMatch(/<v-container fluid/)` + require v-row pa-2 mt-0 + v-col cols=12.
- 2 account-view tests added the same source-grep assertion + `<v-card color="surface">` check.
- admin.layout test: 6 new tests asserting sibling pattern (NOT inside `#tabs` slot), router-view outside container, title="Admin" / "" by breadcrumb mode, icon stays both modes.

- **Devkit Vue full suite:** 119 test files / 1910 tests green.
- **Coverage:** 98.98% / 94.11% / 98.95% / 99.59% — exact match with #4187 baseline (no logic paths changed, only templates).
- **Audit:** 0 vulnerabilities. No new deps.

## Visual smoke (Chrome DevTools MCP)

GREEN — all 3 user-reported surfaces visually confirmed clean:
- `/admin/users` — icon + "Admin" title + tab bar; data table on `bg-surface` with matching gutter.
- `/users/profile` — Account chrome + profile form on `bg-surface` (rgb(255,255,255) confirmed via DOM), danger zone below.
- `/users/organizations` — Account chrome + org list on `bg-surface`, gutter matches `/tasks` reference.

## Downstream propagation

After merge, propagate to all Vue downstream projects via `/update-project`. Order: `pierreb_vue`, `comes_vue`, `trawl_vue`, `montaine_vue`, `ism_vue`. Per `feedback_shim_defer_downstream` — on-demand. The trawl_vue propagation will be triggered first (user-priority) since the user reported the issue on `trawl.me`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added migration guidance for unified page layout conventions across admin and user interfaces.

* **Refactor**
  * Restructured page layouts for consistent spacing and visual hierarchy across admin views (activity, organizations, readiness, user management) and user profile pages.
  * Standardized content wrapping and container structure throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->