### PR TITLE
fix(billing): nav compute gauge — admin ∞ display + login refresh (#4260, #4261)

### DIFF
--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -139,7 +139,7 @@ export const useAuthStore = defineStore('auth', {
         // populates without waiting for mount/focus (guard: only when meterMode is on).
         if (this.serverConfig?.billing?.meterMode === true) {
           const billingStore = useBillingStore();
-          billingStore.fetchUsageMeter().catch(() => {});
+          billingStore.fetchUsageMeter().catch((err) => { console.error('[auth] fetchUsageMeter on signin failed:', err); });
         }
 
         // PostHog identify on signin

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -5,6 +5,7 @@ import { defineStore } from 'pinia';
 import axios from '../../../lib/services/axios';
 import config from '../../../lib/services/config';
 import { useCoreStore } from '../../core/stores/core.store';
+import { useBillingStore } from '../../billing/stores/billing.store';
 import { updateAbilities } from '../../../lib/helpers/ability';
 import { capture, identify, reset as analyticsReset } from '../../../lib/helpers/analytics';
 
@@ -133,6 +134,13 @@ export const useAuthStore = defineStore('auth', {
         if (res.data.pendingRequests) this.pendingRequests = res.data.pendingRequests;
 
         coreStore.refreshNav(this.isLoggedIn);
+
+        // Refresh compute meter immediately on login so the sidenav gauge
+        // populates without waiting for mount/focus (guard: only when meterMode is on).
+        if (this.serverConfig?.billing?.meterMode === true) {
+          const billingStore = useBillingStore();
+          billingStore.fetchUsageMeter().catch(() => {});
+        }
 
         // PostHog identify on signin
         const u = res.data.user;

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useAuthStore, deduceNamesFromEmail } from '../stores/auth.store';
+import { useBillingStore } from '../../billing/stores/billing.store';
 import axios from '../../../lib/services/axios';
 import config from '../../../lib/services/config';
 
@@ -263,6 +264,71 @@ describe('Auth Store', () => {
       expect(consoleErrorSpy).toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
+    });
+
+    // ── #4261 — fetchUsageMeter called on signin when meterMode is on ────────
+
+    it('calls billingStore.fetchUsageMeter after signin when meterMode is true (#4261)', async () => {
+      const authStore = useAuthStore();
+      // Pre-set serverConfig with meterMode enabled (simulates router guard having run before login)
+      authStore.serverConfig = { billing: { meterMode: true } };
+
+      const mockResponse = {
+        data: {
+          user: { id: '123', email: 'test@test.com', roles: ['user'] },
+          tokenExpiresIn: Date.now() + 3600000,
+        },
+      };
+      axios.post.mockResolvedValueOnce(mockResponse);
+      // fetchUsageMeter uses GET /billing/usage — stub to avoid throwing
+      axios.get.mockResolvedValue({ data: { data: { meterUsed: 0, meterQuota: 500 } } });
+
+      const billingStore = useBillingStore();
+      const fetchUsageMeterSpy = vi.spyOn(billingStore, 'fetchUsageMeter');
+
+      await authStore.signin({ email: 'test@test.com', password: 'password' });
+
+      expect(fetchUsageMeterSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call billingStore.fetchUsageMeter after signin when meterMode is false (#4261)', async () => {
+      const authStore = useAuthStore();
+      authStore.serverConfig = { billing: { meterMode: false } };
+
+      const mockResponse = {
+        data: {
+          user: { id: '123', email: 'test@test.com', roles: ['user'] },
+          tokenExpiresIn: Date.now() + 3600000,
+        },
+      };
+      axios.post.mockResolvedValueOnce(mockResponse);
+
+      const billingStore = useBillingStore();
+      const fetchUsageMeterSpy = vi.spyOn(billingStore, 'fetchUsageMeter');
+
+      await authStore.signin({ email: 'test@test.com', password: 'password' });
+
+      expect(fetchUsageMeterSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call billingStore.fetchUsageMeter after signin when serverConfig is null (#4261)', async () => {
+      const authStore = useAuthStore();
+      authStore.serverConfig = null;
+
+      const mockResponse = {
+        data: {
+          user: { id: '123', email: 'test@test.com', roles: ['user'] },
+          tokenExpiresIn: Date.now() + 3600000,
+        },
+      };
+      axios.post.mockResolvedValueOnce(mockResponse);
+
+      const billingStore = useBillingStore();
+      const fetchUsageMeterSpy = vi.spyOn(billingStore, 'fetchUsageMeter');
+
+      await authStore.signin({ email: 'test@test.com', password: 'password' });
+
+      expect(fetchUsageMeterSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/billing/components/billing.navComputeGauge.component.vue
+++ b/src/modules/billing/components/billing.navComputeGauge.component.vue
@@ -39,7 +39,7 @@
         </template>
         <!-- Admin: ∞ rainbow label -->
         <v-list-item-title v-if="isAdmin">
-          <span class="admin-rainbow admin-rainbow--text">∞</span>
+          <span class="admin-rainbow admin-rainbow--text" aria-hidden="true">∞</span>
         </v-list-item-title>
         <v-list-item-title v-else>{{ usageMeter ? `${pctUsed}% used` : '—' }}</v-list-item-title>
       </v-list-item>

--- a/src/modules/billing/components/billing.navComputeGauge.component.vue
+++ b/src/modules/billing/components/billing.navComputeGauge.component.vue
@@ -6,6 +6,7 @@
   reflecting consumption level.
 
   Hover tooltip exposes the precise figures: "X / Y compute · resets <day>".
+  Admin users see a permanent ∞ rainbow state (no quota applies).
 
   Click → navigates to /users/billing.
   Auto-fetches on mount + on window.focus.
@@ -18,13 +19,17 @@
       <v-list-item
         v-bind="tooltipProps"
         :to="'/users/billing'"
-        :aria-label="`Compute usage: ${usageMeter ? pctUsed + '% used' : '—'}`"
+        :aria-label="isAdmin ? 'Compute usage: unlimited (admin)' : `Compute usage: ${usageMeter ? pctUsed + '% used' : '—'}`"
         aria-haspopup="true"
         :aria-expanded="tooltipOpen ? 'true' : 'false'"
         @touchstart.passive="onTouchActivate"
       >
         <template #prepend>
+          <!-- Admin: rainbow circular indicator (full ring) -->
+          <div v-if="isAdmin" class="nav-gauge-admin-ring me-8" aria-hidden="true" />
+          <!-- Standard: color-coded progress ring -->
           <v-progress-circular
+            v-else
             :model-value="pctUsed"
             :color="iconColor"
             size="24"
@@ -32,11 +37,18 @@
             class="me-8"
           />
         </template>
-        <v-list-item-title>{{ usageMeter ? `${pctUsed}% used` : '—' }}</v-list-item-title>
+        <!-- Admin: ∞ rainbow label -->
+        <v-list-item-title v-if="isAdmin">
+          <span class="admin-rainbow admin-rainbow--text">∞</span>
+        </v-list-item-title>
+        <v-list-item-title v-else>{{ usageMeter ? `${pctUsed}% used` : '—' }}</v-list-item-title>
       </v-list-item>
     </template>
-    <div>{{ usedDisplay }} / {{ totalDisplay }} compute</div>
-    <div v-if="resetLabel">{{ resetLabel }}</div>
+    <div v-if="isAdmin">Admin — unlimited compute</div>
+    <template v-else>
+      <div>{{ usedDisplay }} / {{ totalDisplay }} compute</div>
+      <div v-if="resetLabel">{{ resetLabel }}</div>
+    </template>
   </v-tooltip>
 </template>
 
@@ -74,6 +86,16 @@ export default {
     show() {
       if (!this.authStore.isLoggedIn) return false;
       return this.authStore.serverConfig?.billing?.meterMode === true;
+    },
+
+    /**
+     * @desc True when the authenticated user has the 'admin' role.
+     * Admins have unlimited quota — show ∞ rainbow state instead of a progress ring.
+     * Mirrors the `displayMode === 'admin'` branch in billing.usageBar.component.vue.
+     * @returns {boolean}
+     */
+    isAdmin() {
+      return this.authStore.user?.roles?.includes('admin') === true;
     },
 
     usageMeter() {
@@ -166,3 +188,41 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+/* ── Admin rainbow — reused from billing.usageBar.component ──────────────── */
+.admin-rainbow {
+  background: linear-gradient(
+    90deg,
+    rgb(var(--v-theme-warning)),
+    rgb(var(--v-theme-error)),
+    rgb(var(--v-theme-secondary)),
+    rgb(var(--v-theme-info)),
+    rgb(var(--v-theme-success))
+  );
+}
+
+.admin-rainbow--text {
+  background-clip: text;
+  color: transparent;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* Admin ring: 24×24 filled circle with rainbow gradient (matches VProgressCircular size) */
+.nav-gauge-admin-ring {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: linear-gradient(
+    90deg,
+    rgb(var(--v-theme-warning)),
+    rgb(var(--v-theme-error)),
+    rgb(var(--v-theme-secondary)),
+    rgb(var(--v-theme-info)),
+    rgb(var(--v-theme-success))
+  );
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+</style>

--- a/src/modules/billing/tests/billing.navComputeGauge.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.navComputeGauge.component.unit.tests.js
@@ -401,4 +401,80 @@ describe('BillingNavComputeGaugeComponent', () => {
       expect(wrapper.vm.tooltipOpen).toBe(false);
     });
   });
+
+  // ── #4260 — admin ∞ rainbow display ─────────────────────────────────────
+
+  describe('admin display (#4260)', () => {
+    const setupAdmin = () => {
+      const authStore = useAuthStore();
+      authStore.cookieExpire = Date.now() + 86400000;
+      authStore.serverConfig = { billing: { meterMode: true } };
+      authStore.user = { roles: ['admin'] };
+    };
+
+    it('isAdmin is true when user roles include "admin"', () => {
+      setupAdmin();
+      wrapper = mountComponent();
+      expect(wrapper.vm.isAdmin).toBe(true);
+    });
+
+    it('isAdmin is false when user has no admin role', () => {
+      const authStore = useAuthStore();
+      authStore.cookieExpire = Date.now() + 86400000;
+      authStore.serverConfig = { billing: { meterMode: true } };
+      authStore.user = { roles: ['user'] };
+      wrapper = mountComponent();
+      expect(wrapper.vm.isAdmin).toBe(false);
+    });
+
+    it('isAdmin is false when user is null', () => {
+      const authStore = useAuthStore();
+      authStore.cookieExpire = Date.now() + 86400000;
+      authStore.serverConfig = { billing: { meterMode: true } };
+      authStore.user = null;
+      wrapper = mountComponent();
+      expect(wrapper.vm.isAdmin).toBe(false);
+    });
+
+    it('renders ∞ glyph for admin instead of "X% used"', () => {
+      setupAdmin();
+      wrapper = mountComponent();
+      expect(wrapper.text()).toContain('∞');
+      expect(wrapper.text()).not.toContain('% used');
+      expect(wrapper.text()).not.toContain('—');
+    });
+
+    it('renders admin-rainbow class on the ∞ span', () => {
+      setupAdmin();
+      wrapper = mountComponent();
+      const rainbowSpan = wrapper.find('.admin-rainbow');
+      expect(rainbowSpan.exists()).toBe(true);
+    });
+
+    it('renders .nav-gauge-admin-ring div in prepend slot for admin (not VProgressCircular)', () => {
+      setupAdmin();
+      wrapper = mountComponent();
+      expect(wrapper.find('.nav-gauge-admin-ring').exists()).toBe(true);
+      expect(wrapper.findComponent({ name: 'VProgressCircular' }).exists()).toBe(false);
+    });
+
+    it('renders VProgressCircular (not admin ring) for non-admin users', () => {
+      const authStore = useAuthStore();
+      const billingStore = useBillingStore();
+      authStore.cookieExpire = Date.now() + 86400000;
+      authStore.serverConfig = { billing: { meterMode: true } };
+      authStore.user = { roles: ['user'] };
+      billingStore.usageMeter = { meterUsed: 50, meterQuota: 100, extrasRemaining: 0, weekResetAt: null };
+      wrapper = mountComponent();
+      expect(wrapper.find('.nav-gauge-admin-ring').exists()).toBe(false);
+      expect(wrapper.findComponent({ name: 'VProgressCircular' }).exists()).toBe(true);
+    });
+
+    it('aria-label includes "unlimited (admin)" for admin users', () => {
+      setupAdmin();
+      wrapper = mountComponent();
+      const listItem = wrapper.findComponent({ name: 'VListItem' });
+      expect(listItem.attributes('aria-label')).toMatch(/unlimited.*admin/i);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **#4260 — admin ∞ display:** `billing.navComputeGauge.component.vue` had no admin branch — admins fell through to generic `—`/0% path. Added `isAdmin` computed (`user.roles.includes('admin')`) and ported the rainbow ∞ pattern from `billing.usageBar.component.vue`: rainbow ring in `#prepend` + `∞` glyph with `admin-rainbow` gradient + tooltip reads "Admin — unlimited compute". `aria-label` also updated for admins.
- **#4261 — login refresh:** After in-app signin the gauge was stale (empty until mount/focus). Added `billingStore.fetchUsageMeter()` call in `auth.store.js` `signin()` action, guarded by `serverConfig.billing.meterMode === true`. Fire-and-forget (`.catch` logs but does not block). Existing mount + window.focus fetches remain.

## Test coverage

- 8 new `billing.navComputeGauge.component.unit.tests.js` tests: `isAdmin` true/false/null, ∞ render, rainbow CSS class, admin ring vs VProgressCircular, aria-label
- 3 new `auth.store.unit.tests.js` tests: `fetchUsageMeter` called when `meterMode=true`, NOT called when `meterMode=false`, NOT called when `serverConfig=null`
- All 120 affected tests pass; 6 pre-existing failures on master are unrelated (snapshot drift + home config — verified by stash comparison)

## Test plan

- [ ] Verify gauge shows `∞` rainbow in sidenav for admin user
- [ ] Verify gauge shows % ring for non-admin users
- [ ] Verify gauge populates immediately after in-app login (no manual refresh needed)
- [ ] Verify gauge still populates on mount / window.focus for non-login paths

Closes #4260
Closes #4261