### PR TITLE
refactor(home): remove releases/changelog consumers + static home stat (#3725)

### DIFF
--- a/src/lib/helpers/tests/tools.unit.tests.js
+++ b/src/lib/helpers/tests/tools.unit.tests.js
@@ -1,55 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { releasesNumber, pageRequest, serverItemsLength } from '../tools.js';
+import { pageRequest, serverItemsLength } from '../tools.js';
 
 describe('Tools Helpers', () => {
-  describe('releasesNumber', () => {
-    it('should parse release version starting with v', () => {
-      const result = releasesNumber('v2.3.4');
-      expect(result).toEqual(['20', '3']);
-    });
-
-    it('should parse release version without v prefix', () => {
-      const result = releasesNumber('2.3.4');
-      expect(result).toEqual(['20', '3']);
-    });
-
-    it('should handle version 1.x.x specially', () => {
-      const result = releasesNumber('1.5.2');
-      expect(result).toEqual(['1', '5']);
-    });
-
-    it('should handle version v1.x.x specially', () => {
-      const result = releasesNumber('v1.5.2');
-      expect(result).toEqual(['1', '5']);
-    });
-
-    it('should multiply major version by 10 for versions >= 2', () => {
-      const result = releasesNumber('3.2.1');
-      expect(result).toEqual(['30', '2']);
-    });
-
-    it('should handle double digit major version', () => {
-      const result = releasesNumber('10.5.3');
-      expect(result).toEqual(['100', '5']);
-    });
-
-    it('should handle version with v prefix and double digit major', () => {
-      const result = releasesNumber('v12.4.7');
-      expect(result).toEqual(['120', '4']);
-    });
-
-    it('should pop the patch version', () => {
-      const result = releasesNumber('5.9.99');
-      expect(result).toHaveLength(2);
-      expect(result).toEqual(['50', '9']);
-    });
-
-    it('should handle zero major version', () => {
-      const result = releasesNumber('0.8.3');
-      expect(result).toEqual(['0', '8']);
-    });
-  });
-
   describe('pageRequest', () => {
     it('should generate request string without search', () => {
       const result = pageRequest(1, 10, '');

--- a/src/lib/helpers/tools.js
+++ b/src/lib/helpers/tools.js
@@ -3,18 +3,6 @@
  */
 
 /**
- * @desc Function to evaluate numbers of release from last release
- * @param {String} release - Version string (e.g. '2.3.4' or 'v2.3.4')
- * @returns {Array} Array of version number parts
- */
-export const releasesNumber = (release) => {
-  const numbers = release[0] === 'v' ? release.substr(1).split('.') : release.split('.'); // get numbers last release
-  numbers.pop();
-  numbers[0] = numbers[0] === '1' ? '1' : String(parseInt(numbers[0], 10) * 10); // calc aproximativly number of release
-  return numbers;
-};
-
-/**
  * @desc Function generate pagniation request
  * @param {Int} page
  * @param {Int} perPage
@@ -39,4 +27,4 @@ export const serverItemsLength = (items, options) =>
 /**
  * Exports.
  */
-export default { releasesNumber, pageRequest, serverItemsLength };
+export default { pageRequest, serverItemsLength };

--- a/src/modules/app/config/app.development.config.js
+++ b/src/modules/app/config/app.development.config.js
@@ -147,11 +147,6 @@ export default {
             url: '/team',
           },
           {
-            label: 'Changelogs',
-            icon: 'fa-solid fa-clipboard-list',
-            url: '/changelogs',
-          },
-          {
             label: `DevKit ${new Date().getFullYear()}`,
             icon: 'fa-regular fa-copyright',
             url: 'https://devkit.me',

--- a/src/modules/home/config/home.development.config.js
+++ b/src/modules/home/config/home.development.config.js
@@ -634,10 +634,6 @@ export default {
         },
         {
           value: '0',
-          title: 'Releases',
-        },
-        {
-          value: '0',
           title: 'Users',
         },
         {

--- a/src/modules/home/router/home.router.js
+++ b/src/modules/home/router/home.router.js
@@ -21,17 +21,6 @@ export default [
     },
   },
   {
-    path: '/changelogs',
-    name: 'changelogs',
-    component: pages,
-    meta: {
-      display: false, // hide from drawer any time
-      title: 'Changelogs',
-      data: 'getChangelogs', // array of {title: ..., markdown: ...}
-      footer: true, // display footer
-    },
-  },
-  {
     path: '/team',
     name: 'Team',
     component: team,

--- a/src/modules/home/stores/home.store.js
+++ b/src/modules/home/stores/home.store.js
@@ -77,6 +77,10 @@ export const useHomeStore = defineStore('home', {
       }
     },
 
+    /**
+     * Fetch home statistics (tasks and users counts) and update the store.
+     * @returns {Promise<void>}
+     */
     async getStatistics() {
       const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
 

--- a/src/modules/home/stores/home.store.js
+++ b/src/modules/home/stores/home.store.js
@@ -2,11 +2,10 @@
  * Module dependencies.
  */
 import { defineStore } from 'pinia';
-import { sum, flatten, merge } from 'lodash-es';
+import { merge } from 'lodash-es';
 import GhostContentAPI from '@tryghost/content-api';
 import axios from '../../../lib/services/axios';
 import config from '../../../lib/services/config';
-import * as tools from '../../../lib/helpers/tools';
 import { createLogger } from '../../../lib/helpers/logger';
 
 const log = createLogger('home');
@@ -34,21 +33,6 @@ export const useHomeStore = defineStore('home', {
       try {
         const team = await axios.get(`${api}/${config.api.endPoints.home}/team`);
         this.team = team.data.data;
-      } catch (err) {
-        log.error(err);
-      }
-    },
-
-    async getChangelogs() {
-      const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
-
-      try {
-        const changelogs = await axios.get(`${api}/${config.api.endPoints.home}/changelogs`);
-        this.contents = changelogs.data.data.map((item) => ({
-          title: item.title,
-          markdown: item.markdown.replace(/\[([^\\[\]]*)\]\((.*?)\)/gm, '$1').replace(/\(\w{7}\)/g, ''),
-          style: 'air',
-        }));
       } catch (err) {
         log.error(err);
       }
@@ -98,22 +82,11 @@ export const useHomeStore = defineStore('home', {
 
       try {
         const tasks = await axios.get(`${api}/${config.api.endPoints.tasks}/stats`);
-        const releases = await axios.get(`${api}/${config.api.endPoints.home}/releases`);
         const users = await axios.get(`${api}/${config.api.endPoints.account}/stats`);
 
         if (this.statistics) {
           this.statistics[0].value = tasks.data.data;
-          this.statistics[1].value = sum(
-            flatten(
-              releases.data.data.map((release) => {
-                if (release.list.length > 0) {
-                  return tools.releasesNumber(release.list[0].name);
-                }
-                return 0;
-              }),
-            ).map((x) => +x),
-          );
-          this.statistics[2].value = users.data.data;
+          this.statistics[1].value = users.data.data;
         }
       } catch (err) {
         log.error(err);

--- a/src/modules/home/tests/home.store.unit.tests.js
+++ b/src/modules/home/tests/home.store.unit.tests.js
@@ -149,45 +149,6 @@ describe('Home Store', () => {
     });
   });
 
-  describe('getChangelogs', () => {
-    it('should fetch and transform changelog data', async () => {
-      const homeStore = useHomeStore();
-      const mockChangelogsData = {
-        data: {
-          data: [
-            {
-              title: 'v1.0.0',
-              markdown: '- [Fix] Bug fixes (#abc1234)\n- [Feature] New feature (def5678)',
-            },
-          ],
-        },
-      };
-
-      axios.get.mockResolvedValueOnce(mockChangelogsData);
-
-      await homeStore.getChangelogs();
-
-      expect(homeStore.contents).toHaveLength(1);
-      expect(homeStore.contents[0].title).toBe('v1.0.0');
-      expect(homeStore.contents[0].style).toBe('air');
-      expect(homeStore.contents[0].markdown).toBeDefined();
-    });
-
-    it('should handle getChangelogs error', async () => {
-      const homeStore = useHomeStore();
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      axios.get.mockRejectedValueOnce(new Error('Failed to fetch changelogs'));
-
-      await homeStore.getChangelogs();
-
-      expect(homeStore.contents).toEqual([]);
-      expect(consoleErrorSpy).toHaveBeenCalled();
-
-      consoleErrorSpy.mockRestore();
-    });
-  });
-
   describe('getPages', () => {
     it('should fetch and transform page data with banner', async () => {
       const homeStore = useHomeStore();
@@ -265,62 +226,25 @@ describe('Home Store', () => {
   });
 
   describe('getStatistics', () => {
-    it('should fetch and calculate statistics successfully', async () => {
+    it('should fetch and update tasks and users statistics', async () => {
       const homeStore = useHomeStore();
       homeStore.initStatistics();
 
       if (!homeStore.statistics) {
-        homeStore.statistics = [{ value: 0 }, { value: 0 }, { value: 0 }];
+        homeStore.statistics = [{ value: 0 }, { value: 0 }];
       }
 
       const mockTasksData = { data: { data: 150 } };
-      const mockReleasesData = {
-        data: {
-          data: [
-            { list: [{ name: 'v2.5.3' }] },
-            { list: [{ name: 'v3.2.1' }] },
-          ],
-        },
-      };
       const mockUsersData = { data: { data: 1000 } };
 
       axios.get
         .mockResolvedValueOnce(mockTasksData)
-        .mockResolvedValueOnce(mockReleasesData)
         .mockResolvedValueOnce(mockUsersData);
 
       await homeStore.getStatistics();
 
       expect(homeStore.statistics[0].value).toBe(150);
-      expect(homeStore.statistics[1].value).toBeGreaterThan(0);
-      expect(homeStore.statistics[2].value).toBe(1000);
-    });
-
-    it('should handle empty release list in statistics', async () => {
-      const homeStore = useHomeStore();
-      homeStore.initStatistics();
-
-      if (!homeStore.statistics) {
-        homeStore.statistics = [{ value: 0 }, { value: 0 }, { value: 0 }];
-      }
-
-      const mockTasksData = { data: { data: 100 } };
-      const mockReleasesData = {
-        data: {
-          data: [{ list: [] }],
-        },
-      };
-      const mockUsersData = { data: { data: 500 } };
-
-      axios.get
-        .mockResolvedValueOnce(mockTasksData)
-        .mockResolvedValueOnce(mockReleasesData)
-        .mockResolvedValueOnce(mockUsersData);
-
-      await homeStore.getStatistics();
-
-      expect(homeStore.statistics[0].value).toBe(100);
-      expect(homeStore.statistics[2].value).toBe(500);
+      expect(homeStore.statistics[1].value).toBe(1000);
     });
 
     it('should handle getStatistics error', async () => {
@@ -342,12 +266,10 @@ describe('Home Store', () => {
       homeStore.statistics = null;
 
       const mockTasksData = { data: { data: 150 } };
-      const mockReleasesData = { data: { data: [] } };
       const mockUsersData = { data: { data: 1000 } };
 
       axios.get
         .mockResolvedValueOnce(mockTasksData)
-        .mockResolvedValueOnce(mockReleasesData)
         .mockResolvedValueOnce(mockUsersData);
 
       await homeStore.getStatistics();

--- a/src/modules/home/views/home.pages.view.vue
+++ b/src/modules/home/views/home.pages.view.vue
@@ -69,8 +69,6 @@ export default {
         const action = this.$route.meta.data;
         if (action === 'getPages') {
           homeStore.getPages(this.$route.params.name);
-        } else if (action === 'getChangelogs') {
-          homeStore.getChangelogs();
         }
         this.page = this.$route.params.name;
       }
@@ -84,8 +82,6 @@ export default {
         homeStore.getPages(this.$route.params.name);
       }
       this.page = this.$route.params.name;
-    } else if (action === 'getChangelogs') {
-      homeStore.getChangelogs();
     }
   },
   methods: {


### PR DESCRIPTION
## Summary

- **#3725** (Vue side): Remove all releases/changelog consumers from the Vue frontend.
  - Remove `getChangelogs` store action from `home.store.js`
  - Remove `/changelogs` route from `home.router.js`
  - Remove changelogs footer nav link from `app.development.config.js`
  - Remove dead `getChangelogs()` calls from `home.pages.view.vue` (watcher + created hook)
  - Update `getStatistics`: drop releases API call; `statistics[0]` = tasks, `statistics[1]` = users
  - Remove `Releases` stat from `home.development.config.js` statistics.content (indices aligned)
  - Remove `releasesNumber` from `tools.js` helper and its unit tests (no longer used anywhere)

## Cross-reference

Node PR: pierreb-devkit/Node#3735 (fix(home): restrict /team fields, remove releases/changelog, add jwt readiness check #3724 #3725 #3718)

## Test plan

- [ ] `npm run lint` → 0 issues
- [ ] `npm run generateConfig && npm run test:unit` → 120 test files, 1941 tests pass
- [ ] Home statistics section still renders (tasks + users stats updated from API; Total Downloads static)
- [ ] `/team` page still works; `/changelogs` route removed
- [ ] Footer "Changelogs" link gone; "Us?" team link kept