### PR TITLE
feat(seo): config-driven llms.txt generator in seo-static plugin

### DIFF
--- a/src/config/defaults/test.config.js
+++ b/src/config/defaults/test.config.js
@@ -35,6 +35,16 @@ export default {
         enabled: true,
         display: 'standalone',
       },
+      llms: {
+        enabled: true,
+        summary: 'Test summary',
+        intro: 'Test intro paragraph.',
+        sections: [
+          { title: 'Links', items: [{ label: 'Home', url: 'https://example.com', note: 'the home page' }] },
+          { title: 'Plain', items: [{ label: 'bullet-only', note: 'no url here' }] },
+        ],
+        body: '## Extra\nsome trailing markdown',
+      },
     },
   },
   vuetify: {

--- a/src/lib/plugins/seo-static.js
+++ b/src/lib/plugins/seo-static.js
@@ -44,6 +44,11 @@ export function seoStaticPlugin(config) {
       if (manifestJson !== null) {
         this.emitFile({ type: 'asset', fileName: 'manifest.json', source: manifestJson });
       }
+
+      const llmsTxt = buildLlmsTxt(seo.llms, app);
+      if (llmsTxt !== null) {
+        this.emitFile({ type: 'asset', fileName: 'llms.txt', source: llmsTxt });
+      }
     },
   };
 }
@@ -149,4 +154,29 @@ export function buildManifestJson(manifestConfig, app) {
   }
 
   return JSON.stringify(manifest, null, 2);
+}
+
+/**
+ * Build llms.txt content from config (https://llmstxt.org/).
+ * Markdown entry point for LLM crawlers / answer engines.
+ *
+ * @param {object|undefined} llmsConfig - llms configuration object
+ * @param {object} app - app-level config (title fallback)
+ * @returns {string|null} llms.txt content or null if disabled
+ */
+export function buildLlmsTxt(llmsConfig, app) {
+  if (!llmsConfig?.enabled) return null;
+  const lines = [`# ${llmsConfig.title || app.title || 'App'}`, ''];
+  if (llmsConfig.summary) lines.push(`> ${llmsConfig.summary}`, '');
+  if (llmsConfig.intro) lines.push(llmsConfig.intro, '');
+  for (const section of llmsConfig.sections || []) {
+    lines.push(`## ${section.title}`);
+    for (const item of section.items || []) {
+      const head = item.url ? `- [${item.label}](${item.url})` : `- ${item.label}`;
+      lines.push(item.note ? `${head}: ${item.note}` : head);
+    }
+    lines.push('');
+  }
+  if (llmsConfig.body) lines.push(llmsConfig.body, '');
+  return `${lines.join('\n').trimEnd()}\n`;
 }

--- a/src/lib/plugins/seo-static.js
+++ b/src/lib/plugins/seo-static.js
@@ -25,7 +25,7 @@ export function seoStaticPlugin(config) {
     },
 
     /**
-     * Emits robots.txt, sitemap.xml, and manifest.json as build assets.
+     * Emits robots.txt, sitemap.xml, manifest.json, and llms.txt as build assets.
      *
      * @returns {void}
      */
