### PR TITLE
fix(core): pin CorePageHeader to content size in flex-column contexts

### DIFF
--- a/src/modules/core/components/core.pageHeader.component.vue
+++ b/src/modules/core/components/core.pageHeader.component.vue
@@ -85,6 +85,10 @@ export default {
  * a 56px rhythm for title↔breadcrumb route transitions use CorePageHeaderTabs,
  * which enforces the height externally.
  */
+.core-page-header {
+  flex: 0 0 auto; /* never grow on the main axis of a flex-column parent — v-row inherits flex: 1 1 auto from Vuetify */
+}
+
 .core-page-header__content {
   flex: 1 1 0;
   min-width: 0;


### PR DESCRIPTION
## Summary

- `CorePageHeader` renders a Vuetify `<v-row>` which inherits `flex: 1 1 auto` from Vuetify internals
- When placed inside a `flex-direction: column` shell, the header could expand to fill all available vertical space before sibling content renders
- Adds `flex: 0 0 auto` on `.core-page-header` (the root element) to clamp it to content size; no-op in normal block flow

## Test plan

- [x] `npm run lint` — zero ESLint errors
- [x] `npm run test:unit` — all 16 `core.pageHeader.component` tests pass (CSS value assertions not possible with `css: false` in vitest; class presence already asserted)
- [ ] Visual smoke: wrap `CorePageHeader` in a `flex-direction:column` container — header stays at ~40px content height, never balloons to fill spare space

## Notes

- No unit test added for the CSS value itself — `vitest.config.js` sets `css: false` (happy-dom), making computed style assertions meaningless. This is documented in the plan.
- After merge: propagate via `/update-stack` to downstream Vue projects. The local guard in `trawl_vue#934` (`.scrap-request-shell > :deep(.core-page-header) { flex: 0 0 auto; }`) becomes redundant and can be dropped.

Closes #4202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved page header layout to prevent unwanted expansion in flex containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->