### PR TITLE
feat(configGuard): block dev-host/port leak into production config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
       - run: UV_USE_IO_URING=0 npm run build
         env:
           DEVKIT_VUE_api_host: https://api.example.com
+          DEVKIT_VUE_api_port: ""
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,8 @@ jobs:
       - run: npm run lint
       - run: npm run test:unit:coverage
       - run: UV_USE_IO_URING=0 npm run build
+        env:
+          DEVKIT_VUE_api_host: https://api.example.com
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/lib/helpers/configGuard.js
+++ b/src/lib/helpers/configGuard.js
@@ -7,7 +7,7 @@ const CONFIG_PLACEHOLDER = { port: 8080 };
 
 /**
  * Dev-only hostnames and ports that must never reach a production bundle.
- * Root cause of 2026-05-10 signin-broken :3010 outage (issue #949).
+ * Root cause of 2026-05-10 signin-broken :3010 outage (trawl_vue#949).
  */
 const DEV_HOSTS = new Set(['localhost', '127.0.0.1']);
 const DEV_PORTS = new Set(['3000', '3001', '3010', '4000', '5000', '8000', '8080', '8888']);
@@ -35,22 +35,22 @@ export const assertConfigLoaded = (config, mode) => {
     safeConfig === CONFIG_PLACEHOLDER || (Object.keys(safeConfig).length === 1 && safeConfig.port === 8080 && !safeConfig.host);
   if (isPlaceholder) {
     throw new Error(
-      'Production build requires a valid config. Run `npm run config` to generate src/config/index.js before building.',
+      'Production build requires a valid config. Run `npm run generateConfig` to generate src/config/index.js before building.',
     );
   }
 
-  // Guard against dev-default API host leaking into a prod bundle (#949).
-  const apiHost = safeConfig?.api?.host;
-  if (apiHost && DEV_HOSTS.has(String(apiHost))) {
+  // Guard against dev-default API host leaking into a prod bundle (trawl_vue#949).
+  const apiHost = String(safeConfig?.api?.host || '').trim().toLowerCase();
+  if (apiHost && DEV_HOSTS.has(apiHost)) {
     throw new Error(
-      `Production build has dev-default API host "${apiHost}". ` +
-        'Set DEVKIT_VUE_api_host to the real API URL before building.',
+      `Production build has dev-default API host/hostname "${safeConfig?.api?.host}". ` +
+        'Set DEVKIT_VUE_api_host to the real host/hostname before building.',
     );
   }
 
-  // Guard against dev-default API port leaking into a prod bundle (#949).
-  const apiPort = safeConfig?.api?.port;
-  if (apiPort && DEV_PORTS.has(String(apiPort))) {
+  // Guard against dev-default API port leaking into a prod bundle (trawl_vue#949).
+  const apiPort = String(safeConfig?.api?.port || '').trim();
+  if (apiPort && DEV_PORTS.has(apiPort)) {
     throw new Error(
       `Production build has dev-default API port "${apiPort}". ` +
         'Set DEVKIT_VUE_api_port to "" (empty) or the real port before building.',

--- a/src/lib/helpers/configGuard.js
+++ b/src/lib/helpers/configGuard.js
@@ -6,22 +6,54 @@
 const CONFIG_PLACEHOLDER = { port: 8080 };
 
 /**
- * Validate that the application config is fully loaded (not the placeholder).
- * In production mode, a missing config is a fatal error because SEO plugins
- * depend on real values.  In development mode the placeholder is acceptable.
+ * Dev-only hostnames and ports that must never reach a production bundle.
+ * Root cause of 2026-05-10 signin-broken :3010 outage (issue #949).
+ */
+const DEV_HOSTS = new Set(['localhost', '127.0.0.1']);
+const DEV_PORTS = new Set(['3000', '3001', '3010', '4000', '5000', '8000', '8080', '8888']);
+
+/**
+ * Validate that the application config is fully loaded (not the placeholder)
+ * and does not contain dev-default API coordinates in production builds.
+ *
+ * In production mode:
+ *   - A missing/placeholder config is a fatal error (SEO plugins need real values).
+ *   - api.host must not be localhost or 127.0.0.1.
+ *   - api.port must not be a well-known local dev port.
+ * In development/test mode the function is a no-op.
  *
  * @param {object} config - The resolved application config object.
  * @param {string} mode   - Vite build mode (e.g. 'production', 'development').
  * @returns {void}
- * @throws {Error} When mode is 'production' and config is still the placeholder.
+ * @throws {Error} When mode is 'production' and config is invalid or contains dev defaults.
  */
 export const assertConfigLoaded = (config, mode) => {
+  if (mode !== 'production') return;
+
   const safeConfig = config || CONFIG_PLACEHOLDER;
   const isPlaceholder =
     safeConfig === CONFIG_PLACEHOLDER || (Object.keys(safeConfig).length === 1 && safeConfig.port === 8080 && !safeConfig.host);
-  if (mode === 'production' && isPlaceholder) {
+  if (isPlaceholder) {
     throw new Error(
       'Production build requires a valid config. Run `npm run config` to generate src/config/index.js before building.',
+    );
+  }
+
+  // Guard against dev-default API host leaking into a prod bundle (#949).
+  const apiHost = safeConfig?.api?.host;
+  if (apiHost && DEV_HOSTS.has(String(apiHost))) {
+    throw new Error(
+      `Production build has dev-default API host "${apiHost}". ` +
+        'Set DEVKIT_VUE_api_host to the real API URL before building.',
+    );
+  }
+
+  // Guard against dev-default API port leaking into a prod bundle (#949).
+  const apiPort = safeConfig?.api?.port;
+  if (apiPort && DEV_PORTS.has(String(apiPort))) {
+    throw new Error(
+      `Production build has dev-default API port "${apiPort}". ` +
+        'Set DEVKIT_VUE_api_port to "" (empty) or the real port before building.',
     );
   }
 };

--- a/src/lib/helpers/tests/configGuard.unit.tests.js
+++ b/src/lib/helpers/tests/configGuard.unit.tests.js
@@ -40,4 +40,42 @@ describe('configGuard – assertConfigLoaded', () => {
       'Production build requires a valid config',
     );
   });
+
+  // DEV_HOSTS / DEV_PORTS leak-detection tests (incident ref: trawl_vue #949 — signin-broken :3010 outage)
+
+  it('throws in production when api.host is localhost', () => {
+    expect(() =>
+      assertConfigLoaded({ api: { host: 'localhost', port: '' } }, 'production'),
+    ).toThrow('dev-default API host');
+  });
+
+  it('throws in production when api.host is 127.0.0.1', () => {
+    expect(() =>
+      assertConfigLoaded({ api: { host: '127.0.0.1', port: '' } }, 'production'),
+    ).toThrow('dev-default API host');
+  });
+
+  it('throws in production when api.port is a dev port', () => {
+    expect(() =>
+      assertConfigLoaded({ api: { host: 'api.example.com', port: '3010' } }, 'production'),
+    ).toThrow('dev-default API port');
+  });
+
+  it('throws in production when api.port is 3000', () => {
+    expect(() =>
+      assertConfigLoaded({ api: { host: 'api.example.com', port: '3000' } }, 'production'),
+    ).toThrow('dev-default API port');
+  });
+
+  it('does not throw in production with valid config (real host + empty port)', () => {
+    expect(() =>
+      assertConfigLoaded({ api: { host: 'api.example.com', port: '' } }, 'production'),
+    ).not.toThrow();
+  });
+
+  it('does not throw in production with valid config (real host + no port key)', () => {
+    expect(() =>
+      assertConfigLoaded({ api: { host: 'api.example.com' } }, 'production'),
+    ).not.toThrow();
+  });
 });

--- a/src/lib/helpers/tests/configGuard.unit.tests.js
+++ b/src/lib/helpers/tests/configGuard.unit.tests.js
@@ -78,4 +78,18 @@ describe('configGuard – assertConfigLoaded', () => {
       assertConfigLoaded({ api: { host: 'api.example.com' } }, 'production'),
     ).not.toThrow();
   });
+
+  // Normalization regression tests: case and whitespace must not bypass guards.
+
+  it('throws in production when api.host is "LOCALHOST" (uppercase bypass attempt)', () => {
+    expect(() =>
+      assertConfigLoaded({ api: { host: 'LOCALHOST', port: '' } }, 'production'),
+    ).toThrow('dev-default API host');
+  });
+
+  it('throws in production when api.port is " 3000 " (padded bypass attempt)', () => {
+    expect(() =>
+      assertConfigLoaded({ api: { host: 'api.example.com', port: ' 3000 ' } }, 'production'),
+    ).toThrow('dev-default API port');
+  });
 });


