### PR TITLE
fix(billing): update VProgressLinear snapshots for Vuetify 4.1.0

### DIFF
--- a/src/modules/billing/tests/__snapshots__/billing.meterProgress.component.unit.tests.js.snap
+++ b/src/modules/billing/tests/__snapshots__/billing.meterProgress.component.unit.tests.js.snap
@@ -5,10 +5,10 @@ exports[`BillingMeterProgressComponent > matches the overage snapshot 1`] = `
   <!-- Label row -->
   <!--v-if-->
   <!-- Bar variant -->
-  <div data-v-f7f25334="" class="v-progress-linear v-progress-linear--rounded v-progress-linear--rounded v-theme--light v-locale--is-ltr" style="top: 0px; height: 10px; --v-progress-linear-height: 10px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
+  <div data-v-f7f25334="" class="v-progress-linear v-progress-linear--rounded v-progress-linear--rounded v-theme--light v-locale--is-ltr" style="top: 0px; height: 10px; --v-progress-linear-height: 10px; --v-progress-chunk-gap: 4px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
     <!---->
-    <div class="v-progress-linear__background bg-surface-variant" style="opacity: NaN;"></div>
-    <div class="v-progress-linear__buffer bg-surface-variant" style="opacity: NaN; width: 0%;"></div>
+    <div class="v-progress-linear__background bg-surface-variant"></div>
+    <div class="v-progress-linear__buffer bg-surface-variant" style="width: 0%;"></div>
     <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
       <div class="v-progress-linear__determinate bg-error" style="width: 100%;"></div>
     </transition-stub>

--- a/src/modules/billing/tests/__snapshots__/billing.usageBar.component.unit.tests.js.snap
+++ b/src/modules/billing/tests/__snapshots__/billing.usageBar.component.unit.tests.js.snap
@@ -9,10 +9,10 @@ exports[`BillingUsageBarComponent > matches the meter overage snapshot 1`] = `
     <!-- Label row -->
     <!--v-if-->
     <!-- Bar variant -->
-    <div data-v-f7f25334="" class="v-progress-linear v-progress-linear--rounded v-progress-linear--rounded v-theme--light v-locale--is-ltr" style="top: 0px; height: 10px; --v-progress-linear-height: 10px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
+    <div data-v-f7f25334="" class="v-progress-linear v-progress-linear--rounded v-progress-linear--rounded v-theme--light v-locale--is-ltr" style="top: 0px; height: 10px; --v-progress-linear-height: 10px; --v-progress-chunk-gap: 4px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
       <!---->
-      <div class="v-progress-linear__background bg-surface-variant" style="opacity: NaN;"></div>
-      <div class="v-progress-linear__buffer bg-surface-variant" style="opacity: NaN; width: 0%;"></div>
+      <div class="v-progress-linear__background bg-surface-variant"></div>
+      <div class="v-progress-linear__buffer bg-surface-variant" style="width: 0%;"></div>
       <transition-stub name="slide-x-transition" appear="false" persisted="false" css="true">
         <div class="v-progress-linear__determinate bg-error" style="width: 100%;"></div>
       </transition-stub>


### PR DESCRIPTION
## Summary
- Vuetify 4.1.0 changed `VProgressLinear` rendering (bump landed in #4253)
- Background/buffer divs no longer emit `style="opacity: NaN; "` (upstream fix)
- Now emits `--v-progress-chunk-gap: 4px;` CSS variable in inline style
- Stored snapshots were taken under 4.0.8 → 2 CI failures on master

## Changes
- Update `billing.meterProgress.component.unit.tests.js.snap`
- Update `billing.usageBar.component.unit.tests.js.snap`

Snapshot-only change — no behavior difference. All 2036 tests pass locally.

## Test plan
- [ ] CI green (unit tests pass with updated snapshots)