### PR TITLE
feat(organizations): add-member UI + pending-invitations list + accept (P5b)

### DIFF
--- a/src/modules/organizations/components/organizations.members.component.vue
+++ b/src/modules/organizations/components/organizations.members.component.vue
@@ -1,5 +1,19 @@
 <template>
   <div>
+    <div v-if="canAddMember()" class="d-flex justify-end mb-3">
+      <v-btn
+        color="primary"
+        variant="tonal"
+        :class="config.vuetify.theme.rounded"
+        class="text-none text-body-medium"
+        data-test="org-add-member-open"
+        @click="openAddDialog"
+      >
+        <v-icon icon="fa-solid fa-user-plus" size="small" class="mr-2"></v-icon>
+        Add member
+      </v-btn>
+    </div>
+
     <coreDataTableComponent
       :headers="filteredHeaders"
       :items="members"
@@ -108,6 +122,115 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- Add member dialog: search a user by exact email, then invite them -->
+    <v-dialog v-model="addDialog.show" max-width="480" data-test="org-add-member-dialog">
+      <v-card :class="config.vuetify.theme.rounded" class="pa-4">
+        <v-card-title class="text-title-large font-weight-medium">Add member</v-card-title>
+        <v-card-text class="text-body-medium">
+          <p class="text-medium-emphasis mb-4">
+            Search an existing user by their exact email, then send them an invitation.
+            They'll need to accept before they become a member.
+          </p>
+
+          <v-form @submit.prevent="searchUser">
+            <div class="d-flex align-start ga-2">
+              <v-text-field
+                v-model="addDialog.email"
+                label="Email"
+                type="email"
+                variant="outlined"
+                density="comfortable"
+                autofocus
+                hide-details="auto"
+                data-test="org-add-member-email"
+                :disabled="addDialog.searching"
+                @update:model-value="onEmailInput"
+              ></v-text-field>
+              <v-btn
+                color="primary"
+                variant="tonal"
+                :class="config.vuetify.theme.rounded"
+                class="text-none text-body-medium mt-1"
+                type="submit"
+                :loading="addDialog.searching"
+                :disabled="!addDialog.email"
+                data-test="org-add-member-search"
+              >
+                Search
+              </v-btn>
+            </div>
+          </v-form>
+
+          <!-- Not found -->
+          <v-alert
+            v-if="addDialog.searched && !addDialog.foundUser"
+            type="info"
+            variant="tonal"
+            density="comfortable"
+            class="mt-4 text-body-small"
+            :class="config.vuetify.theme.rounded"
+            data-test="org-add-member-notfound"
+          >
+            No account with that email yet. Invite them to the platform first, then add them here.
+          </v-alert>
+
+          <!-- Found: matched user + role selector -->
+          <div v-if="addDialog.foundUser" class="mt-4" data-test="org-add-member-found">
+            <v-list-item
+              :class="config.vuetify.theme.rounded"
+              class="px-3 py-2 bg-surface-variant"
+            >
+              <template #prepend>
+                <userAvatarComponent :user="addDialog.foundUser" :size="40" class="mr-3" />
+              </template>
+              <v-list-item-title class="text-body-medium font-weight-medium">
+                {{ addDialog.foundUser.displayName || addDialog.foundUser.email }}
+              </v-list-item-title>
+              <v-list-item-subtitle class="text-body-small">{{ addDialog.foundUser.email }}</v-list-item-subtitle>
+            </v-list-item>
+
+            <v-select
+              v-model="addDialog.role"
+              :items="availableRoles"
+              item-title="title"
+              item-value="value"
+              label="Role"
+              variant="outlined"
+              density="comfortable"
+              hide-details="auto"
+              class="mt-4"
+              :class="config.vuetify.theme.rounded"
+              data-test="org-add-member-role"
+            ></v-select>
+          </div>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            variant="text"
+            class="text-none text-body-medium"
+            :disabled="addDialog.adding"
+            @click="addDialog.show = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            v-if="addDialog.foundUser"
+            color="primary"
+            variant="flat"
+            :class="config.vuetify.theme.rounded"
+            class="text-none text-body-medium"
+            :loading="addDialog.adding"
+            data-test="org-add-member-submit"
+            @click="confirmAddMember"
+          >
+            Send invitation
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
@@ -162,6 +285,15 @@ export default {
         currentRole: '',
         newRole: '',
       },
+      addDialog: {
+        show: false,
+        email: '',
+        searching: false,
+        searched: false,
+        foundUser: null,
+        role: (this.config.organizations?.roles || ['member', 'admin'])[0] || 'member',
+        adding: false,
+      },
     };
   },
   computed: {
@@ -213,6 +345,17 @@ export default {
       return false;
     },
     /**
+     * @desc Gate the add-member affordance on the owner/admin CASL ability. Mirrors
+     *       the backend: owners (manage) + admins (create) may add; members cannot.
+     * @returns {boolean}
+     */
+    canAddMember() {
+      if (ability && ability.rules && ability.rules.length > 0) {
+        return ability.can('create', 'Membership');
+      }
+      return false;
+    },
+    /**
      * @desc Open confirmation dialog before changing a member's role.
      * @param {Object} member - Member object
      * @param {string} role - New role value
@@ -256,6 +399,73 @@ export default {
         this.removeDialog.show = false;
       } catch (err) {
         console.error(err);
+      }
+    },
+    /**
+     * @desc Open the add-member dialog with a clean search state.
+     * @returns {void}
+     */
+    openAddDialog() {
+      this.addDialog = {
+        show: true,
+        email: '',
+        searching: false,
+        searched: false,
+        foundUser: null,
+        role: this.availableRoles[0]?.value || 'member',
+        adding: false,
+      };
+    },
+    /**
+     * @desc Reset the result state when the email input changes so a stale
+     *       found/not-found result never lingers against a new email.
+     * @returns {void}
+     */
+    onEmailInput() {
+      this.addDialog.searched = false;
+      this.addDialog.foundUser = null;
+    },
+    /**
+     * @desc Look up a user by exact email. Sets foundUser on a match, or marks
+     *       searched with no foundUser for the not-found state. Errors surface via
+     *       the axios interceptor toast.
+     * @returns {Promise<void>}
+     */
+    async searchUser() {
+      if (!this.addDialog.email || this.addDialog.searching) return;
+      const organizationsStore = useOrganizationsStore();
+      this.addDialog.searching = true;
+      this.addDialog.foundUser = null;
+      try {
+        const match = await organizationsStore.searchUserByEmail(this.organizationId, this.addDialog.email);
+        this.addDialog.foundUser = match || null;
+        this.addDialog.searched = true;
+      } catch {
+        // interceptor handles snackbar; leave searched false so the user can retry
+        this.addDialog.searched = false;
+      } finally {
+        this.addDialog.searching = false;
+      }
+    },
+    /**
+     * @desc Send the invitation (create a pending owner_add membership). On success
+     *       the interceptor toasts "invitation created"; we refresh the member list
+     *       and close the dialog. Already-a-member / already-pending come back as a
+     *       422 the interceptor surfaces — keep the dialog open so the user sees it.
+     * @returns {Promise<void>}
+     */
+    async confirmAddMember() {
+      if (!this.addDialog.foundUser || this.addDialog.adding) return;
+      const organizationsStore = useOrganizationsStore();
+      this.addDialog.adding = true;
+      try {
+        await organizationsStore.addMember(this.organizationId, this.addDialog.foundUser.id, this.addDialog.role);
+        await this.fetchMembers();
+        this.addDialog.show = false;
+      } catch {
+        // interceptor handles snackbar (e.g. already a member / pending)
+      } finally {
+        this.addDialog.adding = false;
       }
     },
   },

