### PR TITLE
fix(core): center footer version badge + show backend API version

### DIFF
--- a/src/modules/core/components/core.footer.component.vue
+++ b/src/modules/core/components/core.footer.component.vue
@@ -1,6 +1,6 @@
 <template>
   <v-footer v-if="enabled" class="footer pa-0" :style="footerStyle" app>
-    <v-container v-if="visibleSections.length > 0 || appVersion" class="px-0 py-4" :style="custom && custom.section ? custom.section : null">
+    <v-container v-if="visibleSections.length > 0 || appVersion || backendVersion" class="px-0 py-4" :style="custom && custom.section ? custom.section : null">
       <v-row v-if="visibleSections.length > 0" density="compact" align="center" justify="center">
         <v-col
           v-for="({ items, title }, i) in visibleSections"
@@ -22,14 +22,15 @@
           </v-card>
         </v-col>
       </v-row>
-      <v-row v-if="appVersion" justify="center" class="mt-2">
+      <v-row v-if="appVersion || backendVersion" justify="center" class="mt-2">
         <v-col cols="12" class="text-center py-2">
           <component
             :is="appVersionHref ? 'a' : 'span'"
+            v-if="appVersion"
             v-bind="appVersionHref ? { href: appVersionHref, target: '_blank', rel: 'noopener noreferrer' } : {}"
             class="text-label-small text-medium-emphasis footer-version"
           >Web {{ appVersion }}</component>
-          <span v-if="backendVersion" class="text-label-small text-medium-emphasis footer-version"> · API {{ backendVersion }}</span>
+          <span v-if="backendVersion" class="text-label-small text-medium-emphasis footer-version">{{ appVersion ? ' · ' : '' }}API {{ backendVersion }}</span>
         </v-col>
       </v-row>
     </v-container>

--- a/src/modules/core/components/core.footer.component.vue
+++ b/src/modules/core/components/core.footer.component.vue
@@ -1,12 +1,12 @@
 <template>
-  <v-footer v-if="enabled" class="footer pa-0 align-end" :style="footerStyle" app>
-    <v-container v-if="allLinks.length > 0" class="px-0 py-4" :style="custom && custom.section ? custom.section : null">
-      <v-row density="compact" align="center" justify="center">
+  <v-footer v-if="enabled" class="footer pa-0" :style="footerStyle" app>
+    <v-container v-if="visibleSections.length > 0 || appVersion" class="px-0 py-4" :style="custom && custom.section ? custom.section : null">
+      <v-row v-if="visibleSections.length > 0" density="compact" align="center" justify="center">
         <v-col
-          v-for="({ items, title }, i) in allLinks.filter((section) => section.items)"
+          v-for="({ items, title }, i) in visibleSections"
           :key="i"
           cols="12"
-          :md="12 / allLinks.filter((section) => section.items).length"
+          :md="12 / visibleSections.length"
           class="text-center"
         >
           <v-card color="transparent" :flat="config.vuetify.theme.flat" :style="custom && custom.section ? custom.section : null">
@@ -22,15 +22,16 @@
           </v-card>
         </v-col>
       </v-row>
-    </v-container>
-    <v-container v-if="appVersion" class="px-4 py-2 text-center">
-      <component
-        :is="appVersionHref ? 'a' : 'span'"
-        v-bind="appVersionHref ? { href: appVersionHref, target: '_blank', rel: 'noopener noreferrer' } : {}"
-        class="text-label-small text-medium-emphasis footer-version"
-      >
-        {{ appVersion }}
-      </component>
+      <v-row v-if="appVersion" justify="center" class="mt-2">
+        <v-col cols="12" class="text-center py-2">
+          <component
+            :is="appVersionHref ? 'a' : 'span'"
+            v-bind="appVersionHref ? { href: appVersionHref, target: '_blank', rel: 'noopener noreferrer' } : {}"
+            class="text-label-small text-medium-emphasis footer-version"
+          >Web {{ appVersion }}</component>
+          <span v-if="backendVersion" class="text-label-small text-medium-emphasis footer-version"> · API {{ backendVersion }}</span>
+        </v-col>
+      </v-row>
     </v-container>
   </v-footer>
 </template>
@@ -41,6 +42,7 @@
  */
 import { useTheme } from 'vuetify';
 import { useFooterExtras } from '@/lib/composables/useFooterExtras';
+import { useAuthStore } from '@/modules/auth/stores/auth.store';
 /**
  * Component definition.
  */
@@ -68,7 +70,9 @@ export default {
    */
   setup() {
     const { extras } = useFooterExtras();
-    return { extras };
+    let authStore = null;
+    try { authStore = useAuthStore(); } catch { authStore = null; }
+    return { extras, authStore };
   },
   data() {
     const theme = useTheme();
@@ -154,6 +158,27 @@ export default {
         }
       }
       return result;
+    },
+    /**
+     * @desc Resolved display string for the backend (API) version badge.
+     * Read from the auth store's serverConfig, populated by the public
+     * /api/auth/config endpoint (no login required). Returns `null` when
+     * unavailable so the element is omitted (Pinia inactive, endpoint unreachable).
+     * @returns {string|null}
+     */
+    backendVersion() {
+      const v = this.authStore?.serverConfig?.app?.version;
+      if (!v) return null;
+      if (/^\d/.test(v)) return `v${v}`;
+      return v;
+    },
+    /**
+     * @desc Sections from allLinks that have items, used by the template to
+     * avoid double-filtering (previously called twice inline in the template).
+     * @returns {Array}
+     */
+    visibleSections() {
+      return this.allLinks.filter((section) => section.items);
     },
   },
   watch: {

--- a/src/modules/core/components/tests/core.footer.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.footer.component.unit.tests.js
@@ -16,6 +16,16 @@ vi.mock('vuetify', async (importOriginal) => {
   };
 });
 
