### PR TITLE
test(billing): decouple subscriptions component test from tenant plan IDs

### DIFF
--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -25,6 +25,15 @@ vi.mock('../../auth/stores/auth.store', () => ({
   useAuthStore: () => authState,
 }));
 
+// ─── Decouple from tenant-specific plan IDs ──────────────────────────────────
+
+vi.mock('../lib/billing.resolveStaticContent.js', () => ({
+  resolveStaticContent: () => ({
+    plans: [{ id: 'p1' }, { id: 'p2' }, { id: 'p3' }],
+    packs: [],
+  }),
+}));
+
 // ─── Imports (after mocks) ───────────────────────────────────────────────────
 
 import { useBillingStore } from '../stores/billing.store';
@@ -386,7 +395,7 @@ describe('BillingSubscriptionsComponent — status and paid plan CTAs', () => {
   });
 
   it('labels the paid plan upgrade CTA as Change Plan when a higher plan exists', async () => {
-    store.subscription = { status: 'active', plan: 'starter', currentPeriodEnd: new Date().toISOString() };
+    store.subscription = { status: 'active', plan: 'p2', currentPeriodEnd: new Date().toISOString() };
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
     await flushPromises();
     expect(wrapper.text()).toContain('Change Plan');


### PR DESCRIPTION
## Summary

Closes #4189

- Add `vi.mock('../lib/billing.resolveStaticContent.js', ...)` returning generic plan IDs (`p1`, `p2`, `p3`) to decouple the subscriptions component test from tenant-specific plan IDs (e.g. `starter`)
- Update one test fixture to use the generic `p2` plan instead of the hardcoded `starter` plan ID

## Why

The billing subscriptions component test was relying on tenant-specific plan IDs that live in resolved static content. When the plan IDs change (e.g. new pricing tiers, GTM plan rename), tests break for non-structural reasons. This mock makes the test fixture-agnostic and aligned with the billing module's own test isolation pattern.

## Test plan

- [x] All 82/82 billing component tests pass locally (`npm run test:unit`)
- [x] No coverage thresholds changed
- [x] No production code touched — test file only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for subscription functionality by updating test fixtures to ensure consistent behavior across different scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->