### PR DESCRIPTION
## Summary

Promotes the `DEV_HOSTS` / `DEV_PORTS` leak-detection guard from trawl_vue downstream into devkit Vue's `src/lib/helpers/configGuard.js`. This is generic build-safety infrastructure — any downstream that accidentally configures `api.host = localhost` or `api.port = 3010` in a production bundle now gets a hard throw at build time instead of a silent outage.

The change is a strict superset of the existing `assertConfigLoaded` function: all prior behaviour is preserved, two new guard blocks are appended, and the early-return on non-production mode makes the function a clean no-op in dev/test.

## Incident reference

**trawl_vue #949 — signin-broken :3010 outage (2026-05-10)**: a dev port leaked into the prod bundle because `DEVKIT_VUE_api_port` was not set during the CI build step. Users could not sign in. The guard in this PR would have aborted the build before it shipped.

## Changes

- `src/lib/helpers/configGuard.js`: add `DEV_HOSTS` / `DEV_PORTS` sets + two guard blocks inside `assertConfigLoaded`
- `src/lib/helpers/tests/configGuard.unit.tests.js`: add 6 new tests (localhost host, 127.0.0.1 host, port 3010, port 3000, valid host+empty-port, valid host+no-port)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit` — all 13 configGuard tests pass (38 pre-existing unrelated failures unchanged)
- [ ] Downstream absorb (trawl_vue local override removal) — separate follow-up PR

## Closes

Closes #4234
Partially closes pierreb-projects/infra#38 (Task T11 — devkit side)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added production-mode validation to detect development-only hostnames (localhost, 127.0.0.1) and ports (3000, 3010) in configurations.

* **Tests**
  * Extended test coverage to verify production validation behavior for host and port configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->