+// Mock auth store — avoids pulling in axios/config/ability which aren't available
+// in the unit-test environment. authStoreState is a mutable hoisted object so
+// individual tests can override serverConfig without re-mocking.
+const authStoreState = vi.hoisted(() => ({
+  serverConfig: null,
+}));
+vi.mock('@/modules/auth/stores/auth.store', () => ({
+  useAuthStore: () => authStoreState,
+}));
+
 import CoreFooter from '../core.footer.component.vue';
 
 /**
@@ -57,11 +67,12 @@ describe('core.footer.component — app version badge', () => {
   beforeEach(() => {
     const { extras } = useFooterExtras();
     extras.value = [];
+    authStoreState.serverConfig = null;
   });
 
   it('renders the version badge when config.app.version is set', () => {
     const wrapper = mountFooter({ ...baseConfig(), app: { version: '1.36.0' } });
-    expect(wrapper.text()).toContain('v1.36.0');
+    expect(wrapper.text()).toContain('Web v1.36.0');
   });
 
   it('prefixes bare semver with v', () => {
@@ -129,6 +140,7 @@ describe('core.footer.component — registry extras', () => {
     // Clear any extras registered by previous tests
     const { extras } = useFooterExtras();
     extras.value = [];
+    authStoreState.serverConfig = null;
   });
 
   afterEach(() => {
@@ -216,5 +228,48 @@ describe('core.footer.component — registry extras', () => {
     expect(actionItem).toBeTruthy();
     await actionItem.trigger('click');
     expect(onClick).toHaveBeenCalledOnce();
+  });
+});
+
+describe('core.footer.component — layout + backend version (Parts A + C)', () => {
+  beforeEach(() => {
+    const { extras } = useFooterExtras();
+    extras.value = [];
+    authStoreState.serverConfig = null;
+  });
+
+  afterEach(() => {
+    const { extras } = useFooterExtras();
+    extras.value = [];
+    authStoreState.serverConfig = null;
+  });
+
+  it('Part A — renders exactly ONE v-container when both links and appVersion are present', () => {
+    // Pre-fix the template had two sibling <v-container> elements (one for links, one for version),
+    // causing the version badge to appear beside the columns rather than below them.
+    // After the fix both live inside a single container.
+    // VFooter is stubbed as a plain div, so VContainer renders as a real Vuetify component;
+    // we assert via DOM class (.v-container) rather than findAllComponents to avoid stub
+    // name-resolution quirks — Vuetify renders VContainer with that class reliably.
+    const wrapper = mountFooter({ ...baseConfig(), app: { version: '2.2.0' } });
+    const containers = wrapper.findAll('.v-container');
+    expect(containers.length).toBe(1);
+  });
+
+  it('Part C — renders Web + API versions when auth store has serverConfig', async () => {
+    // authStoreState is the hoisted mock object — mutate before mount so setup()
+    // picks it up. @pinia/testing is not in devDeps; mock is sufficient.
+    authStoreState.serverConfig = { app: { version: '0.4.0' } };
+    const wrapper = mountFooter({ ...baseConfig(), app: { version: '2.2.0' } });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('Web v2.2.0');
+    expect(wrapper.text()).toContain('API v0.4.0');
+  });
+
+  it('Part C — omits API segment when serverConfig is null (pre-login / no backend response)', () => {
+    // authStoreState.serverConfig is null (reset in beforeEach) → backendVersion returns null
+    const wrapper = mountFooter({ ...baseConfig(), app: { version: '1.36.0' } });
+    expect(wrapper.text()).toContain('Web v1.36.0');
+    expect(wrapper.text()).not.toContain('API');
   });
 });

--- a/src/modules/core/components/tests/core.footer.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.footer.component.unit.tests.js
@@ -272,4 +272,18 @@ describe('core.footer.component — layout + backend version (Parts A + C)', () 
     expect(wrapper.text()).toContain('Web v1.36.0');
     expect(wrapper.text()).not.toContain('API');
   });
+
+  it('Part C — renders API version alone (no Web, no leading separator) when frontend version is unset', async () => {
+    // api-only case: backend reports a version but config.app.version is absent.
+    // The version row must still render the API badge, without a "Web" segment and
+    // without a leading "·" separator.
+    authStoreState.serverConfig = { app: { version: '0.4.0' } };
+    const wrapper = mountFooter(baseConfig());
+    await wrapper.vm.$nextTick();
+    const text = wrapper.text();
+    expect(text).toContain('API v0.4.0');
+    expect(text).not.toContain('Web');
+    // No leading separator before the API segment
+    expect(text).not.toMatch(/·\s*API v0\.4\.0/);
+  });
 });


### PR DESCRIPTION
## Summary

- **Part A:** Merged the two sibling `<v-container>` elements into one — previously the version badge rendered in a second container beside the columns, causing it to appear off-center. Now it occupies its own `v-row` inside the single container, centered below the link columns.
- **Part C:** Reads `serverConfig.app.version` from the auth store (populated by the public `/api/auth/config` endpoint) and renders `Web vX.Y.Z · API vZ` in the footer badge. Gracefully omitted when null (pre-login, backend unreachable, Pinia inactive).

Closes #4270

## Scope

- Modules impacted: `core` (footer component + unit tests)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: reads from an already-fetched public endpoint; no extra network call.
- Mergeability considerations: purely additive to the footer component; downstream projects unaffected.
- Follow-up tasks: downstream projects can expose their own backend version via `serverConfig.app.version` once they update the stack.