### PR TITLE
feat(auth): add beta seat getters (signupCap/seatsRemaining/betaCapped)

### DIFF
--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -63,6 +63,10 @@ export const useAuthStore = defineStore('auth', {
   getters: {
     isLoggedIn: (state) => !!state.cookieExpire,
     authStatus: (state) => state.status,
+    // Beta capacity from the public auth config: cap/remaining are null when uncapped; betaCapped is true only when a numeric cap is set.
+    signupCap: (state) => state.serverConfig?.sign?.cap ?? null,
+    seatsRemaining: (state) => state.serverConfig?.sign?.remaining ?? null,
+    betaCapped: (state) => state.serverConfig?.sign?.cap != null,
   },
 
   actions: {

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -1011,3 +1011,31 @@ describe('Auth Store', () => {
     });
   });
 });
+
+describe('auth store — beta seat getters', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('uncapped serverConfig → cap null, remaining null, betaCapped false', () => {
+    const store = useAuthStore();
+    store.serverConfig = { sign: { in: true, up: false, cap: null, remaining: null } };
+    expect(store.signupCap).toBeNull();
+    expect(store.seatsRemaining).toBeNull();
+    expect(store.betaCapped).toBe(false);
+  });
+
+  it('capped serverConfig → exposes cap + remaining, betaCapped true', () => {
+    const store = useAuthStore();
+    store.serverConfig = { sign: { in: true, up: false, cap: 50, remaining: 40 } };
+    expect(store.signupCap).toBe(50);
+    expect(store.seatsRemaining).toBe(40);
+    expect(store.betaCapped).toBe(true);
+  });
+
+  it('missing serverConfig → safe nulls', () => {
+    const store = useAuthStore();
+    store.serverConfig = null;
+    expect(store.signupCap).toBeNull();
+    expect(store.seatsRemaining).toBeNull();
+    expect(store.betaCapped).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds three null-safe Pinia getters to the auth store — `signupCap`, `seatsRemaining`, `betaCapped` — reading `serverConfig.sign.{cap,remaining}` (populated by the upstream `GET /api/auth/config` response). No action/state/fetch changes.

## Why

Upstream-generic half of a downstream private-beta invite gate. Downstream landing components read these getters to render a "Beta · X seats left" banner; exposing typed getters avoids reaching into `serverConfig.sign.*` raw.

## Inert by default

For any downstream without a configured cap, all three return null/false. Pairs with the devkit Node `/auth/config` change (contract: Node adds the fields, Vue reads them).

## Tests

3 unit tests (uncapped, capped, missing serverConfig). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)