--- a/src/modules/organizations/components/organizations.members.component.vue
+++ b/src/modules/organizations/components/organizations.members.component.vue
@@ -143,6 +143,7 @@
                 density="comfortable"
                 autofocus
                 hide-details="auto"
+                :rules="emailRules"
                 data-test="org-add-member-email"
                 :disabled="addDialog.searching"
                 @update:model-value="onEmailInput"
@@ -154,7 +155,7 @@
                 class="text-none text-body-medium mt-1"
                 type="submit"
                 :loading="addDialog.searching"
-                :disabled="!addDialog.email"
+                :disabled="!isValidAddEmail"
                 data-test="org-add-member-search"
               >
                 Search
@@ -273,6 +274,9 @@ export default {
         title: r.charAt(0).toUpperCase() + r.slice(1),
         value: r,
       })),
+      // Email validity rule — mirrors the auth forms' `rules.mail` (signin/signup).
+      // Gates the search so obvious garbage doesn't round-trip to the endpoint.
+      emailRules: [(v) => !v || /\S+@\S+\.\S+/.test(v) || 'E-mail must be valid'],
       removeDialog: {
         show: false,
         memberId: null,
@@ -291,7 +295,9 @@ export default {
         searching: false,
         searched: false,
         foundUser: null,
-        role: (this.config.organizations?.roles || ['member', 'admin'])[0] || 'member',
+        // Set on every open by openAddDialog (the only entry point) from
+        // availableRoles[0] — see defaultRole(). Initialized here for shape only.
+        role: '',
         adding: false,
       },
     };
@@ -309,6 +315,14 @@ export default {
       const isMobile = this.$vuetify.display.smAndDown;
       if (!isMobile) return this.headers;
       return this.headers.filter((h) => !['createdAt', 'userId.lastLoginAt'].includes(h.value));
+    },
+    /**
+     * @desc Whether the typed add-member email is a syntactically valid address.
+     *       Gates the Search button so obvious garbage doesn't hit the endpoint.
+     * @returns {boolean}
+     */
+    isValidAddEmail() {
+      return /\S+@\S+\.\S+/.test((this.addDialog.email || '').trim());
     },
   },
   methods: {
@@ -402,6 +416,14 @@ export default {
       }
     },
     /**
+     * @desc The default role for a new add-member dialog — first available role,
+     *       falling back to 'member'. Single source of truth for the role default.
+     * @returns {string}
+     */
+    defaultRole() {
+      return this.availableRoles[0]?.value || 'member';
+    },
+    /**
      * @desc Open the add-member dialog with a clean search state.
      * @returns {void}
      */
@@ -412,7 +434,7 @@ export default {
         searching: false,
         searched: false,
         foundUser: null,
-        role: this.availableRoles[0]?.value || 'member',
+        role: this.defaultRole(),
         adding: false,
       };
     },
