### PR TITLE
fix(tasks): propagate store errors so views gate navigation on success

### DIFF
--- a/src/modules/tasks/stores/tasks.store.js
+++ b/src/modules/tasks/stores/tasks.store.js
@@ -13,6 +13,12 @@ import model from '../../../lib/middlewares/model';
 const whitelists = ['title', 'description'];
 
 /**
+ * @desc Build the base API URL from config.
+ * @returns {string} Base API URL
+ */
+const apiBase = () => `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
+
+/**
  * Store definition.
  */
 export const useTasksStore = defineStore('tasks', {
@@ -25,61 +31,67 @@ export const useTasksStore = defineStore('tasks', {
   }),
 
   actions: {
+    /**
+     * @desc Fetch all tasks.
+     * @returns {Promise<Array>} Resolved list of tasks
+     */
     async getTasks() {
-      const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
-
-      try {
-        const res = await axios.get(`${api}/${config.api.endPoints.tasks}/`);
-        this.tasks = res.data.data;
-      } catch (err) {
-        console.error(err);
-      }
+      const api = apiBase();
+      const res = await axios.get(`${api}/${config.api.endPoints.tasks}/`);
+      this.tasks = res.data.data;
+      return this.tasks;
     },
 
+    /**
+     * @desc Fetch a single task by ID.
+     * @param {Object} params - Request params
+     * @param {string} params.id - Task ID
+     * @returns {Promise<Object>} Resolved task object
+     */
     async getTask(params) {
-      const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
-
-      try {
-        const res = await axios.get(`${api}/${config.api.endPoints.tasks}/${params.id}`);
-        this.task = res.data.data;
-      } catch (err) {
-        console.error(err);
-      }
+      const api = apiBase();
+      const res = await axios.get(`${api}/${config.api.endPoints.tasks}/${params.id}`);
+      this.task = res.data.data;
+      return this.task;
     },
 
+    /**
+     * @desc Create a new task.
+     * @param {Object} params - Task data
+     * @returns {Promise<Object>} Resolved created task
+     */
     async createTask(params) {
-      const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
-
-      try {
-        const obj = model.clean(params, whitelists);
-        const res = await axios.post(`${api}/${config.api.endPoints.tasks}/`, obj);
-        this.task = res.data.data;
-      } catch (err) {
-        console.error(err);
-      }
+      const api = apiBase();
+      const obj = model.clean(params, whitelists);
+      const res = await axios.post(`${api}/${config.api.endPoints.tasks}/`, obj);
+      this.task = res.data.data;
+      return this.task;
     },
 
+    /**
+     * @desc Update an existing task.
+     * @param {Object} params - Request params
+     * @param {string} params.id - Task ID
+     * @returns {Promise<Object>} Resolved updated task
+     */
     async updateTask(params) {
-      const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
-
-      try {
-        const obj = model.clean(this.task, whitelists);
-        const res = await axios.put(`${api}/${config.api.endPoints.tasks}/${params.id}`, obj);
-        assign(this.task, res.data.data);
-      } catch (err) {
-        console.error(err);
-      }
+      const api = apiBase();
+      const obj = model.clean(this.task, whitelists);
+      const res = await axios.put(`${api}/${config.api.endPoints.tasks}/${params.id}`, obj);
+      assign(this.task, res.data.data);
+      return this.task;
     },
 
+    /**
+     * @desc Delete a task by ID.
+     * @param {Object} params - Request params
+     * @param {string} params.id - Task ID
+     * @returns {Promise<void>}
+     */
     async deleteTask(params) {
-      const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
-
-      try {
-        await axios.delete(`${api}/${config.api.endPoints.tasks}/${params.id}`);
-        this.resetTask();
-      } catch (err) {
-        console.error(err);
-      }
+      const api = apiBase();
+      await axios.delete(`${api}/${config.api.endPoints.tasks}/${params.id}`);
+      this.resetTask();
     },
 
     resetTask() {

--- a/src/modules/tasks/tests/task.view.unit.tests.js
+++ b/src/modules/tasks/tests/task.view.unit.tests.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+
+/**
+ * Hoisted mocks — must be defined before any imports that transitively use them.
+ */
+const createTaskMock = vi.hoisted(() => vi.fn());
+const updateTaskMock = vi.hoisted(() => vi.fn());
+const deleteTaskMock = vi.hoisted(() => vi.fn());
+const getTaskMock = vi.hoisted(() => vi.fn());
+const resetTaskMock = vi.hoisted(() => vi.fn());
+
+const mockTask = vi.hoisted(() => ({
+  title: 'My Task',
+  description: 'My Description',
+  id: null,
+}));
+
+vi.mock('../stores/tasks.store', () => ({
+  useTasksStore: () => ({
+    get task() {
+      return mockTask;
+    },
+    createTask: createTaskMock,
+    updateTask: updateTaskMock,
+    deleteTask: deleteTaskMock,
+    getTask: getTaskMock,
+    resetTask: resetTaskMock,
+  }),
+}));
+
+vi.mock('../../../lib/services/config', () => ({
+  default: {
+    api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api', endPoints: { tasks: 'tasks' } },
+    vuetify: { theme: { flat: true, rounded: 'rounded-lg', maxWidth: '1200px', snackbar: { status: false } } },
+  },
+}));
+
+vi.mock('../../core/components/core.pageHeader.component.vue', () => ({
+  default: { template: '<div><slot name="actions" /></div>' },
+}));
+
+vi.mock('../components/task.component.vue', () => ({
+  default: { template: '<div />' },
+}));
+
+import TaskView from '../views/task.view.vue';
+
+const mockPush = vi.fn();
+
+/**
+ * Mount the task view with optional route params.
+ * @param {Object} [options]
+ * @param {string|null} [options.id=null] - Route param id
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mockConfig = {
+  api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api', endPoints: { tasks: 'tasks' } },
+  sign: { route: '/tasks', in: true, up: true },
+  vuetify: { theme: { flat: true, maxWidth: '1200px', rounded: 'rounded-lg', snackbar: { status: false } } },
+};
+
+const mountView = ({ id = null } = {}) =>
+  mount(TaskView, {
+    global: {
+      plugins: [createVuetify(), createPinia()],
+      mocks: {
+        config: mockConfig,
+        $route: { params: { id } },
+        $router: { push: mockPush },
+      },
+      stubs: { RouterLink: true },
+    },
+  });
+
+describe('task.view — create()', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    mockTask.id = null;
+    mockTask.title = 'My Task';
+    mockTask.description = 'My Description';
+  });
+
+  it('navigates to /tasks after a successful create', async () => {
+    createTaskMock.mockResolvedValueOnce({ id: 'new-id', title: 'My Task', description: 'My Description' });
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.vm.create();
+
+    expect(createTaskMock).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/tasks');
+    expect(wrapper.vm.save).toBe(false);
+  });
+
+  it('does NOT navigate when createTask rejects', async () => {
+    createTaskMock.mockRejectedValueOnce(new Error('Server error'));
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.vm.create();
+
+    expect(createTaskMock).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('does NOT clear save flag when createTask rejects', async () => {
+    createTaskMock.mockRejectedValueOnce(new Error('Server error'));
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    wrapper.vm.save = true;
+    await wrapper.vm.create();
+
+    // save should remain true (not cleared to false) on failure
+    expect(wrapper.vm.save).toBe(true);
+  });
+});
+
+describe('task.view — update()', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    mockTask.id = 'task-123';
+    mockTask.title = 'My Task';
+    mockTask.description = 'My Description';
+    getTaskMock.mockResolvedValue({ id: 'task-123', title: 'My Task', description: 'My Description' });
+  });
+
+  it('navigates to /tasks after a successful update', async () => {
+    updateTaskMock.mockResolvedValueOnce({ id: 'task-123', title: 'My Task', description: 'My Description' });
+
+    const wrapper = mountView({ id: 'task-123' });
+    await flushPromises();
+
+    await wrapper.vm.update();
+
+    expect(updateTaskMock).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/tasks');
+    expect(wrapper.vm.save).toBe(false);
+  });
+
+  it('does NOT navigate when updateTask rejects', async () => {
+    updateTaskMock.mockRejectedValueOnce(new Error('Update failed'));
+
+    const wrapper = mountView({ id: 'task-123' });
+    await flushPromises();
+
+    await wrapper.vm.update();
+
+    expect(updateTaskMock).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('does NOT clear save flag when updateTask rejects', async () => {
+    updateTaskMock.mockRejectedValueOnce(new Error('Update failed'));
+
+    const wrapper = mountView({ id: 'task-123' });
+    await flushPromises();
+
+    wrapper.vm.save = true;
+    await wrapper.vm.update();
+
+    expect(wrapper.vm.save).toBe(true);
+  });
+});
+
+describe('task.view — remove()', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    mockTask.id = 'task-123';
+    mockTask.title = 'My Task';
+    mockTask.description = 'My Description';
+    getTaskMock.mockResolvedValue({ id: 'task-123', title: 'My Task', description: 'My Description' });
+  });
+
+  it('navigates to /tasks after a successful delete', async () => {
+    deleteTaskMock.mockResolvedValueOnce(undefined);
+
+    const wrapper = mountView({ id: 'task-123' });
+    await flushPromises();
+
+    await wrapper.vm.remove();
+
+    expect(deleteTaskMock).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/tasks');
+  });
+
+  it('does NOT navigate when deleteTask rejects', async () => {
+    deleteTaskMock.mockRejectedValueOnce(new Error('Delete failed'));
+
+    const wrapper = mountView({ id: 'task-123' });
+    await flushPromises();
+
+    await wrapper.vm.remove();
+
+    expect(deleteTaskMock).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/tasks/tests/task.view.unit.tests.js
+++ b/src/modules/tasks/tests/task.view.unit.tests.js
@@ -10,7 +10,6 @@ const createTaskMock = vi.hoisted(() => vi.fn());
 const updateTaskMock = vi.hoisted(() => vi.fn());
 const deleteTaskMock = vi.hoisted(() => vi.fn());
 const getTaskMock = vi.hoisted(() => vi.fn());
-const resetTaskMock = vi.hoisted(() => vi.fn());
 
 const mockTask = vi.hoisted(() => ({
   title: 'My Task',
@@ -27,15 +26,8 @@ vi.mock('../stores/tasks.store', () => ({
     updateTask: updateTaskMock,
     deleteTask: deleteTaskMock,
     getTask: getTaskMock,
-    resetTask: resetTaskMock,
+    resetTask: vi.fn(),
   }),
-}));
-
-vi.mock('../../../lib/services/config', () => ({
-  default: {
-    api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api', endPoints: { tasks: 'tasks' } },
-    vuetify: { theme: { flat: true, rounded: 'rounded-lg', maxWidth: '1200px', snackbar: { status: false } } },
-  },
 }));
 
 vi.mock('../../core/components/core.pageHeader.component.vue', () => ({
@@ -58,7 +50,6 @@ const mockPush = vi.fn();
  */
 const mockConfig = {
   api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api', endPoints: { tasks: 'tasks' } },
-  sign: { route: '/tasks', in: true, up: true },
   vuetify: { theme: { flat: true, maxWidth: '1200px', rounded: 'rounded-lg', snackbar: { status: false } } },
 };
 

--- a/src/modules/tasks/tests/task.view.unit.tests.js
+++ b/src/modules/tasks/tests/task.view.unit.tests.js
@@ -49,8 +49,7 @@ const mockPush = vi.fn();
  * @returns {import('@vue/test-utils').VueWrapper}
  */
 const mockConfig = {
-  api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api', endPoints: { tasks: 'tasks' } },
-  vuetify: { theme: { flat: true, maxWidth: '1200px', rounded: 'rounded-lg', snackbar: { status: false } } },
+  vuetify: { theme: { flat: true, rounded: 'rounded-lg' } },
 };
 
 const mountView = ({ id = null } = {}) =>

--- a/src/modules/tasks/tests/tasks.store.unit.tests.js
+++ b/src/modules/tasks/tests/tasks.store.unit.tests.js
@@ -13,10 +13,24 @@ vi.mock('../../../lib/services/axios', () => ({
   },
 }));
 
+// Mock config
+vi.mock('../../../lib/services/config', () => ({
+  default: {
+    api: {
+      protocol: 'http',
+      host: 'localhost',
+      port: '3000',
+      base: 'api',
+      endPoints: { tasks: 'tasks' },
+    },
+  },
+}));
+
 describe('Tasks Store', () => {
   beforeEach(() => {
     // Create a new pinia instance for each test
     setActivePinia(createPinia());
+    vi.clearAllMocks();
   });
 
   it('should initialize with default state', () => {
@@ -85,16 +99,13 @@ describe('Tasks Store', () => {
       expect(tasksStore.tasks).toEqual(mockTasks);
     });
 
-    it('should handle getTasks error', async () => {
+    it('should propagate getTasks error to caller', async () => {
       const tasksStore = useTasksStore();
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const error = new Error('Network error');
 
-      axios.get.mockRejectedValueOnce(new Error('Failed'));
+      axios.get.mockRejectedValueOnce(error);
 
-      await tasksStore.getTasks();
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+      await expect(tasksStore.getTasks()).rejects.toThrow('Network error');
     });
   });
 
@@ -110,16 +121,13 @@ describe('Tasks Store', () => {
       expect(tasksStore.task).toEqual(mockTask);
     });
 
-    it('should handle getTask error', async () => {
+    it('should propagate getTask error to caller', async () => {
       const tasksStore = useTasksStore();
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const error = new Error('Not found');
 
-      axios.get.mockRejectedValueOnce(new Error('Failed'));
+      axios.get.mockRejectedValueOnce(error);
 
-      await tasksStore.getTask({ id: '123' });
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+      await expect(tasksStore.getTask({ id: '123' })).rejects.toThrow('Not found');
     });
   });
 
@@ -136,16 +144,23 @@ describe('Tasks Store', () => {
       expect(tasksStore.task).toEqual(mockResponse.data.data);
     });
 
-    it('should handle createTask error', async () => {
+    it('should propagate createTask error to caller', async () => {
       const tasksStore = useTasksStore();
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const error = new Error('Server error');
+
+      axios.post.mockRejectedValueOnce(error);
+
+      await expect(tasksStore.createTask({ title: 'Test' })).rejects.toThrow('Server error');
+    });
+
+    it('should not update store state when createTask fails', async () => {
+      const tasksStore = useTasksStore();
+      const originalTask = { ...tasksStore.task };
 
       axios.post.mockRejectedValueOnce(new Error('Failed'));
 
-      await tasksStore.createTask({ title: 'Test' });
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+      await expect(tasksStore.createTask({ title: 'Test' })).rejects.toThrow();
+      expect(tasksStore.task).toEqual(originalTask);
     });
   });
 
@@ -162,16 +177,13 @@ describe('Tasks Store', () => {
       expect(tasksStore.task).toMatchObject(updatedTask);
     });
 
-    it('should handle updateTask error', async () => {
+    it('should propagate updateTask error to caller', async () => {
       const tasksStore = useTasksStore();
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const error = new Error('Update failed');
 
-      axios.put.mockRejectedValueOnce(new Error('Failed'));
+      axios.put.mockRejectedValueOnce(error);
 
-      await tasksStore.updateTask({ id: '789' });
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+      await expect(tasksStore.updateTask({ id: '789' })).rejects.toThrow('Update failed');
     });
   });
 
@@ -187,16 +199,24 @@ describe('Tasks Store', () => {
       expect(tasksStore.task).toEqual({ title: '', description: '' });
     });
 
-    it('should handle deleteTask error', async () => {
+    it('should propagate deleteTask error to caller', async () => {
       const tasksStore = useTasksStore();
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const error = new Error('Delete failed');
+
+      axios.delete.mockRejectedValueOnce(error);
+
+      await expect(tasksStore.deleteTask({ id: '999' })).rejects.toThrow('Delete failed');
+    });
+
+    it('should not reset task state when deleteTask fails', async () => {
+      const tasksStore = useTasksStore();
+      tasksStore.task = { id: '999', title: 'To Delete', description: 'Delete me' };
 
       axios.delete.mockRejectedValueOnce(new Error('Failed'));
 
-      await tasksStore.deleteTask({ id: '999' });
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+      await expect(tasksStore.deleteTask({ id: '999' })).rejects.toThrow();
+      // Task should NOT have been reset since the delete failed
+      expect(tasksStore.task).toMatchObject({ id: '999', title: 'To Delete' });
     });
   });
 });

--- a/src/modules/tasks/views/tasks.view.vue
+++ b/src/modules/tasks/views/tasks.view.vue
@@ -66,9 +66,13 @@ export default {
       return tasksStore.tasks;
     },
   },
-  created() {
+  async created() {
     const tasksStore = useTasksStore();
-    tasksStore.getTasks();
+    try {
+      await tasksStore.getTasks();
+    } catch (err) {
+      console.error(err);
+    }
   },
 };
 </script>


### PR DESCRIPTION
## Summary

Fixes #4218 — tasks store swallows errors, causing views to navigate on failed writes (silent data loss + misleading UX).

**Root cause**: All 5 actions in `tasks.store.js` wrapped requests in `try { ... } catch (err) { console.error(err); }`, swallowing errors. Views' `await tasksStore.createTask(...)` resolved to `undefined` on failure, so `router.push('/tasks')` and `this.save = false` executed even when the write failed.

**Pattern chosen**: natural re-throw (no try/catch in store actions) — matches the established convention in `organizations.store.js`. The axios interceptor already shows a snackbar on API errors via `err.response.data.description`, so no additional error display is needed in the views.

**Changes**:
- `tasks.store.js`: Remove all try/catch wrappers; actions now propagate errors naturally. Extract `apiBase()` helper (matching organizations.store.js). Add JSDoc returns.
- `tasks.store.unit.tests.js`: Replace `console.error` spy assertions with `.rejects.toThrow()`. Add config mock, `vi.clearAllMocks()` in beforeEach. Add state-isolation tests (createTask fail → store unchanged, deleteTask fail → task not reset).
- `task.view.unit.tests.js` (new): Assert navigation + save-flag on success; assert no navigation + save-flag preserved on failure for create/update/remove.

**Out of scope** (separate P2 tracked separately): VUE-TASKS-stale-list (create/update don't refresh `this.tasks`).

## Test plan

- [ ] `npm run test:unit` → 121 test files, 1963 tests, all pass
- [ ] `npm run lint` → no issues
- [ ] Store error tests: all 5 actions reject on axios failure
- [ ] View tests: router.push not called on store failure; save flag not cleared on failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for task management workflows (create, update, delete, and list operations).

* **Bug Fixes**
  * Improved error handling for task operations to properly communicate failures to the user interface instead of silently suppressing them.
  * Enhanced task list loading with proper async error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Vue/pull/4221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->