### PR TITLE
feat(skills/update-stack): block on undeclared drift vs upstream

### DIFF
--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -92,6 +92,40 @@ BODY
 
 Proceed to Phase 2 and track the upstream fix separately — do not block downstream alignment on it.
 
+### 3ter. Block on undeclared drift
+
+After `/verify` passes, run a final diff sweep before starting Phase 2. Any stack file that diverges from upstream **and** is not declared in `DOWNSTREAM_PATCHES.md` blocks the flow.
+
+```bash
+git fetch devkit-vue master --quiet
+
+drift_found=0
+while IFS= read -r f; do
+  upstream_blob=$(git ls-tree devkit-vue/master -- "$f" 2>/dev/null | awk '{print $3}')
+  [ -z "$upstream_blob" ] && continue  # downstream-only file — skip
+  local_hash=$(git hash-object "$f" 2>/dev/null)
+  if [ "$upstream_blob" != "$local_hash" ]; then
+    if ! grep -qF "$f" DOWNSTREAM_PATCHES.md 2>/dev/null; then
+      echo "BLOCK: undeclared drift on stack file: $f"
+      echo "  Fix A — revert to upstream:  git checkout devkit-vue/master -- $f"
+      echo "  Fix B — declare it:          add '$f' + rationale to DOWNSTREAM_PATCHES.md"
+      drift_found=1
+    fi
+  fi
+done < <(git ls-files src/modules/home src/modules/auth src/modules/users src/modules/tasks src/modules/core src/modules/app src/modules/secure 2>/dev/null \
+  | grep -v "/tests/" | grep -vE "\.(test|spec)\.(js|ts|vue)$")
+
+[ "$drift_found" -eq 1 ] && exit 1
+echo "3ter: no undeclared drift — OK"
+```
+
+**Rules:**
+- Missing `DOWNSTREAM_PATCHES.md` = no declared divergences allowed (treat as empty).
+- `src/config/defaults/<project>.js` (downstream-only config file) will be absent from `devkit-vue/master` → `upstream_blob` empty → auto-skipped.
+- `src/modules/app/app.router.js` legitimately diverges (downstream routes) — declare it in `DOWNSTREAM_PATCHES.md` once on project bootstrap.
+- This gate runs **after** `/verify` (never blocks on transient verify failures) and **before** Phase 2 (failure is recoverable — no merge commit yet).
+- Ref: plan `2026-05-30-trawl-devkit-perfect-alignment.md` Tasks E.1 + E.2.
+
 ---
 
 ## Phase 2 — Project alignment

--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -103,9 +103,9 @@ drift_found=0
 while IFS= read -r f; do
   upstream_blob=$(git ls-tree devkit-vue/master -- "$f" 2>/dev/null | awk '{print $3}')
   [ -z "$upstream_blob" ] && continue  # downstream-only file — skip
-  local_hash=$(git hash-object "$f" 2>/dev/null)
-  if [ "$upstream_blob" != "$local_hash" ]; then
-    if ! grep -qF "$f" DOWNSTREAM_PATCHES.md 2>/dev/null; then
+  local_blob=$(git rev-parse "HEAD:$f" 2>/dev/null)
+  if [ "$upstream_blob" != "$local_blob" ]; then
+    if ! grep -qF "'$f'" DOWNSTREAM_PATCHES.md 2>/dev/null; then
       echo "BLOCK: undeclared drift on stack file: $f"
       echo "  Fix A — revert to upstream:  git checkout devkit-vue/master -- $f"
       echo "  Fix B — declare it:          add '$f' + rationale to DOWNSTREAM_PATCHES.md"
@@ -121,7 +121,8 @@ echo "3ter: no undeclared drift — OK"
 
 **Rules:**
 - Missing `DOWNSTREAM_PATCHES.md` = no declared divergences allowed (treat as empty).
-- `src/config/defaults/<project>.js` (downstream-only config file) will be absent from `devkit-vue/master` → `upstream_blob` empty → auto-skipped.
+- Declare diverging paths in `DOWNSTREAM_PATCHES.md` as `'path/to/file'` (single-quoted) — the gate matches on the quoted token to avoid substring collisions.
+- Downstream-only files (new modules, composables) are not scanned — the sweep only covers the stack module directories listed above.
 - `src/modules/app/app.router.js` legitimately diverges (downstream routes) — declare it in `DOWNSTREAM_PATCHES.md` once on project bootstrap.
 - This gate runs **after** `/verify` (never blocks on transient verify failures) and **before** Phase 2 (failure is recoverable — no merge commit yet).
 - Ref: plan `2026-05-30-trawl-devkit-perfect-alignment.md` Tasks E.1 + E.2.

--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -113,7 +113,7 @@ while IFS= read -r f; do
     fi
   fi
 done < <(git ls-files src/modules/home src/modules/auth src/modules/users src/modules/tasks src/modules/core src/modules/app src/modules/secure 2>/dev/null \
-  | grep -v "/tests/" | grep -vE "\.(test|spec)\.(js|ts|vue)$")
+  | grep -vE "/(tests|__tests__)/" | grep -vE "\.(test|spec)\.(js|jsx|ts|tsx|vue)$")
 
 [ "$drift_found" -eq 1 ] && exit 1
 echo "3ter: no undeclared drift — OK"


### PR DESCRIPTION
## Summary

- Adds gate **3ter** to Phase 1 of `/update-stack` (after `/verify` passes, before Phase 2): diffs each stack-module non-test file against `devkit-vue/master`; any divergence not declared in `DOWNSTREAM_PATCHES.md` causes `exit 1` with a clear fix message
- Missing `DOWNSTREAM_PATCHES.md` = no declared divergences allowed (treated as empty)
- `src/config/defaults/<project>.js` is auto-skipped (absent from devkit → `upstream_blob` empty)
- `src/modules/app/app.router.js` legitimately diverges (downstream routes) — document it in `DOWNSTREAM_PATCHES.md` once on project bootstrap

## Why

A 2026-05-30 audit of `comes-io/trawl_node` found **3 architectural violations + 9 promote-up candidates** in stack-managed modules that accumulated silently over weeks — `/update-stack` had no gate. The same risk applies to Vue downstreams: any shared module file diverging from `devkit-vue/master` without a `DOWNSTREAM_PATCHES.md` entry is silent drift.

This gate enforces the "no dev in shared modules" rule at the only moment it can be enforced mechanically: when the downstream actually runs `/update-stack`.

## Gate test output (fake-drift exercise on trawl_node, Node-side equivalent)

**Block path** (undeclared drift — `exit 1`):
```
BLOCK: undeclared drift on stack file: lib/helpers/guides.js
  Fix A — revert to upstream:  git checkout devkit-node/master -- lib/helpers/guides.js
  Fix B — declare it:          add 'lib/helpers/guides.js' + rationale to DOWNSTREAM_PATCHES.md
EXIT 1 — gate blocked as expected
```

**Pass path** (all diverging files declared in ledger — `exit 0`):
```
OK (declared): lib/helpers/guides.js
OK (declared): lib/services/express.js
OK (declared): modules/auth/controllers/auth.controller.js
OK (declared): modules/tasks/doc/tasks.yml
3ter: no undeclared drift — OK (EXIT 0)
```

## Complement

- **E.1**: `DOWNSTREAM_PATCHES.md` ledger convention (downstreams must create ledger before first `/update-stack` with this gate)
- **E.3**: PRF Phase 0.5 gate — catches drift at PR time
- **E.6**: memory `feedback_no_dev_in_shared_modules`

Closes #4227 — plan `2026-05-30-trawl-devkit-perfect-alignment.md` Task E.2