### PR TITLE
fix(configGuard): warn-only by default, opt-in strict flag

### DIFF
--- a/src/lib/helpers/configGuard.js
+++ b/src/lib/helpers/configGuard.js
@@ -16,33 +16,51 @@ const DEV_PORTS = new Set(['3000', '3001', '3010', '4000', '5000', '8000', '8080
  * Validate that the application config is fully loaded (not the placeholder)
  * and does not contain dev-default API coordinates in production builds.
  *
- * In production mode:
- *   - A missing/placeholder config is a fatal error (SEO plugins need real values).
- *   - api.host must not be localhost or 127.0.0.1.
- *   - api.port must not be a well-known local dev port.
- * In development/test mode the function is a no-op.
+ * Behavior in production mode:
+ *   - By DEFAULT (warn-only): logs a console.warn for each violation and continues.
+ *     This preserves the '{project}.config.js as local-usable template, overridden at
+ *     build time via Docker build-args' pattern used by some downstreams (e.g. pierreb_vue).
+ *   - STRICT (opt-in): pass `strict: true` or set DEVKIT_VUE_assert_strict=true in the
+ *     build environment and read it in vite.config.js before calling this function.
+ *     Recommended for projects that were burned by a dev-default leak (e.g. trawl_vue#949).
  *
- * @param {object} config - The resolved application config object.
- * @param {string} mode   - Vite build mode (e.g. 'production', 'development').
+ * In development/test mode the function is always a no-op.
+ *
+ * @param {object}  config          - The resolved application config object.
+ * @param {string}  mode            - Vite build mode (e.g. 'production', 'development').
+ * @param {object}  [options]       - Optional settings.
+ * @param {boolean} [options.strict=false] - When true, violations throw instead of warn.
+ *   Activate via `{ strict: process.env.DEVKIT_VUE_assert_strict === 'true' }` in
+ *   vite.config.js (Node context where process.env is available).
  * @returns {void}
- * @throws {Error} When mode is 'production' and config is invalid or contains dev defaults.
+ * @throws {Error} Only when mode is 'production', options.strict is true, and config is
+ *   invalid or contains dev defaults.
  */
-export const assertConfigLoaded = (config, mode) => {
+export const assertConfigLoaded = (config, mode, { strict = false } = {}) => {
   if (mode !== 'production') return;
+
+  /**
+   * Report a violation — throw in strict mode, warn otherwise.
+   * @param {string} message - Human-readable violation description.
+   */
+  const report = (message) => {
+    if (strict) throw new Error(message);
+    console.warn(message);
+  };
 
   const safeConfig = config || CONFIG_PLACEHOLDER;
   const isPlaceholder =
     safeConfig === CONFIG_PLACEHOLDER || (Object.keys(safeConfig).length === 1 && safeConfig.port === 8080 && !safeConfig.host);
   if (isPlaceholder) {
-    throw new Error(
-      'Production build requires a valid config. Run `npm run generateConfig` to generate src/config/index.js before building.',
-    );
+    report('Production build requires a valid config. Run `npm run generateConfig` to generate src/config/index.js before building.');
+    // In warn mode, a placeholder config means no api object to inspect — bail early.
+    if (!strict) return;
   }
 
   // Guard against dev-default API host leaking into a prod bundle (trawl_vue#949).
   const apiHost = String(safeConfig?.api?.host || '').trim().toLowerCase();
   if (apiHost && DEV_HOSTS.has(apiHost)) {
-    throw new Error(
+    report(
       `Production build has dev-default API host/hostname "${safeConfig?.api?.host}". ` +
         'Set DEVKIT_VUE_api_host to the real host/hostname before building.',
     );
@@ -51,7 +69,7 @@ export const assertConfigLoaded = (config, mode) => {
   // Guard against dev-default API port leaking into a prod bundle (trawl_vue#949).
   const apiPort = String(safeConfig?.api?.port || '').trim();
   if (apiPort && DEV_PORTS.has(apiPort)) {
-    throw new Error(
+    report(
       `Production build has dev-default API port "${apiPort}". ` +
         'Set DEVKIT_VUE_api_port to "" (empty) or the real port before building.',
     );

--- a/src/lib/helpers/tests/configGuard.unit.tests.js
+++ b/src/lib/helpers/tests/configGuard.unit.tests.js
@@ -1,95 +1,144 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { assertConfigLoaded, CONFIG_PLACEHOLDER } from '../configGuard.js';
 
+// ── Fixture configs ────────────────────────────────────────────────────────
+
+const VALID_CONFIG = { api: { host: 'api.example.com', port: '' } };
+const VALID_CONFIG_WITH_URL = { port: 8080, host: 'https://example.com', api: { url: '/api' } };
+const DEV_HOST_CONFIG = { api: { host: 'localhost', port: '' } };
+const DEV_PORT_CONFIG = { api: { host: 'api.example.com', port: '3010' } };
+
+// Shorthand helpers to keep assertions concise.
+const defaultCall = (config) => () => assertConfigLoaded(config, 'production');
+const strictCall = (config) => () => assertConfigLoaded(config, 'production', { strict: true });
+
 describe('configGuard – assertConfigLoaded', () => {
-  it('should throw when mode is production and config is the placeholder', () => {
-    expect(() => assertConfigLoaded(CONFIG_PLACEHOLDER, 'production')).toThrow(
-      'Production build requires a valid config',
-    );
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
-  it('should throw when mode is production and config looks like the placeholder', () => {
-    expect(() => assertConfigLoaded({ port: 8080 }, 'production')).toThrow(
-      'Production build requires a valid config',
-    );
-  });
+  // ── No-op in non-production modes ─────────────────────────────────────────
 
-  it('should not throw when mode is production and config is fully loaded', () => {
-    const realConfig = { port: 8080, host: 'https://example.com', api: { url: '/api' } };
-    expect(() => assertConfigLoaded(realConfig, 'production')).not.toThrow();
-  });
-
-  it('should not throw when mode is development and config is the placeholder', () => {
+  it('should not throw and should not warn when mode is development and config is the placeholder', () => {
     expect(() => assertConfigLoaded(CONFIG_PLACEHOLDER, 'development')).not.toThrow();
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
-  it('should not throw when mode is development and config is fully loaded', () => {
+  it('should not throw and should not warn when mode is development and config is fully loaded', () => {
     const realConfig = { port: 3000, host: 'http://localhost' };
     expect(() => assertConfigLoaded(realConfig, 'development')).not.toThrow();
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
-  it('should throw when mode is production and config is null', () => {
-    expect(() => assertConfigLoaded(null, 'production')).toThrow(
-      'Production build requires a valid config',
-    );
+  // ── Default mode (warn-only, strict not set) ───────────────────────────────
+
+  describe('default mode — warns, does NOT throw', () => {
+    it('does NOT throw for placeholder config — warns instead', () => {
+      expect(defaultCall(CONFIG_PLACEHOLDER)).not.toThrow();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Production build requires a valid config'));
+    });
+
+    it('does NOT throw for config shaped like placeholder ({ port: 8080 }) — warns instead', () => {
+      expect(defaultCall({ port: 8080 })).not.toThrow();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Production build requires a valid config'));
+    });
+
+    it('does NOT throw for null config — warns instead', () => {
+      expect(defaultCall(null)).not.toThrow();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Production build requires a valid config'));
+    });
+
+    it('does NOT throw for undefined config — warns instead', () => {
+      expect(defaultCall(undefined)).not.toThrow();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Production build requires a valid config'));
+    });
+
+    it('does NOT throw for dev-host config — warns instead', () => {
+      expect(defaultCall(DEV_HOST_CONFIG)).not.toThrow();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('dev-default API host'));
+    });
+
+    it('does NOT throw for dev-port config — warns instead', () => {
+      expect(defaultCall(DEV_PORT_CONFIG)).not.toThrow();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('dev-default API port'));
+    });
+
+    it('does NOT throw and does NOT warn for a clean production config', () => {
+      expect(defaultCall(VALID_CONFIG)).not.toThrow();
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('does NOT throw and does NOT warn for a multi-field config with a real host', () => {
+      expect(defaultCall(VALID_CONFIG_WITH_URL)).not.toThrow();
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('does NOT throw and still warns when strict is explicitly false', () => {
+      expect(() => assertConfigLoaded(DEV_HOST_CONFIG, 'production', { strict: false })).not.toThrow();
+      expect(console.warn).toHaveBeenCalled();
+    });
   });
 
-  it('should throw when mode is production and config is undefined', () => {
-    expect(() => assertConfigLoaded(undefined, 'production')).toThrow(
-      'Production build requires a valid config',
-    );
-  });
+  // ── Strict mode (opt-in via { strict: true }) ──────────────────────────────
+  // In vite.config.js (Node context) callers activate this with:
+  //   assertConfigLoaded(appConfig, mode, { strict: process.env.DEVKIT_VUE_assert_strict === 'true' })
 
-  // DEV_HOSTS / DEV_PORTS leak-detection tests (incident ref: trawl_vue #949 — signin-broken :3010 outage)
+  describe('strict mode — { strict: true } — throws', () => {
+    it('should throw when config is the CONFIG_PLACEHOLDER sentinel', () => {
+      expect(strictCall(CONFIG_PLACEHOLDER)).toThrow('Production build requires a valid config');
+    });
 
-  it('throws in production when api.host is localhost', () => {
-    expect(() =>
-      assertConfigLoaded({ api: { host: 'localhost', port: '' } }, 'production'),
-    ).toThrow('dev-default API host');
-  });
+    it('should throw when config looks like the placeholder ({ port: 8080 })', () => {
+      expect(strictCall({ port: 8080 })).toThrow('Production build requires a valid config');
+    });
 
-  it('throws in production when api.host is 127.0.0.1', () => {
-    expect(() =>
-      assertConfigLoaded({ api: { host: '127.0.0.1', port: '' } }, 'production'),
-    ).toThrow('dev-default API host');
-  });
+    it('should throw when config is null', () => {
+      expect(strictCall(null)).toThrow('Production build requires a valid config');
+    });
 
-  it('throws in production when api.port is a dev port', () => {
-    expect(() =>
-      assertConfigLoaded({ api: { host: 'api.example.com', port: '3010' } }, 'production'),
-    ).toThrow('dev-default API port');
-  });
+    it('should throw when config is undefined', () => {
+      expect(strictCall(undefined)).toThrow('Production build requires a valid config');
+    });
 
-  it('throws in production when api.port is 3000', () => {
-    expect(() =>
-      assertConfigLoaded({ api: { host: 'api.example.com', port: '3000' } }, 'production'),
-    ).toThrow('dev-default API port');
-  });
+    // DEV_HOSTS / DEV_PORTS leak-detection (incident ref: trawl_vue #949 — signin-broken :3010 outage)
 
-  it('does not throw in production with valid config (real host + empty port)', () => {
-    expect(() =>
-      assertConfigLoaded({ api: { host: 'api.example.com', port: '' } }, 'production'),
-    ).not.toThrow();
-  });
+    it('throws in production when api.host is localhost', () => {
+      expect(strictCall({ api: { host: 'localhost', port: '' } })).toThrow('dev-default API host');
+    });
 
-  it('does not throw in production with valid config (real host + no port key)', () => {
-    expect(() =>
-      assertConfigLoaded({ api: { host: 'api.example.com' } }, 'production'),
-    ).not.toThrow();
-  });
+    it('throws in production when api.host is 127.0.0.1', () => {
+      expect(strictCall({ api: { host: '127.0.0.1', port: '' } })).toThrow('dev-default API host');
+    });
 
-  // Normalization regression tests: case and whitespace must not bypass guards.
+    it('throws in production when api.port is a dev port (3010)', () => {
+      expect(strictCall({ api: { host: 'api.example.com', port: '3010' } })).toThrow('dev-default API port');
+    });
 
-  it('throws in production when api.host is "LOCALHOST" (uppercase bypass attempt)', () => {
-    expect(() =>
-      assertConfigLoaded({ api: { host: 'LOCALHOST', port: '' } }, 'production'),
-    ).toThrow('dev-default API host');
-  });
+    it('throws in production when api.port is 3000', () => {
+      expect(strictCall({ api: { host: 'api.example.com', port: '3000' } })).toThrow('dev-default API port');
+    });
 
-  it('throws in production when api.port is " 3000 " (padded bypass attempt)', () => {
-    expect(() =>
-      assertConfigLoaded({ api: { host: 'api.example.com', port: ' 3000 ' } }, 'production'),
-    ).toThrow('dev-default API port');
+    it('does not throw in production with valid config (real host + empty port)', () => {
+      expect(strictCall({ api: { host: 'api.example.com', port: '' } })).not.toThrow();
+    });
+
+    it('does not throw in production with valid config (real host + no port key)', () => {
+      expect(strictCall({ api: { host: 'api.example.com' } })).not.toThrow();
+    });
+
+    // Normalization regression: case and whitespace must not bypass guards.
+
+    it('throws in production when api.host is "LOCALHOST" (uppercase bypass attempt)', () => {
+      expect(strictCall({ api: { host: 'LOCALHOST', port: '' } })).toThrow('dev-default API host');
+    });
+
+    it('throws in production when api.port is " 3000 " (padded bypass attempt)', () => {
+      expect(strictCall({ api: { host: 'api.example.com', port: ' 3000 ' } })).toThrow('dev-default API port');
+    });
+
+    it('should not throw when mode is production and config is fully loaded', () => {
+      expect(strictCall(VALID_CONFIG_WITH_URL)).not.toThrow();
+    });
   });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,7 +19,7 @@ try {
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  assertConfigLoaded(appConfig, mode);
+  assertConfigLoaded(appConfig, mode, { strict: process.env.DEVKIT_VUE_assert_strict === 'true' });
   return {
     plugins: [
       seoInjectPlugin(appConfig),


### PR DESCRIPTION
## Summary

- `assertConfigLoaded` now accepts `{ strict: boolean }` (default `false`); violations **warn** instead of throw in default mode
- Strict (throw) path fully preserved — activated via `{ strict: process.env.DEVKIT_VUE_assert_strict === 'true' }` in `vite.config.js` (Node context where `process` is available)
- `vite.config.js` wired to read `DEVKIT_VUE_assert_strict` env var and pass it as the `strict` flag
- Tests: 11 default-mode cases (warn, never throw) + 13 strict-mode cases (throw on all violation paths) — 24 total, all green
- Lint: clean (no `process` usage in `src/` browser-linted files)

This resolves the downstream divergence: `pierreb_vue` skips the guard call entirely as a workaround (#438); warn-by-default removes the need for that skip. Trawl (burned by `:3010` outage, trawl_vue#949) sets `DEVKIT_VUE_assert_strict=true` in CI to keep the hard-block.

Closes #4258

## Test plan

- [ ] `npm run test:unit` — 24 configGuard tests pass, full suite delta-neutral vs baseline
- [ ] `npm run lint` — no issues
- [ ] Downstream: `pierreb_vue` removes the `assertConfigLoaded` skip in `vite.config.js` and CI stays green without the env var set
- [ ] Downstream: `trawl_vue` sets `DEVKIT_VUE_assert_strict=true` in CI and CI stays red on bad configs (strict path intact)