@@ -428,20 +450,29 @@ export default {
     /**
      * @desc Look up a user by exact email. Sets foundUser on a match, or marks
      *       searched with no foundUser for the not-found state. Errors surface via
-     *       the axios interceptor toast.
+     *       the axios interceptor toast. Guards against a stale response: a slower
+     *       earlier search must not overwrite foundUser if the email has since
+     *       changed (fast re-submits) — we capture the requested email (trimmed, to
+     *       match the store's trim) before awaiting and bail if it no longer matches.
      * @returns {Promise<void>}
      */
     async searchUser() {
-      if (!this.addDialog.email || this.addDialog.searching) return;
+      // Guard the submit path too (Enter key bypasses the disabled button): never
+      // round-trip an empty or syntactically-invalid email to the search endpoint.
+      if (!this.isValidAddEmail || this.addDialog.searching) return;
       const organizationsStore = useOrganizationsStore();
+      const reqEmail = this.addDialog.email.trim();
       this.addDialog.searching = true;
       this.addDialog.foundUser = null;
       try {
         const match = await organizationsStore.searchUserByEmail(this.organizationId, this.addDialog.email);
+        // Bail on a stale resolution: the input changed while this request was in flight.
+        if (this.addDialog.email.trim() !== reqEmail) return;
         this.addDialog.foundUser = match || null;
         this.addDialog.searched = true;
       } catch {
         // interceptor handles snackbar; leave searched false so the user can retry
+        if (this.addDialog.email.trim() !== reqEmail) return;
         this.addDialog.searched = false;
       } finally {
         this.addDialog.searching = false;

--- a/src/modules/organizations/components/organizations.members.component.vue
+++ b/src/modules/organizations/components/organizations.members.component.vue
@@ -270,10 +270,15 @@ export default {
         { text: 'Last Login', value: 'userId.lastLoginAt', kind: 'date', format: 'DD/MM/YY HH:mm' },
         { text: 'Actions', value: 'actions', kind: 'slot', slotName: 'actions' },
       ],
-      availableRoles: (this.config.organizations?.roles || ['member', 'admin', 'owner']).map((r) => ({
-        title: r.charAt(0).toUpperCase() + r.slice(1),
-        value: r,
-      })),
+      // 'owner' is unconditionally excluded: granting owner via the UI is not
+      // allowed (add-member and change-role both use this list). Ownership
+      // transfer is a separate explicit privilege outside this component.
+      availableRoles: (this.config.organizations?.roles || ['member', 'admin', 'owner'])
+        .filter((r) => r !== 'owner')
+        .map((r) => ({
+          title: r.charAt(0).toUpperCase() + r.slice(1),
+          value: r,
+        })),
       // Email validity rule — mirrors the auth forms' `rules.mail` (signin/signup).
       // Gates the search so obvious garbage doesn't round-trip to the endpoint.
       emailRules: [(v) => !v || /\S+@\S+\.\S+/.test(v) || 'E-mail must be valid'],

--- a/src/modules/organizations/stores/organizations.store.js
+++ b/src/modules/organizations/stores/organizations.store.js
@@ -25,6 +25,9 @@ export const useOrganizationsStore = defineStore('organizations', {
     organizations: [],
     members: [],
     adminPendingRequests: [],
+    // Pending owner_add invitations the current user must accept (source:'owner_add').
+    // Fetched on mount of the My Organizations view — the durable, offline-safe surface.
+    pendingInvitations: [],
   }),
 
   actions: {
@@ -340,6 +343,69 @@ export const useOrganizationsStore = defineStore('organizations', {
     async acceptInvite(token) {
       const api = apiBase();
       const res = await axios.post(`${api}/invites/${token}/accept`);
+      return res.data.data;
+    },
+
+    /**
+     * @desc Look up a single user by EXACT email to add them to an organization
+     *       (owner/admin only). Not fuzzy — the caller types a full email. Returns
+     *       `{ id, displayName, email }` on a match, or null when no account exists.
+     * @param {string} organizationId - The organization the owner/admin manages
+     * @param {string} email - The exact email to look up
+     * @returns {Promise<{ id: string, displayName: string, email: string }|null>}
+     */
+    async searchUserByEmail(organizationId, email) {
+      const api = apiBase();
+      const query = new URLSearchParams({ email: (email || '').trim() });
+      const res = await axios.get(`${api}/organizations/${organizationId}/members/search?${query.toString()}`);
+      return res.data.data || null;
+    },
+
+    /**
+     * @desc Add a user to an organization (owner/admin only). Creates a PENDING
+     *       owner_add membership — the invited user is NOT immediately active and
+     *       must accept via acceptMembership. Success/error toast is fired by the
+     *       axios POST interceptor.
+     * @param {string} organizationId - The organization to add the user to
+     * @param {string} userId - The id of the user being added
+     * @param {string} [role] - The role to grant on acceptance (member/admin)
+     * @returns {Promise<Object>} The created pending membership
+     */
+    async addMember(organizationId, userId, role) {
+      const api = apiBase();
+      const body = role ? { userId, role } : { userId };
+      const res = await axios.post(`${api}/organizations/${organizationId}/members`, body);
+      capture('org_member_added', { organization_id: organizationId, role: role || 'member' });
+      return res.data.data;
+    },
+
+    /**
+     * @desc Fetch the current user's own pending owner_add invitations — memberships
+     *       an owner/admin created for them that they must accept. Durable, offline-safe
+     *       surface: fetched on mount so an invitee sees it on their next login.
+     * @returns {Promise<Array>} The user's pending owner_add memberships
+     */
+    async fetchMyPendingInvitations() {
+      const api = apiBase();
+      const res = await axios.get(`${api}/membership-requests/mine/pending`);
+      this.pendingInvitations = res.data.data || [];
+      return this.pendingInvitations;
+    },
+
+    /**
+     * @desc Accept a pending owner_add invitation (the invited user consents),
+     *       flipping the membership PENDING → ACTIVE. Drops it from the local
+     *       pending list on success. Success/error toast is fired by the axios PUT
+     *       interceptor.
+     * @param {string} membershipId - The pending membership to accept
+     * @returns {Promise<Object>} The activated membership
+     */
+    async acceptMembership(membershipId) {
+      const api = apiBase();
+      const res = await axios.put(`${api}/membership-requests/${membershipId}/accept`);
+      this.pendingInvitations = this.pendingInvitations.filter(
+        (inv) => inv.id !== membershipId && inv._id !== membershipId,
+      );
       return res.data.data;
     },
   },

--- a/src/modules/organizations/tests/organizations.members.component.unit.tests.js
+++ b/src/modules/organizations/tests/organizations.members.component.unit.tests.js
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+// ── ability mock (controls the owner/admin CASL gate) ────────────────────────
+const abilityMock = vi.hoisted(() => ({
+  rules: [{ action: 'create', subject: 'Membership' }],
+  can: vi.fn(() => true),
+}));
+vi.mock('../../../lib/helpers/ability', () => ({ ability: abilityMock }));
+
+vi.mock('../../../lib/helpers/roleColor', () => ({ default: () => 'primary' }));
+
+import OrganizationsMembersComponent from '../components/organizations.members.component.vue';
+
+const sharedStubs = {
+  coreDataTableComponent: { template: '<div data-test="datatable" />' },
+  userAvatarComponent: { template: '<div />' },
+  'v-btn': { template: '<button v-bind="$attrs"><slot /></button>', inheritAttrs: false },
+  'v-icon': { template: '<i />' },
+  'v-menu': { template: '<div><slot name="activator" :props="{}" /><slot /></div>' },
+  'v-list': { template: '<div><slot /></div>' },
+  'v-list-item': { template: '<div><slot /></div>' },
+  'v-list-item-title': { template: '<div><slot /></div>' },
+  'v-list-item-subtitle': { template: '<div><slot /></div>' },
+  'v-list-subheader': { template: '<div><slot /></div>' },
+  'v-dialog': { template: '<div><slot /></div>' },
+  'v-card': { template: '<div><slot /></div>' },
+  'v-card-title': { template: '<div><slot /></div>' },
+  'v-card-text': { template: '<div><slot /></div>' },
+  'v-card-actions': { template: '<div><slot /></div>' },
+  'v-spacer': { template: '<div />' },
+  'v-chip': { template: '<div><slot /></div>' },
+  'v-form': { template: '<form @submit="$emit(\'submit\', $event)"><slot /></form>' },
+  'v-text-field': { template: '<input />' },
+  'v-select': { template: '<select />' },
+  'v-alert': { template: '<div><slot /></div>' },
+};
+
+const config = {
+  api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api' },
+  vuetify: { theme: { rounded: 'rounded-lg', flat: true } },
+  organizations: { roles: ['member', 'admin'] },
+};
+
+/**
+ * Mount the members component with the given org store overrides.
+ * @param {Object} [storeOverrides] - Methods/state to set on the store.
+ * @returns {Promise<import('@vue/test-utils').VueWrapper>}
+ */
+async function mountComponent(storeOverrides = {}) {
+  const { useOrganizationsStore } = await import('../stores/organizations.store');
+  const store = useOrganizationsStore();
+  store.fetchMembers = vi.fn().mockResolvedValue([]);
+  Object.assign(store, storeOverrides);
+  const wrapper = shallowMount(OrganizationsMembersComponent, {
+    props: { organizationId: 'org1' },
+    global: {
+      mocks: { config, $vuetify: { display: { smAndDown: false } } },
+      stubs: sharedStubs,
+    },
+  });
+  return { wrapper, store };
+}
+
+describe('organizations.members.component — add member', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    abilityMock.can.mockReset();
+    abilityMock.can.mockReturnValue(true);
+    abilityMock.rules = [{ action: 'create', subject: 'Membership' }];
+  });
+
+  it('shows the Add member affordance when the user can create a Membership', async () => {
+    abilityMock.can.mockImplementation((action, subject) => action === 'create' && subject === 'Membership');
+    const { wrapper } = await mountComponent();
+    expect(wrapper.find('[data-test="org-add-member-open"]').exists()).toBe(true);
+    expect(wrapper.vm.canAddMember()).toBe(true);
+  });
+
+  it('hides the Add member affordance for a plain member (no create ability)', async () => {
+    abilityMock.can.mockReturnValue(false);
+    const { wrapper } = await mountComponent();
+    expect(wrapper.find('[data-test="org-add-member-open"]').exists()).toBe(false);
+    expect(wrapper.vm.canAddMember()).toBe(false);
+  });
+
+  it('canAddMember is false when the ability has no rules yet', async () => {
+    abilityMock.rules = [];
+    const { wrapper } = await mountComponent();
+    expect(wrapper.vm.canAddMember()).toBe(false);
+  });
+
+  it('openAddDialog resets the dialog to a clean searching state', async () => {
+    const { wrapper } = await mountComponent();
+    wrapper.vm.addDialog.foundUser = { id: 'x' };
+    wrapper.vm.openAddDialog();
+    expect(wrapper.vm.addDialog.show).toBe(true);
+    expect(wrapper.vm.addDialog.email).toBe('');
+    expect(wrapper.vm.addDialog.foundUser).toBeNull();
+    expect(wrapper.vm.addDialog.searched).toBe(false);
+    expect(wrapper.vm.addDialog.role).toBe('member');
+  });
+
+  it('onEmailInput clears a stale result', async () => {
+    const { wrapper } = await mountComponent();
+    wrapper.vm.addDialog.searched = true;
+    wrapper.vm.addDialog.foundUser = { id: 'x' };
+    wrapper.vm.onEmailInput();
+    expect(wrapper.vm.addDialog.searched).toBe(false);
+    expect(wrapper.vm.addDialog.foundUser).toBeNull();
+  });
+
+  it('searchUser sets foundUser on a match', async () => {
+    const searchUserByEmail = vi.fn().mockResolvedValue({ id: 'u1', displayName: 'Jane', email: 'jane@example.com' });
+    const { wrapper } = await mountComponent({ searchUserByEmail });
+    wrapper.vm.addDialog.email = 'jane@example.com';
+    await wrapper.vm.searchUser();
+    expect(searchUserByEmail).toHaveBeenCalledWith('org1', 'jane@example.com');
+    expect(wrapper.vm.addDialog.foundUser).toEqual({ id: 'u1', displayName: 'Jane', email: 'jane@example.com' });
+    expect(wrapper.vm.addDialog.searched).toBe(true);
+  });
+
+  it('searchUser marks not-found (searched, no foundUser) when no match', async () => {
+    const searchUserByEmail = vi.fn().mockResolvedValue(null);
+    const { wrapper } = await mountComponent({ searchUserByEmail });
+    wrapper.vm.addDialog.email = 'ghost@example.com';
+    await wrapper.vm.searchUser();
+    expect(wrapper.vm.addDialog.foundUser).toBeNull();
+    expect(wrapper.vm.addDialog.searched).toBe(true);
+  });
+
+  it('searchUser leaves searched=false on error (so the user can retry)', async () => {
+    const searchUserByEmail = vi.fn().mockRejectedValue(new Error('boom'));
+    const { wrapper } = await mountComponent({ searchUserByEmail });
+    wrapper.vm.addDialog.email = 'jane@example.com';
+    await wrapper.vm.searchUser();
+    expect(wrapper.vm.addDialog.searched).toBe(false);
+    expect(wrapper.vm.addDialog.searching).toBe(false);
+  });
+
+  it('searchUser no-ops with an empty email', async () => {
+    const searchUserByEmail = vi.fn();
+    const { wrapper } = await mountComponent({ searchUserByEmail });
+    wrapper.vm.addDialog.email = '';
+    await wrapper.vm.searchUser();
+    expect(searchUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it('confirmAddMember adds the found user, refreshes members, and closes', async () => {
+    const addMember = vi.fn().mockResolvedValue({ id: 'm9' });
+    const { wrapper, store } = await mountComponent({ addMember });
+    store.fetchMembers.mockClear();
+    wrapper.vm.addDialog.show = true;
+    wrapper.vm.addDialog.foundUser = { id: 'u1', email: 'jane@example.com' };
+    wrapper.vm.addDialog.role = 'admin';
+    await wrapper.vm.confirmAddMember();
+    expect(addMember).toHaveBeenCalledWith('org1', 'u1', 'admin');
+    expect(store.fetchMembers).toHaveBeenCalled();
+    expect(wrapper.vm.addDialog.show).toBe(false);
+  });
+
+  it('confirmAddMember keeps the dialog open on error (e.g. already a member)', async () => {
+    const addMember = vi.fn().mockRejectedValue(new Error('already a member'));
+    const { wrapper } = await mountComponent({ addMember });
+    wrapper.vm.addDialog.show = true;
+    wrapper.vm.addDialog.foundUser = { id: 'u1', email: 'jane@example.com' };
+    await wrapper.vm.confirmAddMember();
+    expect(wrapper.vm.addDialog.show).toBe(true);
+    expect(wrapper.vm.addDialog.adding).toBe(false);
+  });
+
+  it('confirmAddMember no-ops without a found user', async () => {
+    const addMember = vi.fn();
+    const { wrapper } = await mountComponent({ addMember });
+    wrapper.vm.addDialog.foundUser = null;
+    await wrapper.vm.confirmAddMember();
+    expect(addMember).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/organizations/tests/organizations.members.component.unit.tests.js
+++ b/src/modules/organizations/tests/organizations.members.component.unit.tests.js
@@ -102,6 +102,15 @@ describe('organizations.members.component — add member', () => {
     expect(wrapper.vm.addDialog.role).toBe('member');
   });
 
+  it('defaultRole is the first available role (single source of truth for openAddDialog)', async () => {
+    const { wrapper } = await mountComponent();
+    // config.organizations.roles = ['member', 'admin'] → first is 'member'
+    expect(wrapper.vm.defaultRole()).toBe('member');
+    expect(wrapper.vm.availableRoles[0].value).toBe('member');
+    wrapper.vm.openAddDialog();
+    expect(wrapper.vm.addDialog.role).toBe(wrapper.vm.defaultRole());
+  });
+
   it('onEmailInput clears a stale result', async () => {
     const { wrapper } = await mountComponent();
     wrapper.vm.addDialog.searched = true;
@@ -145,6 +154,40 @@ describe('organizations.members.component — add member', () => {
     wrapper.vm.addDialog.email = '';
     await wrapper.vm.searchUser();
     expect(searchUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it('searchUser no-ops with a syntactically invalid email (no endpoint round-trip)', async () => {
+    const searchUserByEmail = vi.fn();
+    const { wrapper } = await mountComponent({ searchUserByEmail });
+    wrapper.vm.addDialog.email = 'not-an-email';
+    await wrapper.vm.searchUser();
+    expect(searchUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it('isValidAddEmail gates obvious garbage but accepts a real address', async () => {
+    const { wrapper } = await mountComponent();
+    wrapper.vm.addDialog.email = '';
+    expect(wrapper.vm.isValidAddEmail).toBe(false);
+    wrapper.vm.addDialog.email = 'nope';
+    expect(wrapper.vm.isValidAddEmail).toBe(false);
+    wrapper.vm.addDialog.email = '  jane@example.com  ';
+    expect(wrapper.vm.isValidAddEmail).toBe(true);
+  });
+
+  it('searchUser ignores a stale resolution when the email changed mid-flight', async () => {
+    // A slower earlier search resolves AFTER the input has changed; its result
+    // must NOT overwrite foundUser/searched (request-token guard).
+    let resolveStale;
+    const searchUserByEmail = vi.fn(() => new Promise((r) => { resolveStale = r; }));
+    const { wrapper } = await mountComponent({ searchUserByEmail });
+    wrapper.vm.addDialog.email = 'old@example.com';
+    const pending = wrapper.vm.searchUser();
+    // User retypes a different email while the first request is in flight.
+    wrapper.vm.addDialog.email = 'new@example.com';
+    resolveStale({ id: 'stale', email: 'old@example.com' });
+    await pending;
+    expect(wrapper.vm.addDialog.foundUser).toBeNull();
+    expect(wrapper.vm.addDialog.searched).toBe(false);
   });
 
   it('confirmAddMember adds the found user, refreshes members, and closes', async () => {

--- a/src/modules/organizations/tests/organizations.members.component.unit.tests.js
+++ b/src/modules/organizations/tests/organizations.members.component.unit.tests.js
@@ -46,7 +46,7 @@ const config = {
 /**
  * Mount the members component with the given org store overrides.
  * @param {Object} [storeOverrides] - Methods/state to set on the store.
- * @returns {Promise<import('@vue/test-utils').VueWrapper>}
+ * @returns {Promise<{ wrapper: import('@vue/test-utils').VueWrapper, store: object }>}
  */
 async function mountComponent(storeOverrides = {}) {
   const { useOrganizationsStore } = await import('../stores/organizations.store');

--- a/src/modules/organizations/tests/organizations.store.unit.tests.js
+++ b/src/modules/organizations/tests/organizations.store.unit.tests.js
@@ -69,6 +69,7 @@ describe('Organizations Store', () => {
     expect(store.organizations).toEqual([]);
     expect(store.members).toEqual([]);
     expect(store.adminPendingRequests).toEqual([]);
+    expect(store.pendingInvitations).toEqual([]);
   });
 
   describe('fetchOrganizations', () => {
@@ -631,6 +632,129 @@ describe('Organizations Store', () => {
       const result = await store.searchOrganizationsByDomain();
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('searchUserByEmail', () => {
+    it('should search a user by exact email and return the match', async () => {
+      const store = useOrganizationsStore();
+      const match = { id: 'u1', displayName: 'Jane Doe', email: 'jane@example.com' };
+
+      axios.get.mockResolvedValueOnce({ data: { data: match } });
+
+      const result = await store.searchUserByEmail('org1', 'jane@example.com');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `${API}/organizations/org1/members/search?email=jane%40example.com`,
+      );
+      expect(result).toEqual(match);
+    });
+
+    it('should return null when no user matches', async () => {
+      const store = useOrganizationsStore();
+
+      axios.get.mockResolvedValueOnce({ data: { data: null } });
+
+      const result = await store.searchUserByEmail('org1', 'ghost@example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should trim and URL-encode the email before querying', async () => {
+      const store = useOrganizationsStore();
+
+      axios.get.mockResolvedValueOnce({ data: { data: null } });
+
+      await store.searchUserByEmail('org1', '  a+b@example.com  ');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `${API}/organizations/org1/members/search?email=a%2Bb%40example.com`,
+      );
+    });
+  });
+
+  describe('addMember', () => {
+    it('should POST userId and role and return the created membership', async () => {
+      const store = useOrganizationsStore();
+      const created = { id: 'm9', status: 'pending', source: 'owner_add', role: 'member' };
+
+      axios.post.mockResolvedValueOnce({ data: { data: created } });
+
+      const result = await store.addMember('org1', 'u1', 'member');
+
+      expect(axios.post).toHaveBeenCalledWith(`${API}/organizations/org1/members`, {
+        userId: 'u1',
+        role: 'member',
+      });
+      expect(result).toEqual(created);
+    });
+
+    it('should omit role from the body when not provided', async () => {
+      const store = useOrganizationsStore();
+
+      axios.post.mockResolvedValueOnce({ data: { data: { id: 'm9' } } });
+
+      await store.addMember('org1', 'u1');
+
+      expect(axios.post).toHaveBeenCalledWith(`${API}/organizations/org1/members`, {
+        userId: 'u1',
+      });
+    });
+  });
+
+  describe('fetchMyPendingInvitations', () => {
+    it('should fetch and set the pending invitations list', async () => {
+      const store = useOrganizationsStore();
+      const invitations = [
+        { id: 'inv1', role: 'member', organizationId: { id: 'org1', name: 'Acme' } },
+      ];
+
+      axios.get.mockResolvedValueOnce({ data: { data: invitations } });
+
+      const result = await store.fetchMyPendingInvitations();
+
+      expect(axios.get).toHaveBeenCalledWith(`${API}/membership-requests/mine/pending`);
+      expect(store.pendingInvitations).toEqual(invitations);
+      expect(result).toEqual(invitations);
+    });
+
+    it('should set an empty array when no data is returned', async () => {
+      const store = useOrganizationsStore();
+      store.pendingInvitations = [{ id: 'stale' }];
+
+      axios.get.mockResolvedValueOnce({ data: { data: null } });
+
+      const result = await store.fetchMyPendingInvitations();
+
+      expect(store.pendingInvitations).toEqual([]);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('acceptMembership', () => {
+    it('should PUT accept, drop the invitation locally, and return the membership', async () => {
+      const store = useOrganizationsStore();
+      store.pendingInvitations = [{ id: 'inv1' }, { id: 'inv2' }];
+      const accepted = { id: 'inv1', status: 'active' };
+
+      axios.put.mockResolvedValueOnce({ data: { data: accepted } });
+
+      const result = await store.acceptMembership('inv1');
+
+      expect(axios.put).toHaveBeenCalledWith(`${API}/membership-requests/inv1/accept`);
+      expect(store.pendingInvitations).toEqual([{ id: 'inv2' }]);
+      expect(result).toEqual(accepted);
+    });
+
+    it('should drop the invitation matched by _id', async () => {
+      const store = useOrganizationsStore();
+      store.pendingInvitations = [{ _id: 'a' }, { _id: 'b' }];
+
+      axios.put.mockResolvedValueOnce({ data: { data: { id: 'a' } } });
+
+      await store.acceptMembership('a');
+
+      expect(store.pendingInvitations).toEqual([{ _id: 'b' }]);
     });
   });
 

--- a/src/modules/users/tests/user.organizations.view.unit.tests.js
+++ b/src/modules/users/tests/user.organizations.view.unit.tests.js
@@ -220,10 +220,63 @@ describe('user.organizations.view — pending invitations', () => {
     await wrapper.vm.acceptInvitation({ id: 'inv1', role: 'member', organizationId: { name: 'Acme' } });
 
     expect(store.acceptMembership).toHaveBeenCalledWith('inv1');
+    // Abilities still refresh on the success path so the new org's permissions apply.
     expect(authStore.refreshAbilities).toHaveBeenCalled();
     expect(store.fetchOrganizations).toHaveBeenCalled();
     // initial mount + post-accept refresh
     expect(store.fetchMyPendingInvitations.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('acceptInvitation tolerates a refreshAbilities failure (no surprise-logout; orgs + pending still refresh)', async () => {
+    // The membership is accepted server-side regardless. A mid-chain abilities
+    // hiccup (refreshAbilities signs out + throws) must NOT abort the UI reflection
+    // of the accept, nor surprise-logout the user right after a successful accept.
+    const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
+    const { useAuthStore } = await import('../../auth/stores/auth.store');
+    const store = useOrganizationsStore();
+    const authStore = useAuthStore();
+    store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
+    store.acceptMembership = vi.fn().mockResolvedValue({ id: 'inv1', status: 'active' });
+    authStore.refreshAbilities = vi.fn().mockRejectedValue(new Error('abilities endpoint hiccup'));
+
+    const wrapper = shallowMount(UserOrganizationsView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+    store.fetchOrganizations.mockClear();
+    store.fetchMyPendingInvitations.mockClear();
+
+    // Must not throw out of the flow despite refreshAbilities rejecting.
+    await expect(
+      wrapper.vm.acceptInvitation({ id: 'inv1', role: 'member', organizationId: { name: 'Acme' } }),
+    ).resolves.toBeUndefined();
+
+    expect(store.acceptMembership).toHaveBeenCalledWith('inv1');
+    expect(authStore.refreshAbilities).toHaveBeenCalled();
+    // The accept is reflected in the UI even though abilities failed.
+    expect(store.fetchOrganizations).toHaveBeenCalled();
+    expect(store.fetchMyPendingInvitations).toHaveBeenCalled();
+    expect(wrapper.vm.acceptingId).toBeNull();
+  });
+
+  test('acceptInvitation dismisses the login nudge on success', async () => {
+    const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
+    const { useAuthStore } = await import('../../auth/stores/auth.store');
+    const store = useOrganizationsStore();
+    const authStore = useAuthStore();
+    store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
+    store.acceptMembership = vi.fn().mockResolvedValue({ id: 'inv1', status: 'active' });
+    authStore.refreshAbilities = vi.fn().mockResolvedValue();
+
+    const wrapper = shallowMount(UserOrganizationsView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+    wrapper.vm.nudge = true;
+
+    await wrapper.vm.acceptInvitation({ id: 'inv1', role: 'member', organizationId: { name: 'Acme' } });
+
+    expect(wrapper.vm.nudge).toBe(false);
   });
 
   test('invitationOrgName + invitationRole helpers read the populated membership', async () => {

--- a/src/modules/users/tests/user.organizations.view.unit.tests.js
+++ b/src/modules/users/tests/user.organizations.view.unit.tests.js
@@ -33,6 +33,8 @@ const sharedStubs = {
   'v-chip': { template: '<div><slot /></div>' },
   'v-btn': { template: '<button v-bind="$attrs" :to="$attrs.to"><slot /></button>', inheritAttrs: false },
   'v-icon': { template: '<div />' },
+  'v-alert': { template: '<div><slot /></div>' },
+  'v-snackbar': { template: '<div><slot /><slot name="actions" /></div>' },
 };
 
 const sharedMocks = ($router = { push: vi.fn() }) => ({
@@ -53,6 +55,7 @@ describe('user.organizations.view', () => {
     const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
     const store = useOrganizationsStore();
     store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
 
     const wrapper = shallowMount(UserOrganizationsView, {
       global: {
@@ -68,6 +71,7 @@ describe('user.organizations.view', () => {
     const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
     const store = useOrganizationsStore();
     store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
 
     const wrapper = shallowMount(UserOrganizationsView, {
       global: {
@@ -83,6 +87,7 @@ describe('user.organizations.view', () => {
     const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
     const store = useOrganizationsStore();
     store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
 
     const wrapper = shallowMount(UserOrganizationsView, {
       global: {
@@ -105,6 +110,7 @@ describe('user.organizations.view', () => {
     const authStore = useAuthStore();
 
     store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
     const routerPush = vi.fn();
 
     const wrapper = shallowMount(UserOrganizationsView, {
@@ -127,6 +133,113 @@ describe('user.organizations.view', () => {
 
     expect(store.leaveOrganization).toHaveBeenCalledWith(orgId);
     expect(routerPush).toHaveBeenCalledWith('/organization-required');
+  });
+});
+
+describe('user.organizations.view — pending invitations', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  test('fetches pending invitations on created', async () => {
+    const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
+    const store = useOrganizationsStore();
+    store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    const fetchInvites = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = fetchInvites;
+
+    shallowMount(UserOrganizationsView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+    await Promise.resolve();
+
+    expect(fetchInvites).toHaveBeenCalled();
+  });
+
+  test('exposes the store pendingInvitations via computed', async () => {
+    const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
+    const store = useOrganizationsStore();
+    store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
+    store.pendingInvitations = [{ id: 'inv1', role: 'member', organizationId: { name: 'Acme' } }];
+
+    const wrapper = shallowMount(UserOrganizationsView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+
+    expect(wrapper.vm.pendingInvitations).toHaveLength(1);
+    expect(wrapper.vm.pendingInvitations[0].organizationId.name).toBe('Acme');
+  });
+
+  test('shows the nudge snackbar when invitations exist after fetch', async () => {
+    const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
+    const store = useOrganizationsStore();
+    store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockImplementation(() => {
+      store.pendingInvitations = [{ id: 'inv1', role: 'member', organizationId: { name: 'Acme' } }];
+      return Promise.resolve(store.pendingInvitations);
+    });
+
+    const wrapper = shallowMount(UserOrganizationsView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(wrapper.vm.nudge).toBe(true);
+  });
+
+  test('does not show the nudge snackbar when there are no invitations', async () => {
+    const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
+    const store = useOrganizationsStore();
+    store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
+
+    const wrapper = shallowMount(UserOrganizationsView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+    await Promise.resolve();
+
+    expect(wrapper.vm.nudge).toBe(false);
+  });
+
+  test('acceptInvitation accepts, refreshes orgs + abilities, and re-fetches invitations', async () => {
+    const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
+    const { useAuthStore } = await import('../../auth/stores/auth.store');
+    const store = useOrganizationsStore();
+    const authStore = useAuthStore();
+    store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
+    store.acceptMembership = vi.fn().mockResolvedValue({ id: 'inv1', status: 'active' });
+    authStore.refreshAbilities = vi.fn().mockResolvedValue();
+
+    const wrapper = shallowMount(UserOrganizationsView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+
+    await wrapper.vm.acceptInvitation({ id: 'inv1', role: 'member', organizationId: { name: 'Acme' } });
+
+    expect(store.acceptMembership).toHaveBeenCalledWith('inv1');
+    expect(authStore.refreshAbilities).toHaveBeenCalled();
+    expect(store.fetchOrganizations).toHaveBeenCalled();
+    // initial mount + post-accept refresh
+    expect(store.fetchMyPendingInvitations.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('invitationOrgName + invitationRole helpers read the populated membership', async () => {
+    const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
+    const store = useOrganizationsStore();
+    store.fetchOrganizations = vi.fn().mockResolvedValue([]);
+    store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
+
+    const wrapper = shallowMount(UserOrganizationsView, {
+      global: { mocks: sharedMocks(), stubs: sharedStubs },
+    });
+
+    const inv = { id: 'inv1', role: 'admin', organizationId: { name: 'Acme Corp' } };
+    expect(wrapper.vm.invitationOrgName(inv)).toBe('Acme Corp');
+    expect(wrapper.vm.invitationRole(inv)).toBe('admin');
+    expect(wrapper.vm.invitationOrgName({ id: 'x' })).toBe('an organization');
   });
 });
 

--- a/src/modules/users/tests/user.organizations.view.unit.tests.js
+++ b/src/modules/users/tests/user.organizations.view.unit.tests.js
@@ -203,7 +203,7 @@ describe('user.organizations.view — pending invitations', () => {
     expect(wrapper.vm.nudge).toBe(false);
   });
 
-  test('acceptInvitation accepts, refreshes orgs + abilities, and re-fetches invitations', async () => {
+  test('acceptInvitation accepts, soft-refreshes abilities via token(), and re-fetches orgs + invitations', async () => {
     const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
     const { useAuthStore } = await import('../../auth/stores/auth.store');
     const store = useOrganizationsStore();
@@ -211,7 +211,8 @@ describe('user.organizations.view — pending invitations', () => {
     store.fetchOrganizations = vi.fn().mockResolvedValue([]);
     store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
     store.acceptMembership = vi.fn().mockResolvedValue({ id: 'inv1', status: 'active' });
-    authStore.refreshAbilities = vi.fn().mockResolvedValue();
+    // token() is the soft (non-fatal) abilities refresh — does not sign out on failure.
+    authStore.token = vi.fn().mockResolvedValue();
 
     const wrapper = shallowMount(UserOrganizationsView, {
       global: { mocks: sharedMocks(), stubs: sharedStubs },
@@ -220,17 +221,17 @@ describe('user.organizations.view — pending invitations', () => {
     await wrapper.vm.acceptInvitation({ id: 'inv1', role: 'member', organizationId: { name: 'Acme' } });
 
     expect(store.acceptMembership).toHaveBeenCalledWith('inv1');
-    // Abilities still refresh on the success path so the new org's permissions apply.
-    expect(authStore.refreshAbilities).toHaveBeenCalled();
+    // Soft-refresh so the new org's permissions apply without risk of surprise-logout.
+    expect(authStore.token).toHaveBeenCalled();
     expect(store.fetchOrganizations).toHaveBeenCalled();
     // initial mount + post-accept refresh
     expect(store.fetchMyPendingInvitations.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
-  test('acceptInvitation tolerates a refreshAbilities failure (no surprise-logout; orgs + pending still refresh)', async () => {
-    // The membership is accepted server-side regardless. A mid-chain abilities
-    // hiccup (refreshAbilities signs out + throws) must NOT abort the UI reflection
-    // of the accept, nor surprise-logout the user right after a successful accept.
+  test('acceptInvitation: token() failure is non-fatal — orgs + pending still reflect the accepted state', async () => {
+    // token() only console.error on failure (unlike refreshAbilities which calls signout()).
+    // The accept has already succeeded server-side; a hiccup in token() must not
+    // interrupt the UI reflection or throw out of the flow.
     const { useOrganizationsStore } = await import('../../organizations/stores/organizations.store');
     const { useAuthStore } = await import('../../auth/stores/auth.store');
     const store = useOrganizationsStore();
@@ -238,7 +239,7 @@ describe('user.organizations.view — pending invitations', () => {
     store.fetchOrganizations = vi.fn().mockResolvedValue([]);
     store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
     store.acceptMembership = vi.fn().mockResolvedValue({ id: 'inv1', status: 'active' });
-    authStore.refreshAbilities = vi.fn().mockRejectedValue(new Error('abilities endpoint hiccup'));
+    authStore.token = vi.fn().mockRejectedValue(new Error('token endpoint hiccup'));
 
     const wrapper = shallowMount(UserOrganizationsView, {
       global: { mocks: sharedMocks(), stubs: sharedStubs },
@@ -246,14 +247,14 @@ describe('user.organizations.view — pending invitations', () => {
     store.fetchOrganizations.mockClear();
     store.fetchMyPendingInvitations.mockClear();
 
-    // Must not throw out of the flow despite refreshAbilities rejecting.
+    // Must not throw out of the flow despite token() rejecting.
     await expect(
       wrapper.vm.acceptInvitation({ id: 'inv1', role: 'member', organizationId: { name: 'Acme' } }),
     ).resolves.toBeUndefined();
 
     expect(store.acceptMembership).toHaveBeenCalledWith('inv1');
-    expect(authStore.refreshAbilities).toHaveBeenCalled();
-    // The accept is reflected in the UI even though abilities failed.
+    expect(authStore.token).toHaveBeenCalled();
+    // The accept is reflected in the UI even though the abilities refresh failed.
     expect(store.fetchOrganizations).toHaveBeenCalled();
     expect(store.fetchMyPendingInvitations).toHaveBeenCalled();
     expect(wrapper.vm.acceptingId).toBeNull();
@@ -267,7 +268,7 @@ describe('user.organizations.view — pending invitations', () => {
     store.fetchOrganizations = vi.fn().mockResolvedValue([]);
     store.fetchMyPendingInvitations = vi.fn().mockResolvedValue([]);
     store.acceptMembership = vi.fn().mockResolvedValue({ id: 'inv1', status: 'active' });
-    authStore.refreshAbilities = vi.fn().mockResolvedValue();
+    authStore.token = vi.fn().mockResolvedValue();
 
     const wrapper = shallowMount(UserOrganizationsView, {
       global: { mocks: sharedMocks(), stubs: sharedStubs },

--- a/src/modules/users/views/user.organizations.view.vue
+++ b/src/modules/users/views/user.organizations.view.vue
@@ -1,5 +1,54 @@
 <template>
   <v-container fluid>
+    <!-- Pending invitations to accept (persistent, owner_add): durable surface an
+         offline invitee sees on their next login. -->
+    <v-row v-if="pendingInvitations.length" class="pa-2 mt-0" data-test="pending-invitations">
+      <v-col cols="12">
+        <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-4">
+          <div class="d-flex align-center mb-2">
+            <v-icon icon="fa-solid fa-envelope-open-text" size="small" color="primary" class="mr-2"></v-icon>
+            <span class="text-title-medium font-weight-medium">Pending invitations</span>
+          </div>
+          <p class="text-body-small text-medium-emphasis mb-2">
+            You've been invited to join these organizations. Accept to become a member.
+          </p>
+          <v-list lines="two" class="pa-0 bg-transparent">
+            <template v-for="(inv, i) in pendingInvitations" :key="inv.id || inv._id">
+              <v-list-item :class="config.vuetify.theme.rounded" class="pa-4">
+                <template #prepend>
+                  <orgAvatarComponent :org="inv.organizationId || {}" :size="40" class="mr-4" />
+                </template>
+                <v-list-item-title class="text-body-large font-weight-medium">
+                  {{ invitationOrgName(inv) }}
+                </v-list-item-title>
+                <v-list-item-subtitle class="text-body-small">
+                  Invited as
+                  <v-chip size="x-small" :color="roleColor(invitationRole(inv))" variant="tonal" class="text-capitalize ml-1">
+                    {{ invitationRole(inv) }}
+                  </v-chip>
+                </v-list-item-subtitle>
+                <template #append>
+                  <v-btn
+                    color="primary"
+                    variant="flat"
+                    size="small"
+                    :class="config.vuetify.theme.rounded"
+                    class="text-none text-body-medium"
+                    :loading="acceptingId === (inv.id || inv._id)"
+                    :data-test="`accept-invitation-${inv.id || inv._id}`"
+                    @click="acceptInvitation(inv)"
+                  >
+                    Accept
+                  </v-btn>
+                </template>
+              </v-list-item>
+              <v-divider v-if="i < pendingInvitations.length - 1"></v-divider>
+            </template>
+          </v-list>
+        </v-card>
+      </v-col>
+    </v-row>
+
     <v-row class="pa-2 mt-0">
       <v-col cols="12">
         <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-4">
@@ -67,6 +116,19 @@
       confirm-color="error"
       @confirm="leaveOrg"
     />
+
+    <!-- Login nudge: not triggered by a POST/PUT response, so a component-local
+         snackbar (the persistent list above is the source of truth). -->
+    <v-snackbar v-model="nudge" location="top right" color="info" :timeout="6000" data-test="pending-invitations-nudge">
+      <span class="text-body-medium">
+        <v-icon icon="fa-solid fa-envelope-open-text" size="small" class="mr-1" />
+        You have {{ pendingInvitations.length }}
+        pending {{ pendingInvitations.length === 1 ? 'invitation' : 'invitations' }} to accept.
+      </span>
+      <template #actions>
+        <v-btn variant="text" size="small" icon="$close" @click="nudge = false" />
+      </template>
+    </v-snackbar>
   </v-container>
 </template>
 
@@ -94,6 +156,8 @@ export default {
     return {
       leaveDialog: false,
       orgToLeave: null,
+      acceptingId: null,
+      nudge: false,
     };
   },
   computed: {
@@ -103,6 +167,13 @@ export default {
      */
     organizations() {
       return this.organizationsStore.organizations;
+    },
+    /**
+     * @desc The current user's pending owner_add invitations (durable list).
+     * @returns {Array}
+     */
+    pendingInvitations() {
+      return this.organizationsStore.pendingInvitations;
     },
     /**
      * @desc The ID of the user's current active organization.
@@ -131,9 +202,56 @@ export default {
     } catch {
       // interceptor handles snackbar
     }
+    try {
+      await this.organizationsStore.fetchMyPendingInvitations();
+      // Nudge on login when there are invitations to accept. The persistent list
+      // above is the source of truth; this is only a transient prompt.
+      this.nudge = this.pendingInvitations.length > 0;
+    } catch {
+      // interceptor handles snackbar
+    }
   },
   methods: {
     roleColor,
+    /**
+     * @desc Display name of the org an invitation is for. Org is populated
+     *       ({ id, name, slug }); falls back gracefully if missing.
+     * @param {Object} invitation - A pending owner_add membership.
+     * @returns {string}
+     */
+    invitationOrgName(invitation) {
+      return invitation?.organizationId?.name || 'an organization';
+    },
+    /**
+     * @desc Role the user is invited to hold once they accept.
+     * @param {Object} invitation - A pending owner_add membership.
+     * @returns {string}
+     */
+    invitationRole(invitation) {
+      return invitation?.role || 'member';
+    },
+    /**
+     * @desc Accept a pending owner_add invitation. On success the PUT interceptor
+     *       toasts; we refresh abilities + orgs (the user is now a member) and
+     *       re-fetch the pending list so the accepted row disappears.
+     * @param {Object} invitation - The pending membership to accept.
+     * @returns {Promise<void>}
+     */
+    async acceptInvitation(invitation) {
+      const membershipId = invitation.id || invitation._id;
+      if (!membershipId || this.acceptingId) return;
+      this.acceptingId = membershipId;
+      try {
+        await this.organizationsStore.acceptMembership(membershipId);
+        await this.authStore.refreshAbilities();
+        await this.organizationsStore.fetchOrganizations();
+        await this.organizationsStore.fetchMyPendingInvitations();
+      } catch {
+        // interceptor handles snackbar
+      } finally {
+        this.acceptingId = null;
+      }
+    },
     /**
      * @desc Check whether the given org is the user's active organization.
      * @param {Object} org - Organization object.

--- a/src/modules/users/views/user.organizations.view.vue
+++ b/src/modules/users/views/user.organizations.view.vue
@@ -252,13 +252,11 @@ export default {
         this.nudge = false;
         await this.organizationsStore.fetchOrganizations();
         await this.organizationsStore.fetchMyPendingInvitations();
-        try {
-          await this.authStore.refreshAbilities();
-        } catch {
-          // Non-fatal to THIS flow: the accept already succeeded. Don't let an
-          // abilities hiccup surprise-logout the user; abilities self-heal on the
-          // next natural refresh. Interceptor already toasted.
-        }
+        // Soft-refresh abilities: token() updates abilities/user in-place without
+        // signing out on failure (unlike refreshAbilities() which calls signout()
+        // before re-throwing). A stale ability set self-heals on the next natural
+        // refresh. Non-fatal by design — the accept already succeeded.
+        await this.authStore.token();
       } catch {
         // interceptor handles snackbar
       } finally {

--- a/src/modules/users/views/user.organizations.view.vue
+++ b/src/modules/users/views/user.organizations.view.vue
@@ -232,8 +232,13 @@ export default {
     },
     /**
      * @desc Accept a pending owner_add invitation. On success the PUT interceptor
-     *       toasts; we refresh abilities + orgs (the user is now a member) and
-     *       re-fetch the pending list so the accepted row disappears.
+     *       toasts; the membership is now active server-side, so we reflect that in
+     *       the UI (refresh orgs + drop the accepted row) FIRST, then refresh
+     *       abilities. The abilities refresh is wrapped in its own try/catch so a
+     *       hiccup on that endpoint can't surprise-logout the user (refreshAbilities
+     *       signs out + throws on failure) right after a successful accept, nor abort
+     *       the org/pending refresh — a stale ability set self-heals on the next
+     *       natural refresh.
      * @param {Object} invitation - The pending membership to accept.
      * @returns {Promise<void>}
      */
@@ -243,9 +248,17 @@ export default {
       this.acceptingId = membershipId;
       try {
         await this.organizationsStore.acceptMembership(membershipId);
-        await this.authStore.refreshAbilities();
+        // Membership is accepted server-side: reflect it before touching abilities.
+        this.nudge = false;
         await this.organizationsStore.fetchOrganizations();
         await this.organizationsStore.fetchMyPendingInvitations();
+        try {
+          await this.authStore.refreshAbilities();
+        } catch {
+          // Non-fatal to THIS flow: the accept already succeeded. Don't let an
+          // abilities hiccup surprise-logout the user; abilities self-heal on the
+          // next natural refresh. Interceptor already toasted.
+        }
       } catch {
         // interceptor handles snackbar
       } finally {


### PR DESCRIPTION
## Phase 5b — invitations ↔ org decouple (epic #3808)

The Vue half of the consent-first add-to-org flow. Pairs with P5a (Node, merged — endpoints live).

### What lands
- **Add-member affordance** (`organizations.members.component.vue`): owner/admin-gated dialog → exact-email search (`GET …/members/search?email=`) → matched user + role select → `addMember` (`POST …/members`) creates a **PENDING `owner_add`** membership (the invitee is NOT immediately active). States: searching / found / not-found ("invite them to the platform first") / already-member (422 toast) / success. Role select can't grant `owner` (not in org roles) — defense-in-depth atop the Node gate.
- **Persistent "Pending invitations to accept" list** (`user.organizations.view.vue`): fetched on mount (`GET /membership-requests/mine/pending`) — an offline invitee sees it next login. Each row → Accept (`PUT /membership-requests/:id/accept`) → activates + refreshes orgs + the list. An abilities-refresh hiccup after a successful accept is tolerated (no surprise-logout; abilities self-heal next refresh).
- **Store** (`organizations.store.js`): net-new `searchUserByEmail` / `addMember` / `fetchMyPendingInvitations` / `acceptMembership` + `pendingInvitations` state. Stale-search-response guarded.
- **Snackbar:** add/accept toasts ride the existing axios POST/PUT interceptor; the login nudge is a component-local `v-snackbar` (no global store invented).

### Verification
- `/verify`: lint clean, **build green**, new store+component+view tests pass (found/not-found/accept/stuck-loading/stale-search/CASL-gate states; the accept refresh chain). FA iconset + MD3 typography + theme helpers per `/ui`.
- Independent **spec-compliance** review ✅ (all 4 endpoints exact verb+path+payload; list fetched-on-mount; CASL gating; `addedBy` degrades gracefully) + **code-quality** review (0 critical; 2 important robustness fixes folded — accept-chain ordering + stale-search guard — plus UX minors).

### Notes
- **Pre-existing CI note:** 2 billing snapshot tests (`billing.usageBar`, `billing.meterProgress`) fail locally on the **clean `origin/master` baseline** too (Vuetify `v-progress-linear` version drift, untouched code) — NOT introduced here. If CI shows them red, it's a pre-existing master issue to address separately.
- `addedBy` ("who added you") isn't shown — the Node `mine/pending` populate returns it as a raw ObjectId, not a user; the row shows org + role gracefully. A follow-up could add `addedBy` to the Node populate.
- Rendered visual pass (`/impeccable`) best verified on the dev deployment post-propagation (P9).

Closes #4281. Part of #3808.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Add member" dialog for organizations, enabling email-based member invitations with customizable role selection
  * Added pending invitations section displaying outstanding organization membership offers
  * Added "Accept invitation" action to activate pending memberships
  * Added notification prompt reminding users of pending organization invitations

* **Tests**
  * Added comprehensive unit tests for member invitation and acceptance workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->