@@ -166,12 +166,14 @@ export function buildManifestJson(manifestConfig, app) {
  */
 export function buildLlmsTxt(llmsConfig, app) {
   if (!llmsConfig?.enabled) return null;
-  const lines = [`# ${llmsConfig.title || app.title || 'App'}`, ''];
+  const lines = [`# ${llmsConfig.title || app?.title || 'App'}`, ''];
   if (llmsConfig.summary) lines.push(`> ${llmsConfig.summary}`, '');
   if (llmsConfig.intro) lines.push(llmsConfig.intro, '');
   for (const section of llmsConfig.sections || []) {
+    if (!section.title) continue;
     lines.push(`## ${section.title}`);
     for (const item of section.items || []) {
+      if (!item.label) continue;
       const head = item.url ? `- [${item.label}](${item.url})` : `- ${item.label}`;
       lines.push(item.note ? `${head}: ${item.note}` : head);
     }

--- a/src/lib/plugins/tests/seo-static.unit.tests.js
+++ b/src/lib/plugins/tests/seo-static.unit.tests.js
@@ -294,4 +294,34 @@ describe('buildLlmsTxt', () => {
     expect(out).toContain('## Connect\nstuff');
     expect(out.endsWith('\n')).toBe(true);
   });
+
+  it('does not throw and falls back to "App" when app is undefined', () => {
+    expect(buildLlmsTxt({ enabled: true }, undefined)).toMatch(/^# App\n/);
+  });
+
+  it('skips sections without a title and items without a label', () => {
+    const out = buildLlmsTxt(
+      {
+        enabled: true,
+        title: 'X',
+        sections: [
+          { items: [{ label: 'orphan', note: 'no section title' }] },
+          { title: 'Real', items: [{ note: 'no label' }, { label: 'kept' }] },
+        ],
+      },
+      {},
+    );
+    expect(out).not.toContain('orphan');
+    expect(out).not.toContain('undefined');
+    expect(out).toContain('## Real');
+    expect(out).toContain('- kept');
+  });
+
+  it('renders the test.config fixture correctly', () => {
+    const out = buildLlmsTxt(testConfig.app.seo.llms, testConfig.app);
+    expect(out).toMatch(/^# Test App\n/);
+    expect(out).toContain('> Test summary');
+    expect(out).toContain('## Links');
+    expect(out).toContain('- [Home](https://example.com): the home page');
+  });
 });

--- a/src/lib/plugins/tests/seo-static.unit.tests.js
+++ b/src/lib/plugins/tests/seo-static.unit.tests.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { seoStaticPlugin, buildRobotsTxt, buildSitemapXml, buildManifestJson } from '../seo-static.js';
+import { seoStaticPlugin, buildRobotsTxt, buildSitemapXml, buildManifestJson, buildLlmsTxt } from '../seo-static.js';
 import testConfig from '../../../config/defaults/test.config.js';
 
 describe('seoStaticPlugin', () => {
@@ -17,16 +17,17 @@ describe('seoStaticPlugin', () => {
     expect(plugin.apply({}, { command: 'serve', mode: 'production' })).toBe(false);
   });
 
-  it('emits all three files when all are enabled', () => {
+  it('emits all four files when all are enabled', () => {
     const plugin = seoStaticPlugin(testConfig);
     const emitFile = vi.fn();
     plugin.generateBundle.call({ emitFile });
 
-    expect(emitFile).toHaveBeenCalledTimes(3);
+    expect(emitFile).toHaveBeenCalledTimes(4);
     const fileNames = emitFile.mock.calls.map((c) => c[0].fileName);
     expect(fileNames).toContain('robots.txt');
     expect(fileNames).toContain('sitemap.xml');
     expect(fileNames).toContain('manifest.json');
+    expect(fileNames).toContain('llms.txt');
   });
 
   it('emits nothing when config is empty', () => {
@@ -246,5 +247,51 @@ describe('buildManifestJson', () => {
     const parsed = JSON.parse(result);
     expect(parsed.background_color).toBe('#000000');
     expect(parsed.theme_color).toBe('#ff0000');
+  });
+});
+
+describe('buildLlmsTxt', () => {
+  it('returns null when disabled', () => {
+    expect(buildLlmsTxt({ enabled: false }, {})).toBeNull();
+  });
+
+  it('returns null when config is undefined', () => {
+    expect(buildLlmsTxt(undefined, {})).toBeNull();
+  });
+
+  it('renders the title from config, falling back to app.title', () => {
+    expect(buildLlmsTxt({ enabled: true, title: 'Brand' }, { title: 'AppName' })).toMatch(/^# Brand\n/);
+    expect(buildLlmsTxt({ enabled: true }, { title: 'AppName' })).toMatch(/^# AppName\n/);
+    expect(buildLlmsTxt({ enabled: true }, {})).toMatch(/^# App\n/);
+  });
+
+  it('renders summary as a blockquote and intro as a paragraph', () => {
+    const out = buildLlmsTxt({ enabled: true, title: 'X', summary: 'one-liner', intro: 'a paragraph' }, {});
+    expect(out).toContain('> one-liner');
+    expect(out).toContain('a paragraph');
+  });
+
+  it('renders a section item with a url as a markdown link, with a note suffix', () => {
+    const out = buildLlmsTxt(
+      { enabled: true, title: 'X', sections: [{ title: 'S', items: [{ label: 'Docs', url: 'https://e.com', note: 'the docs' }] }] },
+      {},
+    );
+    expect(out).toContain('## S');
+    expect(out).toContain('- [Docs](https://e.com): the docs');
+  });
+
+  it('renders a section item without a url as a plain bullet', () => {
+    const out = buildLlmsTxt(
+      { enabled: true, title: 'X', sections: [{ title: 'Tools', items: [{ label: 'whoami', note: 'verify auth' }] }] },
+      {},
+    );
+    expect(out).toContain('- whoami: verify auth');
+    expect(out).not.toContain('](');
+  });
+
+  it('appends the body passthrough at the end', () => {
+    const out = buildLlmsTxt({ enabled: true, title: 'X', body: '## Connect\nstuff' }, {});
+    expect(out).toContain('## Connect\nstuff');
+    expect(out.endsWith('\n')).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #4269

## What
Adds a generic, config-driven `buildLlmsTxt(llmsConfig, app)` builder to `src/lib/plugins/seo-static.js`, mirroring `buildRobotsTxt` / `buildSitemapXml` / `buildManifestJson`, and emits `llms.txt` from the `generateBundle` hook (prod build only, gated on config).

## Why
[llms.txt](https://llmstxt.org/) is the emerging LLM/answer-engine site entry point (AEO). Keeping it in the stack plugin lets every downstream project ship its own `llms.txt` **from config**, consistent with how robots/sitemap/manifest are already generated — instead of a hand-maintained `public/llms.txt`.

## Rendering
`# title` (fallback `app.title` → `'App'`), `> summary`, `intro`, per-section `## title` with items as `- [label](url): note` (link) or `- label: note` (bullet), then `body` passthrough; single trailing newline. Sections without a `title` and items without a `label` are skipped (no `undefined` in output); `app` is null-guarded.

## Tests
`src/lib/plugins/tests/seo-static.unit.tests.js` — `describe('buildLlmsTxt')`: disabled→null, undefined→null, title fallback, summary/intro, link-vs-bullet + note, body passthrough + trailing newline, `app=undefined` fallback, malformed-entry skipping, `testConfig` fixture render. Plugin emit-count test updated 3→4. **Generic — zero project-specific strings.**

## Scope
- **Stack (devkit Vue) only.** Generic generator + unit test + test fixture.
- **Out of scope (downstream):** the Trawl `seo.llms` content + `/update-stack` propagation land on GTM driver **C1-1** (board comes-io/projects/3) in `comes-io/trawl_vue`.

---
🤖 First run of the "GTM Engineer generates the issue → the dev flow dépiles it" pattern. Driver: comes-io/projects/3 item C1-1. Plan: `infra/docs/superpowers/plans/2026-06-08-trawl-llms-txt.md`. **Draft — human merge gate (do not self-merge).**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic generation of `llms.txt` file during production builds with configurable options
  * Support for customizing content structure including summary, introduction, sections, and body
  * Ability to enable/disable LLM content generation via configuration settings

* **Tests**
  * Added comprehensive test coverage for the new file generation functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->