### PR TITLE
fix(theme): re-apply OS theme post-hydration when dark='auto' (prerender light-lock)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,7 +36,20 @@ app
   .use(plugins.vuetify)
 
 // Initialize stores after all plugins are loaded
-initializeStores(routes);
+const { core: coreStore } = initializeStores(routes);
+
+// Re-apply OS theme on client after hydration so prerendered light markup
+// is corrected for users with dark="auto" and a dark system preference.
+// The prerender Puppeteer process resolves matchMedia to false (no OS), baking
+// a v-theme--light class; this call corrects the Pinia state immediately on
+// client bootstrap so Vuetify syncs the right class before first paint.
+if (typeof window !== 'undefined' && config.vuetify?.theme?.dark === 'auto') {
+  coreStore.syncOsTheme();
+  const mql = window.matchMedia?.('(prefers-color-scheme: dark)');
+  if (mql) {
+    mql.addEventListener('change', () => coreStore.syncOsTheme());
+  }
+}
 
 // Wire global error handlers — fan-out to PostHog Error Tracking
 app.config.errorHandler = (err, instance, info) => {

--- a/src/main.js
+++ b/src/main.js
@@ -49,10 +49,9 @@ if (typeof window !== 'undefined' && config.vuetify?.theme?.dark === 'auto') {
   if (mql) {
     /**
      * Syncs the theme with OS preference changes.
-     * @param {MediaQueryListEvent} _event - Media query change event.
      * @returns {void}
      */
-    const handleOsThemeChange = (_event) => {
+    const handleOsThemeChange = () => {
       coreStore.syncOsTheme();
     };
     mql.addEventListener('change', handleOsThemeChange);

--- a/src/main.js
+++ b/src/main.js
@@ -47,7 +47,15 @@ if (typeof window !== 'undefined' && config.vuetify?.theme?.dark === 'auto') {
   coreStore.syncOsTheme();
   const mql = window.matchMedia?.('(prefers-color-scheme: dark)');
   if (mql) {
-    mql.addEventListener('change', () => coreStore.syncOsTheme());
+    /**
+     * Syncs the theme with OS preference changes.
+     * @param {MediaQueryListEvent} _event - Media query change event.
+     * @returns {void}
+     */
+    const handleOsThemeChange = (_event) => {
+      coreStore.syncOsTheme();
+    };
+    mql.addEventListener('change', handleOsThemeChange);
   }
 }
 

--- a/src/modules/core/stores/core.store.js
+++ b/src/modules/core/stores/core.store.js
@@ -30,6 +30,19 @@ export const useCoreStore = defineStore('core', {
       this.routes = routes;
     },
 
+    /**
+     * @desc Re-apply the OS-derived theme on the client after hydration.
+     * Called post-mount to override the prerendered light class when
+     * `config.vuetify.theme.dark` is `"auto"` and `window.matchMedia` now
+     * reflects the real OS preference (which was unavailable at SSR/prerender
+     * build time). A no-op for explicit `"light"` / `"dark"` configs.
+     * @returns {void}
+     */
+    syncOsTheme() {
+      if (config.vuetify.theme.dark !== 'auto') return;
+      this.theme = isDark(config.vuetify.theme.dark) ? 'dark' : 'light';
+    },
+
     setDrawer(value) {
       this.drawer = value;
     },

--- a/src/modules/core/tests/core.store.unit.tests.js
+++ b/src/modules/core/tests/core.store.unit.tests.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 
 // Mock the ability module — vi.hoisted ensures the variable exists before vi.mock runs
@@ -17,6 +17,8 @@ vi.mock('../../../lib/services/config', () => ({ default: mockConfig }));
 import { useCoreStore } from '../stores/core.store';
 
 describe('Core Store', () => {
+  let originalMatchMedia;
+
   beforeEach(() => {
     // Create a new pinia instance for each test
     setActivePinia(createPinia());
@@ -26,6 +28,15 @@ describe('Core Store', () => {
     mockAbility.rules = [];
     mockAbility.can.mockReset();
     mockAbility.can.mockReturnValue(false);
+    // Save original matchMedia
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    // Restore original matchMedia
+    window.matchMedia = originalMatchMedia;
+    // Reset theme config
+    mockConfig.vuetify.theme.dark = false;
   });
 
   it('should initialize with default state', () => {
@@ -462,6 +473,72 @@ describe('Core Store', () => {
       coreStore.refreshNav(false);
 
       expect(coreStore.nav.map((r) => r.name)).toEqual(['zero', 'ten']);
+    });
+  });
+
+  describe('syncOsTheme — prerender light-lock fix (auto mode)', () => {
+    it('sets theme to dark when config.dark is "auto" and OS is dark', () => {
+      mockConfig.vuetify.theme.dark = 'auto';
+      window.matchMedia = vi.fn().mockImplementation((query) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }));
+
+      const coreStore = useCoreStore();
+      // Simulate prerender baked light theme
+      coreStore.theme = 'light';
+      coreStore.syncOsTheme();
+
+      expect(coreStore.theme).toBe('dark');
+    });
+
+    it('sets theme to light when config.dark is "auto" and OS is light', () => {
+      mockConfig.vuetify.theme.dark = 'auto';
+      window.matchMedia = vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }));
+
+      const coreStore = useCoreStore();
+      coreStore.theme = 'dark';
+      coreStore.syncOsTheme();
+
+      expect(coreStore.theme).toBe('light');
+    });
+
+    it('does not change theme when config.dark is not "auto"', () => {
+      mockConfig.vuetify.theme.dark = 'light';
+
+      const coreStore = useCoreStore();
+      coreStore.theme = 'light';
+      coreStore.syncOsTheme();
+
+      expect(coreStore.theme).toBe('light');
+    });
+
+    it('does not change theme when config.dark is "dark" (explicit, not auto)', () => {
+      mockConfig.vuetify.theme.dark = 'dark';
+
+      const coreStore = useCoreStore();
+      coreStore.theme = 'dark';
+      coreStore.syncOsTheme();
+
+      expect(coreStore.theme).toBe('dark');
+    });
+
+    it('handles missing matchMedia gracefully when config.dark is "auto"', () => {
+      mockConfig.vuetify.theme.dark = 'auto';
+      window.matchMedia = undefined;
+
+      const coreStore = useCoreStore();
+      coreStore.theme = 'light';
+      // Should not throw and should default to light (matchMedia unavailable → isDark returns false)
+      expect(() => coreStore.syncOsTheme()).not.toThrow();
+      expect(coreStore.theme).toBe('light');
     });
   });
 


### PR DESCRIPTION
## Summary

- SEO prerender (Puppeteer headless) bakes the light theme because `window.matchMedia('(prefers-color-scheme: dark)')` is always `false` at build time — a downstream with `seo.prerender.enabled: true` and `vuetify.theme.dark: 'auto'` ships a light-locked production site.
- Adds `syncOsTheme()` action to `core.store.js` that re-reads the real OS preference via `matchMedia` (no-op for explicit `'light'`/`'dark'` configs).
- Calls `coreStore.syncOsTheme()` in `main.js` immediately after client bootstrap (post-hydration), and attaches a `change` listener so live OS preference switches propagate without a reload.
- 5 new unit tests covering: auto+dark OS → dark, auto+light OS → light, non-auto no-op, matchMedia absent graceful fallback.

Closes #4230

## Test plan

- [x] `vitest run src/modules/core/tests/core.store.unit.tests.js` — 36/36 pass (5 new)
- [x] ESLint clean on all 3 changed files
- [x] Pre-push critical-review: **OK** (0 critical, 0 high, 1 low/nit)
- [ ] CI green on this PR
- [ ] Visual verification: downstream with `prerender.enabled: true` + `dark: 'auto'` on dark OS — confirm no light flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dark theme now automatically syncs with your operating system when theme is set to "auto" and updates in real time as system preference changes.

* **Tests**
  * Added tests covering synchronization behavior across initial hydration, OS preference changes, explicit theme settings, and environments without matchMedia.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->