### PR TITLE
feat(footer): display app version from DEVKIT_VUE_app_version build-arg

### DIFF
--- a/src/config/defaults/development.config.js
+++ b/src/config/defaults/development.config.js
@@ -9,6 +9,7 @@ export default {
     logoFile: null, // Optional: path to SVG/PNG (e.g. '/images/logo.svg' in /public) for a branded sidenav logo — takes precedence over icon
     lang: 'en', // html lang attribute — 'en' | 'fr' | 'de' | 'es' | etc.
     url: 'http://localhost:8080', // canonical base URL — override in production
+    version: 'dev', // app release version — overridden at build time via DEVKIT_VUE_app_version build-arg
     notFound: {
       title: 'Page Not Found', // heading displayed on the 404 page
       message: 'The page you are looking for does not exist.', // body text below the heading

--- a/src/modules/core/components/core.footer.component.vue
+++ b/src/modules/core/components/core.footer.component.vue
@@ -23,6 +23,15 @@
         </v-col>
       </v-row>
     </v-container>
+    <v-container v-if="appVersion" class="px-4 py-2 text-center">
+      <component
+        :is="appVersionHref ? 'a' : 'span'"
+        v-bind="appVersionHref ? { href: appVersionHref, target: '_blank', rel: 'noopener noreferrer' } : {}"
+        class="text-label-small text-medium-emphasis footer-version"
+      >
+        {{ appVersion }}
+      </component>
+    </v-container>
   </v-footer>
 </template>
 
@@ -89,6 +98,39 @@ export default {
       };
     },
     /**
+     * @desc Resolved display string for the app version badge.
+     * Returns `null` when no version is configured so the element is omitted.
+     * @returns {string|null}
+     */
+    appVersion() {
+      const v = this.config?.app?.version;
+      if (!v) return null;
+      // Prefix semver tags with 'v' when not already prefixed
+      if (/^\d/.test(v)) return `v${v}`;
+      return v;
+    },
+    /**
+     * @desc Href for the version badge link. Links to the GitHub tag when the
+     * version looks like a semver release; links to the commit when it looks
+     * like a `dev-<sha>` string. Returns `null` otherwise (e.g. plain `'dev'`).
+     * @returns {string|null}
+     */
+    appVersionHref() {
+      const v = this.config?.app?.version;
+      const repoUrl = this.config?.app?.repository;
+      if (!v || !repoUrl) return null;
+      // Guard: only allow https:// repository URLs (defense-in-depth, build-time config)
+      if (!repoUrl.startsWith('https://')) return null;
+      // Normalise: strip leading 'v' before testing (some CI tools prefix the tag)
+      const bare = v.replace(/^v/, '');
+      // e.g. "1.36.0" or "v1.36.0" → link to GitHub releases tag
+      if (/^\d+\.\d+\.\d+$/.test(bare)) return `${repoUrl}/releases/tag/v${bare}`;
+      // e.g. "dev-abc1234" → link to GitHub commit
+      const shaMatch = bare.match(/^dev-([0-9a-f]{7,40})$/i);
+      if (shaMatch) return `${repoUrl}/commit/${shaMatch[1]}`;
+      return null;
+    },
+    /**
      * @desc Combines the prop-provided footer links with sections registered by
      * optional modules via `useFooterExtras`. Extras whose title matches an
      * existing config-driven section are merged into that section (items
@@ -151,5 +193,15 @@ export default {
 <style>
 .footer {
   position: relative !important;
+}
+
+.footer-version {
+  font-size: 0.7rem;
+  text-decoration: none;
+  opacity: 0.6;
+}
+
+.footer-version:hover {
+  opacity: 1;
 }
 </style>

--- a/src/modules/core/components/tests/core.footer.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.footer.component.unit.tests.js
@@ -53,6 +53,77 @@ const mountFooter = (config) =>
     },
   });
 
+describe('core.footer.component — app version badge', () => {
+  beforeEach(() => {
+    const { extras } = useFooterExtras();
+    extras.value = [];
+  });
+
+  it('renders the version badge when config.app.version is set', () => {
+    const wrapper = mountFooter({ ...baseConfig(), app: { version: '1.36.0' } });
+    expect(wrapper.text()).toContain('v1.36.0');
+  });
+
+  it('prefixes bare semver with v', () => {
+    const wrapper = mountFooter({ ...baseConfig(), app: { version: '2.0.1' } });
+    expect(wrapper.text()).toContain('v2.0.1');
+  });
+
+  it('renders dev version as-is when passed as dev-<sha>', () => {
+    const wrapper = mountFooter({ ...baseConfig(), app: { version: 'dev-abc1234' } });
+    expect(wrapper.text()).toContain('dev-abc1234');
+  });
+
+  it('renders plain "dev" string as-is', () => {
+    const wrapper = mountFooter({ ...baseConfig(), app: { version: 'dev' } });
+    expect(wrapper.text()).toContain('dev');
+  });
+
+  it('does not render a version badge when config.app.version is absent', () => {
+    const wrapper = mountFooter(baseConfig());
+    // No version in baseConfig — appVersion computed returns null → badge text absent
+    expect(wrapper.vm.appVersion).toBeNull();
+    expect(wrapper.text()).not.toMatch(/^v\d/);
+  });
+
+  it('appVersionHref is null when config.app.repository is absent', () => {
+    const wrapper = mountFooter({ ...baseConfig(), app: { version: '1.0.0' } });
+    expect(wrapper.vm.appVersionHref).toBeNull();
+  });
+
+  it('appVersionHref points to GitHub tag for semver release when repository is set', () => {
+    const wrapper = mountFooter({
+      ...baseConfig(),
+      app: { version: '1.36.0', repository: 'https://github.com/org/repo' },
+    });
+    expect(wrapper.vm.appVersionHref).toBe('https://github.com/org/repo/releases/tag/v1.36.0');
+  });
+
+  it('appVersionHref normalises v-prefixed version (v1.2.3) to same tag href as unprefixed', () => {
+    const wrapper = mountFooter({
+      ...baseConfig(),
+      app: { version: 'v1.36.0', repository: 'https://github.com/org/repo' },
+    });
+    expect(wrapper.vm.appVersionHref).toBe('https://github.com/org/repo/releases/tag/v1.36.0');
+  });
+
+  it('appVersionHref points to GitHub commit for dev-<sha> version when repository is set', () => {
+    const wrapper = mountFooter({
+      ...baseConfig(),
+      app: { version: 'dev-abc1234f', repository: 'https://github.com/org/repo' },
+    });
+    expect(wrapper.vm.appVersionHref).toBe('https://github.com/org/repo/commit/abc1234f');
+  });
+
+  it('appVersionHref is null when repository does not start with https://', () => {
+    const wrapper = mountFooter({
+      ...baseConfig(),
+      app: { version: '1.0.0', repository: 'http://github.com/org/repo' },
+    });
+    expect(wrapper.vm.appVersionHref).toBeNull();
+  });
+});
+
 describe('core.footer.component — registry extras', () => {
   beforeEach(() => {
     // Clear any extras registered by previous tests


### PR DESCRIPTION
Closes #4259

## Summary
- Adds `config.app.version` field (default `'dev'`) to the development config, mapped at build time from the `DEVKIT_VUE_app_version` build-arg via the existing `generateConfig.js` `DEVKIT_VUE_*` → config convention.
- Footer renders a version badge (e.g. `v1.36.0`) when `config.app.version` is set; omitted when absent.
- Optional link to GitHub releases tag (semver) or commit (`dev-<sha>`) when `config.app.repository` is configured; https-only guard.
- v-prefixed versions (e.g. `v1.36.0` from some CI pipelines) are normalised correctly.
- 10 new unit tests covering all code paths.

## Test plan
- [ ] `npm run test:unit` — all footer tests green (16 pass in the footer suite)
- [ ] `npm run lint` — no issues
- [ ] Downstream wiring: companion issue trawl_vue #990 passes `DEVKIT_VUE_app_version` in `build.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application version badge now displays in the footer, providing visibility of the current app version.
  * The version badge intelligently links to corresponding GitHub release pages or commit history based on version format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->