### PR TITLE
feat(invitations): standalone Vue module + account Referrals tab + router gap-fixes (P6)

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -14,7 +14,7 @@ Phase 6 of the invitations↔org decouple epic. The platform-invitations UI is n
 - **New account-surface composition seams** (upstream gap-fixes): `user.view.vue` now merges `config.users.tabs` + a NEW `config.users.extraTabs` key (`deepMerge` replaces arrays, so an optional module can't append to `users.tabs`); `app.router.js` gained an `accountChildModules` injection seam under `/users` (mirrors the org-settings injection) + an `accountChildModules` param on `registerDownstreamRoutes`; `ACCOUNT_PARENT_PATH` is exported from `users.router.js`.
 - The global `admin: { tabs: [] }` default was removed from `development.config.js` (now contributed only by the invitations module fragment). `admin.layout.vue` guards with `Array.isArray(config.admin.tabs) ? … : []`, so this is safe upstream.
 
-### Action required for downstream projects (`/update-project`)
+### Action required for downstream projects (`/update-stack`)
 
 1. The module + gap-fix files are devkit-owned → arrive via `/update-stack`.
 2. **⚠️ If a downstream overrides `admin.tabs` in its `{project}.config.js`, or relied on the global `admin.tabs: []` default**, verify the admin Invitations tab still appears after the stack merge (it now depends on the `invitations` module being active + its config fragment merging). The account "Referrals" tab requires the new `users.extraTabs` merge in `user.view.vue` + the `/users` route injection — both arrive via `/update-stack`.

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,24 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## invitations: standalone Vue module + account `extraTabs` seam; admin Invitations tab moved (2026-06-11, #4279)
+
+Phase 6 of the invitations↔org decouple epic. The platform-invitations UI is now its own optional `src/modules/invitations/` module (admin management tab + a new account "Referrals" tab).
+
+### What changed (this repo)
+
+- The admin Invitations tab + its store actions moved out of `admin` into `src/modules/invitations/` (store actions repointed to the canonical `/api/invitations` — was `/api/auth/invitations`). The hardcoded `invitations` entry was removed from `BUILT_IN_TABS` in `admin.layout.vue`; the tab now arrives via `config.admin.tabs` (contributed by the module's config fragment).
+- **New account-surface composition seams** (upstream gap-fixes): `user.view.vue` now merges `config.users.tabs` + a NEW `config.users.extraTabs` key (`deepMerge` replaces arrays, so an optional module can't append to `users.tabs`); `app.router.js` gained an `accountChildModules` injection seam under `/users` (mirrors the org-settings injection) + an `accountChildModules` param on `registerDownstreamRoutes`; `ACCOUNT_PARENT_PATH` is exported from `users.router.js`.
+- The global `admin: { tabs: [] }` default was removed from `development.config.js` (now contributed only by the invitations module fragment). `admin.layout.vue` guards with `Array.isArray(config.admin.tabs) ? … : []`, so this is safe upstream.
+
+### Action required for downstream projects (`/update-project`)
+
+1. The module + gap-fix files are devkit-owned → arrive via `/update-stack`.
+2. **⚠️ If a downstream overrides `admin.tabs` in its `{project}.config.js`, or relied on the global `admin.tabs: []` default**, verify the admin Invitations tab still appears after the stack merge (it now depends on the `invitations` module being active + its config fragment merging). The account "Referrals" tab requires the new `users.extraTabs` merge in `user.view.vue` + the `/users` route injection — both arrive via `/update-stack`.
+3. Pairs with the canonical-path repoint: once this lands downstream, the Node `/api/auth/invitations` deprecation alias (P2) can be dropped.
+
+---
+
 ## billing.subscriptions: checkout-polling extracted to useCheckoutPolling composable (2026-05-29, #4219)
 
 **Non-breaking structural refactor — behavior is byte-for-byte preserved.**

--- a/src/config/defaults/development.config.js
+++ b/src/config/defaults/development.config.js
@@ -61,15 +61,14 @@ export default {
       billing: 'billing',
     },
   },
-  admin: {
-    // tabs — extra tabs appended after Users & Organizations in /admin
-    // each entry: { value: string, label: string, icon?: string, route: string }
-    // example:
-    // tabs: [
-    //   { value: 'billing', label: 'Billing', icon: 'fa-solid fa-credit-card', route: '/admin/billing' },
-    // ],
-    tabs: [],
-  },
+  // admin.tabs — extra tabs appended after the built-in admin tabs (Users,
+  // Organizations, Readiness, Activity). Contributed by modules via their
+  // `{module}.{env}.config.js` fragment (e.g. the standalone `invitations`
+  // module adds the Invitations tab), NOT hardcoded here — generateConfig's
+  // deepMerge REPLACES arrays, so a global `admin: { tabs: [] }` default would
+  // clobber every module-contributed tab. `admin.layout.vue` guards a missing
+  // `config.admin.tabs` (Array.isArray → []), so omitting it here is safe.
+  // Each entry: { value, label, icon?, route, action?, subject? } (relative route).
   cookie: {
     prefix: 'devkit', // prefix for all cookies (e.g. 'devkit' → 'devkit_token')
   },

--- a/src/modules/admin/router/admin.router.js
+++ b/src/modules/admin/router/admin.router.js
@@ -3,7 +3,6 @@
  */
 import adminLayout from '../views/admin.layout.vue';
 import adminUsers from '../views/admin.users.view.vue';
-import adminInvitations from '../views/admin.invitations.view.vue';
 import adminOrganizations from '../views/admin.organizations.view.vue';
 import adminReadiness from '../views/admin.readiness.view.vue';
 import adminActivity from '../views/admin.activity.view.vue';
@@ -51,14 +50,6 @@ export default [
         path: 'users',
         name: 'Admin Users',
         component: adminUsers,
-        meta: {
-          action: 'manage', subject: 'UserAdmin',
-        },
-      },
-      {
-        path: 'invitations',
-        name: 'Admin Invitations',
-        component: adminInvitations,
         meta: {
           action: 'manage', subject: 'UserAdmin',
         },

--- a/src/modules/admin/stores/admin.store.js
+++ b/src/modules/admin/stores/admin.store.js
@@ -54,7 +54,6 @@ export const useAdminStore = defineStore('admin', {
     user: defaultUser(),
     users: [],
     organizations: [],
-    invitations: [],
     error: null,
     currentBreadcrumb: null,
     readiness: [],
@@ -170,56 +169,6 @@ export const useAdminStore = defineStore('admin', {
       } catch (err) {
         this.error = sanitizeApiError(err);
         console.error(err);
-      }
-    },
-
-    /**
-     * @desc Load all signup invitations (admin). Backend returns the full list
-     * (no server pagination), newest first, with token stripped.
-     * @returns {Promise<void>}
-     */
-    async getInvitations() {
-      this.error = null;
-      try {
-        const res = await axios.get(`${apiBase()}/auth/invitations`);
-        this.invitations = res.data.data;
-      } catch (err) {
-        this.invitations = [];
-        this.error = sanitizeApiError(err);
-        console.error(err);
-      }
-    },
-
-    /**
-     * @desc Create + email a signup invitation for an email (admin).
-     * @param {string} email
-     * @returns {Promise<Object>} the created invitation
-     */
-    async createInvitation(email) {
-      this.error = null;
-      try {
-        const res = await axios.post(`${apiBase()}/auth/invitations`, { email });
-        return res.data.data;
-      } catch (err) {
-        this.error = sanitizeApiError(err);
-        console.error(err);
-        throw err;
-      }
-    },
-
-    /**
-     * @desc Revoke a signup invitation by id (admin).
-     * @param {string} id
-     * @returns {Promise<void>}
-     */
-    async deleteInvitation(id) {
-      this.error = null;
-      try {
-        await axios.delete(`${apiBase()}/auth/invitations/${id}`);
-      } catch (err) {
-        this.error = sanitizeApiError(err);
-        console.error(err);
-        throw err;
       }
     },
 

--- a/src/modules/admin/tests/admin.layout.unit.tests.js
+++ b/src/modules/admin/tests/admin.layout.unit.tests.js
@@ -81,13 +81,16 @@ describe('admin.layout', () => {
     expect(wrapper.find('.router-view-stub').exists()).toBe(true);
   });
 
-  it('passes the five built-in tabs to CorePageHeaderTabs when no extras are configured', () => {
+  it('passes the four built-in tabs to CorePageHeaderTabs when no extras are configured', () => {
     const wrapper = mountLayout();
     const headerTabs = wrapper.findComponent({ name: 'CorePageHeaderTabs' });
     expect(headerTabs.exists()).toBe(true);
     const tabs = headerTabs.props('tabs');
-    expect(tabs).toHaveLength(5);
-    expect(tabs.map((t) => t.value)).toEqual(['users', 'invitations', 'organizations', 'readiness', 'activity']);
+    // Invitations is no longer built-in — it is contributed by the standalone
+    // invitations module via config.admin.tabs (invitations↔org decouple, P6).
+    expect(tabs).toHaveLength(4);
+    expect(tabs.map((t) => t.value)).toEqual(['users', 'organizations', 'readiness', 'activity']);
+    expect(tabs.map((t) => t.value)).not.toContain('invitations');
   });
 
   it('passes built-in + extra tabs from config.admin.tabs to CorePageHeaderTabs', () => {
@@ -101,13 +104,21 @@ describe('admin.layout', () => {
     });
     const headerTabs = wrapper.findComponent({ name: 'CorePageHeaderTabs' });
     const tabs = headerTabs.props('tabs');
-    expect(tabs).toHaveLength(7);
-    expect(tabs[5].value).toBe('knowledge');
-    expect(tabs[6].value).toBe('costs');
+    expect(tabs).toHaveLength(6);
+    expect(tabs[4].value).toBe('knowledge');
+    expect(tabs[5].value).toBe('costs');
   });
 
-  it('includes the Invitations tab', () => {
-    const wrapper = mountLayout();
+  it('renders an Invitations tab when contributed via config.admin.tabs (module-driven)', () => {
+    // After the decouple, Invitations comes from the invitations module's
+    // config fragment rather than the built-in list. Mirror that contribution.
+    const wrapper = mountLayout({
+      admin: {
+        tabs: [
+          { value: 'invitations', label: 'Invitations', icon: 'fa-solid fa-envelope', route: 'invitations', action: 'manage', subject: 'UserAdmin' },
+        ],
+      },
+    });
     const labels = wrapper.vm.allTabs.map((t) => t.label);
     expect(labels).toContain('Invitations');
     const tab = wrapper.vm.allTabs.find((t) => t.label === 'Invitations');
@@ -126,10 +137,10 @@ describe('admin.layout', () => {
     expect(typeof headerTabs.props('can')).toBe('function');
   });
 
-  it('gracefully handles non-array admin.tabs (CorePageHeaderTabs receives only the built-in 5)', () => {
+  it('gracefully handles non-array admin.tabs (CorePageHeaderTabs receives only the built-in 4)', () => {
     const wrapper = mountLayout({ admin: { tabs: 'invalid' } });
     const headerTabs = wrapper.findComponent({ name: 'CorePageHeaderTabs' });
-    expect(headerTabs.props('tabs')).toHaveLength(5);
+    expect(headerTabs.props('tabs')).toHaveLength(4);
   });
 
   it('renders the error banner at the TOP of the layout, before the header', async () => {

--- a/src/modules/admin/tests/admin.router.unit.tests.js
+++ b/src/modules/admin/tests/admin.router.unit.tests.js
@@ -53,12 +53,14 @@ describe('admin.router (structure)', () => {
     expect(org.meta.display).toBe(false);
   });
 
-  it('registers the invitations child route', () => {
+  it('does NOT register an invitations child route (moved to the standalone invitations module)', () => {
+    // After the invitations↔org decouple (P6), the admin module no longer owns
+    // the invitations route — it is injected under /admin via adminChildModules
+    // from the invitations module, gated by isModuleActive('invitations').
     const routes = adminRoutes;
     const adminParent = routes.find((r) => Array.isArray(r.children));
     const child = adminParent.children.find((c) => c.path === 'invitations');
-    expect(child).toBeTruthy();
-    expect(child.name).toBe('Admin Invitations');
+    expect(child).toBeUndefined();
   });
 });
 

--- a/src/modules/admin/tests/admin.store.unit.tests.js
+++ b/src/modules/admin/tests/admin.store.unit.tests.js
@@ -456,69 +456,6 @@ describe('Admin Store', () => {
   });
 });
 
-describe('admin store — invitations', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia());
-    axios.get.mockReset();
-    axios.post.mockReset();
-    axios.delete.mockReset();
-  });
-
-  it('getInvitations loads the list into state', async () => {
-    const store = useAdminStore();
-    axios.get.mockResolvedValueOnce({ data: { data: [{ id: '1', email: 'a@b.co', usedAt: null }] } });
-    await store.getInvitations();
-    expect(axios.get).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/invitations$/));
-    expect(store.invitations).toEqual([{ id: '1', email: 'a@b.co', usedAt: null }]);
-  });
-
-  it('createInvitation POSTs the email and returns the created invite', async () => {
-    const store = useAdminStore();
-    axios.post.mockResolvedValueOnce({ data: { data: { id: '2', email: 'new@b.co' } } });
-    const result = await store.createInvitation('new@b.co');
-    expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/invitations$/), { email: 'new@b.co' });
-    expect(result).toEqual({ id: '2', email: 'new@b.co' });
-  });
-
-  it('deleteInvitation DELETEs by id', async () => {
-    const store = useAdminStore();
-    axios.delete.mockResolvedValueOnce({ data: { data: { id: '3' } } });
-    await store.deleteInvitation('3');
-    expect(axios.delete).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/invitations\/3$/));
-  });
-
-  it('getInvitations sets error state on API failure', async () => {
-    const store = useAdminStore();
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    axios.get.mockRejectedValueOnce(new Error('Network error'));
-    await store.getInvitations();
-    expect(store.invitations).toEqual([]);
-    expect(store.error).toBe('Failed to load data. Please try again.');
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('createInvitation sets error state and rethrows on API failure', async () => {
-    const store = useAdminStore();
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    axios.post.mockRejectedValueOnce(new Error('Server error'));
-    await expect(store.createInvitation('fail@b.co')).rejects.toThrow('Server error');
-    expect(store.error).toBe('Failed to load data. Please try again.');
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('deleteInvitation sets error state and rethrows on API failure', async () => {
-    const store = useAdminStore();
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    axios.delete.mockRejectedValueOnce(new Error('Forbidden'));
-    await expect(store.deleteInvitation('99')).rejects.toThrow('Forbidden');
-    expect(store.error).toBe('Failed to load data. Please try again.');
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
-  });
-});
-
 describe('admin store — currentBreadcrumb', () => {
   beforeEach(() => {
     setActivePinia(createPinia());

--- a/src/modules/admin/views/admin.layout.vue
+++ b/src/modules/admin/views/admin.layout.vue
@@ -61,7 +61,6 @@ import { useAuthStore } from '../../auth/stores/auth.store';
  */
 const BUILT_IN_TABS = Object.freeze([
   { value: 'users', label: 'Users', icon: 'fa-solid fa-users', route: 'users' },
-  { value: 'invitations', label: 'Invitations', icon: 'fa-solid fa-envelope', route: 'invitations' },
   { value: 'organizations', label: 'Organizations', icon: 'fa-solid fa-building', route: 'organizations' },
   { value: 'readiness', label: 'Readiness', icon: 'fa-solid fa-clipboard-check', route: 'readiness' },
   { value: 'activity', label: 'Activity', icon: 'fa-solid fa-clock-rotate-left', route: 'activity' },

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -13,10 +13,11 @@ import home from '../home/router/home.router';
 import auth from '../auth/router/auth.router';
 import organizations, { ORG_PARENT_PATH } from '../organizations/router/organizations.router';
 import admin from '../admin/router/admin.router';
-import users from '../users/router/users.router';
+import users, { ACCOUNT_PARENT_PATH } from '../users/router/users.router';
 import tasks from '../tasks/router/tasks.router';
 import billing, { organizationRoutes as billingOrganizationRoutes } from '../billing/router/billing.router';
 import legal from '../legal/router/legal.router';
+import { invitationsAdminRoutes, invitationsAccountRoutes } from '../invitations/router/invitations.router';
 
 /**
  * Downstream route registries — mutated by `registerDownstreamRoutes` before
@@ -27,6 +28,7 @@ import legal from '../legal/router/legal.router';
  */
 const _downstreamCoreModules = [];
 const _downstreamAdminChildModules = [];
+const _downstreamAccountChildModules = [];
 const _downstreamOptionalModules = [];
 
 /**
@@ -37,14 +39,16 @@ const _downstreamOptionalModules = [];
  * arrays in place; the router composition picks up the additions automatically.
  *
  * @param {object}   [options={}]
- * @param {Array}    [options.coreModules]        Routes spread into `coreRoutes` (always mounted, no activation gate).
- * @param {Array}    [options.adminChildModules]  Added to `adminChildModules` (injected under `/admin`).
- * @param {Array}    [options.optionalModules]    Added to `optionalModules` (gated by `isModuleActive`).
+ * @param {Array}    [options.coreModules]          Routes spread into `coreRoutes` (always mounted, no activation gate).
+ * @param {Array}    [options.adminChildModules]    Added to `adminChildModules` (injected under `/admin`).
+ * @param {Array}    [options.accountChildModules]  Added to `accountChildModules` (injected under `/users`).
+ * @param {Array}    [options.optionalModules]      Added to `optionalModules` (gated by `isModuleActive`).
  * @returns {void}
  */
 export function registerDownstreamRoutes(options = {}) {
   if (options.coreModules) _downstreamCoreModules.push(...options.coreModules);
   if (options.adminChildModules) _downstreamAdminChildModules.push(...options.adminChildModules);
+  if (options.accountChildModules) _downstreamAccountChildModules.push(...options.accountChildModules);
   if (options.optionalModules) _downstreamOptionalModules.push(...options.optionalModules);
 }
 
@@ -74,8 +78,28 @@ const getRouter = () => {
    *     { name: 'my-tab', routes: myTabRoutes },
    *   ];
    */
-  const adminChildModules = [..._downstreamAdminChildModules];
+  const adminChildModules = [
+    { name: 'invitations', routes: invitationsAdminRoutes },
+    ..._downstreamAdminChildModules,
+  ];
   injectAdminChildren(admin, adminChildModules, isModuleActive);
+
+  /**
+   * Account child modules — routes injected as children of the `/users` parent
+   * route (the account surface) via `injectModuleChildren`, gated by
+   * `isModuleActive`. Net-new seam (mirrors the org-settings injection): the
+   * standalone `invitations` module contributes its "Referrals" tab here so the
+   * account layout renders `/users/invitations` inline. The matching tab
+   * descriptor lives in `config.users.extraTabs` (merged by `user.view.vue`).
+   *
+   * Each module's router exports routes with **relative** paths (e.g.
+   * `'invitations'`) so they resolve under the `/users` parent.
+   */
+  const accountChildModules = [
+    { name: 'invitations', routes: invitationsAccountRoutes },
+    ..._downstreamAccountChildModules,
+  ];
+  injectModuleChildren(users, accountChildModules, isModuleActive, ACCOUNT_PARENT_PATH);
 
   /**
    * Organization-settings child modules — routes injected as children of the

--- a/src/modules/app/tests/app.router.unit.tests.js
+++ b/src/modules/app/tests/app.router.unit.tests.js
@@ -489,6 +489,36 @@ describe('app.router', () => {
     });
   });
 
+  describe('invitations module injection (P6 — optional-module guarantee)', () => {
+    it('injects the invitations child route under BOTH /admin and /users when the module is active', async () => {
+      vi.resetModules();
+      mockIsModuleActive = () => true;
+      const mod = await setupRouterModule();
+      const router = mod.default();
+      const adminParent = router.options.routes.find((r) => r.path === '/admin');
+      const accountParent = router.options.routes.find((r) => r.path === '/users');
+      expect(adminParent).toBeDefined();
+      expect(accountParent).toBeDefined();
+      expect(adminParent.children.find((c) => c.path === 'invitations')).toBeDefined();
+      expect(accountParent.children.find((c) => c.path === 'invitations')).toBeDefined();
+    });
+
+    it('does NOT inject the invitations child route under /admin or /users when the module is inactive (admin + account surfaces still work)', async () => {
+      vi.resetModules();
+      mockIsModuleActive = (name) => name !== 'invitations';
+      const mod = await setupRouterModule();
+      const router = mod.default();
+      const adminParent = router.options.routes.find((r) => r.path === '/admin');
+      const accountParent = router.options.routes.find((r) => r.path === '/users');
+      // The host surfaces remain — the optional module's absence must not break them.
+      expect(adminParent).toBeDefined();
+      expect(accountParent).toBeDefined();
+      // ...but the invitations tab/route is absent from both.
+      expect((adminParent.children || []).find((c) => c.path === 'invitations')).toBeUndefined();
+      expect((accountParent.children || []).find((c) => c.path === 'invitations')).toBeUndefined();
+    });
+  });
+
   describe('module activation gating', () => {
     it('includes all module routes when all modules are active', () => {
       mockIsModuleActive = () => true;

--- a/src/modules/invitations/config/invitations.development.config.js
+++ b/src/modules/invitations/config/invitations.development.config.js
@@ -1,0 +1,27 @@
+export default {
+  // Surface tabs contributed by the standalone invitations module. These are
+  // merged at runtime by the host surfaces (admin.layout.vue → config.admin.tabs,
+  // user.view.vue → config.users.extraTabs) and validated + CASL-filtered inside
+  // CoreSurfaceTabBar. Both routes are relative (resolve under their parent).
+  //
+  // NOTE: the account tab uses `users.extraTabs` (NOT `users.tabs`) on purpose —
+  // generateConfig's deepMerge REPLACES arrays, and `invitations` sorts before
+  // `users` alphabetically, so contributing `users.tabs` here would clobber the
+  // base Profile/Organizations tabs. `extraTabs` is a fresh key owned by nobody,
+  // so it merges cleanly into the `users` config object.
+  admin: {
+    tabs: [
+      { value: 'invitations', label: 'Invitations', icon: 'fa-solid fa-envelope', route: 'invitations', action: 'manage', subject: 'UserAdmin' },
+    ],
+  },
+  users: {
+    extraTabs: [
+      { value: 'invitations', label: 'Referrals', icon: 'fa-solid fa-gift', route: 'invitations', action: 'create', subject: 'Invitation' },
+    ],
+  },
+  modules: {
+    invitations: {
+      activated: true,
+    },
+  },
+};

--- a/src/modules/invitations/router/invitations.router.js
+++ b/src/modules/invitations/router/invitations.router.js
@@ -1,0 +1,56 @@
+/**
+ * Router configuration — standalone `invitations` module.
+ *
+ * This module owns NO top-level route. Instead it exports two relative-path
+ * child-route arrays that the host (`app.router.js`) injects under existing
+ * parents via `injectModuleChildren`, gated by `isModuleActive('invitations')`:
+ *
+ *  - `invitationsAdminRoutes`   → injected under `/admin`  (admin management tab)
+ *  - `invitationsAccountRoutes` → injected under `/users`  (account "Referrals" tab)
+ *
+ * Paths are **relative** (`'invitations'`, not `'/admin/invitations'`) so they
+ * resolve under their respective parents — required by `isValidChildRoute`.
+ * Views are lazy-imported (mirrors the billing module's self-injection pattern)
+ * so they only load when the module is active. The matching tab descriptors live
+ * in `config/invitations.development.config.js` (`admin.tabs` + `users.extraTabs`).
+ *
+ * @module invitations/router
+ */
+
+/**
+ * Admin-surface child route (rendered inside the admin layout). CASL-gated to
+ * platform admins via `meta.action/subject`.
+ * @type {Array<object>}
+ */
+export const invitationsAdminRoutes = [
+  {
+    path: 'invitations',
+    name: 'Admin Invitations',
+    component: () => import('../views/invitations.admin.view.vue'),
+    meta: {
+      action: 'manage', subject: 'UserAdmin',
+    },
+  },
+];
+
+/**
+ * Account-surface child route (rendered inside the account layout). Requires an
+ * authenticated user; fine-grained tab visibility is handled by the
+ * `users.extraTabs` CASL descriptor (`create` / `Invitation`).
+ * @type {Array<object>}
+ */
+export const invitationsAccountRoutes = [
+  {
+    path: 'invitations',
+    name: 'Account Invitations',
+    component: () => import('../views/invitations.account.view.vue'),
+    meta: {
+      requiresAuth: true,
+    },
+  },
+];
+
+/**
+ * Exports.
+ */
+export default { invitationsAdminRoutes, invitationsAccountRoutes };

--- a/src/modules/invitations/router/invitations.router.js
+++ b/src/modules/invitations/router/invitations.router.js
@@ -34,9 +34,10 @@ export const invitationsAdminRoutes = [
 ];
 
 /**
- * Account-surface child route (rendered inside the account layout). Requires an
- * authenticated user; fine-grained tab visibility is handled by the
- * `users.extraTabs` CASL descriptor (`create` / `Invitation`).
+ * Account-surface child route (rendered inside the account layout). CASL-gated
+ * to users who can create an Invitation (`create` / `Invitation`); this mirrors
+ * the tab-descriptor guard in `users.extraTabs` so direct navigation respects
+ * the same ability check.
  * @type {Array<object>}
  */
 export const invitationsAccountRoutes = [
@@ -46,6 +47,8 @@ export const invitationsAccountRoutes = [
     component: () => import('../views/invitations.account.view.vue'),
     meta: {
       requiresAuth: true,
+      action: 'create',
+      subject: 'Invitation',
     },
   },
 ];

--- a/src/modules/invitations/stores/invitations.store.js
+++ b/src/modules/invitations/stores/invitations.store.js
@@ -1,0 +1,106 @@
+/**
+ * Module dependencies.
+ */
+import { defineStore } from 'pinia';
+import axios from '../../../lib/services/axios';
+import config from '../../../lib/services/config';
+import { capture } from '../../../lib/helpers/analytics';
+import { createLogger } from '../../../lib/helpers/logger';
+
+const logger = createLogger('invitations');
+
+/**
+ * Sanitize API error messages to avoid leaking internal details (stack traces, DB paths, etc.).
+ * @param {unknown} err - The caught error object.
+ * @returns {string} A safe, user-facing error message.
+ */
+const sanitizeApiError = (err) => {
+  const msg = err?.response?.data?.message || '';
+  if (msg && msg.length <= 200 && !/\b(collection|stack)\b|Error:|^\s*at\s+|\/[a-z]+\/|\.[jt]s:\d+/.test(msg)) {
+    return msg;
+  }
+  return 'Failed to load data. Please try again.';
+};
+
+/**
+ * Build the base API URL from config.
+ * @returns {string} The base API URL.
+ */
+const apiBase = () => `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
+
+/**
+ * Store definition — platform signup invitations (admin management + account
+ * "Referrals" surface). Talks to the canonical `/api/invitations` mount served
+ * by the standalone Node `invitations` module (the legacy `/api/auth/invitations`
+ * alias is being retired). Replaces the invitation actions previously hosted in
+ * `admin.store.js` as part of the invitations↔org decouple (P6).
+ */
+export const useInvitationsStore = defineStore('invitations', {
+  state: () => ({
+    invitations: [],
+    error: null,
+  }),
+
+  actions: {
+    /**
+     * @desc Load all signup invitations (admin). Backend returns the full list
+     * (no server pagination), newest first, with token stripped.
+     * @returns {Promise<void>}
+     */
+    async getInvitations() {
+      this.error = null;
+      try {
+        const res = await axios.get(`${apiBase()}/invitations`);
+        this.invitations = res.data.data;
+      } catch (err) {
+        this.invitations = [];
+        this.error = sanitizeApiError(err);
+        logger.error(err);
+      }
+    },
+
+    /**
+     * @desc Create + email a platform signup invitation for an email. Used by
+     * both the admin management tab and the account "Referrals" tab — the
+     * backend CASL policy decides who is allowed (platform admins today;
+     * regular users once the referral ability is granted in a later phase).
+     * Re-emits the `invitation_created` analytics event so the funnel parity is
+     * preserved after the org `invitation_sent` capture is dropped (P7).
+     * @param {string} email
+     * @returns {Promise<Object>} the created invitation
+     */
+    async createInvitation(email) {
+      this.error = null;
+      try {
+        const res = await axios.post(`${apiBase()}/invitations`, { email });
+        capture('invitation_created', { source: 'platform' });
+        return res.data.data;
+      } catch (err) {
+        this.error = sanitizeApiError(err);
+        logger.error(err);
+        throw err;
+      }
+    },
+
+    /**
+     * @desc Revoke a signup invitation by id.
+     * @param {string} id
+     * @returns {Promise<void>}
+     */
+    async deleteInvitation(id) {
+      this.error = null;
+      try {
+        await axios.delete(`${apiBase()}/invitations/${id}`);
+      } catch (err) {
+        this.error = sanitizeApiError(err);
+        logger.error(err);
+        throw err;
+      }
+    },
+  },
+});
+
+/**
+ * Exports.
+ */
+export default useInvitationsStore;

--- a/src/modules/invitations/tests/invitations.account.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.account.view.unit.tests.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { shallowMount } from '@vue/test-utils';
+import { useInvitationsStore } from '../stores/invitations.store';
+import InvitationsAccount from '../views/invitations.account.view.vue';
+
+vi.mock('../../../lib/services/axios', () => ({ default: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } }));
+vi.mock('../../../lib/services/config', () => ({
+  default: {
+    api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api' },
+    vuetify: { theme: { flat: true, rounded: 'rounded-lg' } },
+  },
+}));
+
+const stubs = {
+  // Render the #status slot so the chip template function is invoked
+  coreDataTableComponent: {
+    template: `<div><slot name="status" :item="{ id:'s1', email:'a@b.co', usedAt: null, expiresAt: '2999-01-01' }" /></div>`,
+  },
+  'v-container': { template: '<div><slot /></div>' },
+  'v-row': { template: '<div><slot /></div>' },
+  'v-col': { template: '<div><slot /></div>' },
+  'v-btn': { template: '<button @click="$emit(\'click\')"><slot /></button>', emits: ['click'] },
+  'v-card': { template: '<div><slot /></div>' },
+  'v-alert': { template: '<div class="v-alert"><slot /><button class="alert-close" @click="$emit(\'click:close\')"></button></div>', emits: ['click:close'] },
+  'v-text-field': { template: '<input class="vtext-field" @input="$emit(\'update:modelValue\', $event.target.value)" />', emits: ['update:modelValue'], props: ['rules', 'modelValue'] },
+  'v-form': { template: '<form @submit.prevent="$emit(\'update:modelValue\', true)"><slot /></form>', emits: ['update:modelValue'], props: ['modelValue'] },
+  'v-chip': { template: '<span><slot /></span>' },
+  'v-icon': { template: '<i />' },
+};
+
+const mountView = () =>
+  shallowMount(InvitationsAccount, {
+    global: {
+      mocks: { config: { vuetify: { theme: { flat: true, rounded: 'rounded-lg' } } } },
+      stubs,
+    },
+  });
+
+describe('invitations.account.view', () => {
+  let store;
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    store = useInvitationsStore();
+    store.getInvitations = vi.fn().mockResolvedValue();
+    store.createInvitation = vi.fn().mockResolvedValue({ id: '9', email: 'x@y.co' });
+  });
+
+  it('exposes invitations from the invitations store', () => {
+    store.invitations = [{ id: '1', email: 'a@b.co', usedAt: null, expiresAt: null }];
+    const wrapper = mountView();
+    expect(wrapper.vm.invitations).toEqual([{ id: '1', email: 'a@b.co', usedAt: null, expiresAt: null }]);
+  });
+
+  it('exposes the store error (surfaced as a banner)', () => {
+    store.error = 'boom';
+    const wrapper = mountView();
+    expect(wrapper.vm.error).toBe('boom');
+  });
+
+  it('fetchInvitations delegates to the store', async () => {
+    const wrapper = mountView();
+    await wrapper.vm.fetchInvitations();
+    expect(store.getInvitations).toHaveBeenCalled();
+  });
+
+  it('inviteStatus derives Accepted / Expired / Pending', () => {
+    const wrapper = mountView();
+    expect(wrapper.vm.inviteStatus({ usedAt: '2026-01-01' }).label).toBe('Accepted');
+    expect(wrapper.vm.inviteStatus({ usedAt: null, expiresAt: '2000-01-01' }).label).toBe('Expired');
+    expect(wrapper.vm.inviteStatus({ usedAt: null, expiresAt: '2999-01-01' }).label).toBe('Pending');
+  });
+
+  it('submitInvite no-ops when the form is invalid', async () => {
+    const wrapper = mountView();
+    wrapper.vm.inviteForm.valid = false;
+    wrapper.vm.inviteForm.email = 'whatever@b.co';
+    await wrapper.vm.submitInvite();
+    expect(store.createInvitation).not.toHaveBeenCalled();
+  });
+
+  it('submitInvite (valid) creates the invite, resets the email, refreshes the list', async () => {
+    const wrapper = mountView();
+    wrapper.vm.inviteForm.valid = true;
+    wrapper.vm.inviteForm.email = 'new@b.co';
+    await wrapper.vm.submitInvite();
+    expect(store.createInvitation).toHaveBeenCalledWith('new@b.co');
+    expect(store.getInvitations).toHaveBeenCalled();
+    expect(wrapper.vm.inviteForm.email).toBe('');
+    expect(wrapper.vm.inviteForm.loading).toBe(false);
+  });
+
+  it('submitInvite error path: loading ends false, email NOT reset, no throw', async () => {
+    store.createInvitation = vi.fn().mockRejectedValue(new Error('Server error'));
+    const wrapper = mountView();
+    wrapper.vm.inviteForm.valid = true;
+    wrapper.vm.inviteForm.email = 'fail@b.co';
+    await expect(wrapper.vm.submitInvite()).resolves.toBeUndefined();
+    expect(wrapper.vm.inviteForm.loading).toBe(false);
+    // create threw before the email reset → email is preserved so the user can retry
+    expect(wrapper.vm.inviteForm.email).toBe('fail@b.co');
+    expect(store.getInvitations).not.toHaveBeenCalled();
+  });
+
+  it('clearError nulls the store error', () => {
+    store.error = 'oops';
+    const wrapper = mountView();
+    wrapper.vm.clearError();
+    expect(store.error).toBeNull();
+  });
+
+  it('rules.required returns true for a value, error string for empty', () => {
+    const wrapper = mountView();
+    expect(wrapper.vm.rules.required('x')).toBe(true);
+    expect(wrapper.vm.rules.required('')).toBe('Required');
+  });
+
+  it('rules.mail returns true for a valid email, error string for garbage', () => {
+    const wrapper = mountView();
+    expect(wrapper.vm.rules.mail('user@example.com')).toBe(true);
+    expect(wrapper.vm.rules.mail('not-an-email')).toBe('E-mail must be valid');
+  });
+});

--- a/src/modules/invitations/tests/invitations.account.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.account.view.unit.tests.js
@@ -29,6 +29,10 @@ const stubs = {
   'v-icon': { template: '<i />' },
 };
 
+/**
+ * Mount InvitationsAccount in shallow mode with shared stubs.
+ * @returns {import('@vue/test-utils').VueWrapper} Mounted component wrapper.
+ */
 const mountView = () =>
   shallowMount(InvitationsAccount, {
     global: {

--- a/src/modules/invitations/tests/invitations.admin.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.admin.view.unit.tests.js
@@ -49,6 +49,10 @@ const stubs = {
   'v-icon': { template: '<i />' },
 };
 
+/**
+ * Mount InvitationsAdmin in shallow mode with shared stubs.
+ * @returns {import('@vue/test-utils').VueWrapper} Mounted component wrapper.
+ */
 const mountView = () =>
   shallowMount(InvitationsAdmin, {
     global: {

--- a/src/modules/invitations/tests/invitations.admin.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.admin.view.unit.tests.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { shallowMount } from '@vue/test-utils';
-import { useAdminStore } from '../stores/admin.store';
-import AdminInvitations from '../views/admin.invitations.view.vue';
+import { useInvitationsStore } from '../stores/invitations.store';
+import InvitationsAdmin from '../views/invitations.admin.view.vue';
 
 vi.mock('../../../lib/services/axios', () => ({ default: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } }));
 vi.mock('../../../lib/services/config', () => ({
@@ -50,24 +50,24 @@ const stubs = {
 };
 
 const mountView = () =>
-  shallowMount(AdminInvitations, {
+  shallowMount(InvitationsAdmin, {
     global: {
       mocks: { config: { vuetify: { theme: { flat: true, rounded: 'rounded-lg' } } } },
       stubs,
     },
   });
 
-describe('admin.invitations.view', () => {
+describe('invitations.admin.view', () => {
   let store;
   beforeEach(() => {
     setActivePinia(createPinia());
-    store = useAdminStore();
+    store = useInvitationsStore();
     store.getInvitations = vi.fn().mockResolvedValue();
     store.createInvitation = vi.fn().mockResolvedValue({ id: '9', email: 'x@y.co' });
     store.deleteInvitation = vi.fn().mockResolvedValue();
   });
 
-  it('exposes invitations from the admin store', () => {
+  it('exposes invitations from the invitations store', () => {
     store.invitations = [{ id: '1', email: 'a@b.co', usedAt: null, expiresAt: null }];
     const wrapper = mountView();
     expect(wrapper.vm.invitations).toEqual([{ id: '1', email: 'a@b.co', usedAt: null, expiresAt: null }]);
@@ -167,19 +167,6 @@ describe('admin.invitations.view', () => {
     // item has only _id (no .id) — should still populate deleteDialog correctly
     wrapper.vm.openRevoke({ _id: 'mongo-id-99', email: 'only-id@b.co' });
     expect(wrapper.vm.deleteDialog).toEqual({ show: true, id: 'mongo-id-99', email: 'only-id@b.co' });
-  });
-
-  it('cancel button in create-dialog sets createDialog.show = false (line 49)', async () => {
-    const wrapper = mountView();
-    // Open the dialog first so the Cancel click is meaningful
-    wrapper.vm.createDialog.show = true;
-    await wrapper.vm.$nextTick();
-    // The Cancel v-btn is the first button rendered inside v-card-actions.
-    // Its @click calls `createDialog.show = false` directly.
-    // Call the handler directly to assert the exact line behavior.
-    wrapper.vm.createDialog.show = false;
-    await wrapper.vm.$nextTick();
-    expect(wrapper.vm.createDialog.show).toBe(false);
   });
 
   it('v-dialog update:modelValue handler sets createDialog.show (line 33 binding)', async () => {

--- a/src/modules/invitations/tests/invitations.router.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.router.unit.tests.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import router, { invitationsAdminRoutes, invitationsAccountRoutes } from '../router/invitations.router';
+
+describe('invitations.router', () => {
+  it('exports two named child-route arrays (admin + account)', () => {
+    expect(Array.isArray(invitationsAdminRoutes)).toBe(true);
+    expect(Array.isArray(invitationsAccountRoutes)).toBe(true);
+    expect(invitationsAdminRoutes).toHaveLength(1);
+    expect(invitationsAccountRoutes).toHaveLength(1);
+    // default export bundles both (the shape app.router.js consumes)
+    expect(router.invitationsAdminRoutes).toBe(invitationsAdminRoutes);
+    expect(router.invitationsAccountRoutes).toBe(invitationsAccountRoutes);
+  });
+
+  it('admin route is RELATIVE (resolves under /admin) and CASL-gated to platform admins', () => {
+    const [admin] = invitationsAdminRoutes;
+    // relative path — isValidChildRoute rejects absolute/degenerate routes
+    expect(admin.path).toBe('invitations');
+    expect(admin.path.startsWith('/')).toBe(false);
+    expect(admin.meta).toMatchObject({ action: 'manage', subject: 'UserAdmin' });
+    expect(typeof admin.component).toBe('function'); // lazy import
+  });
+
+  it('account route is RELATIVE (resolves under /users) and requires auth', () => {
+    const [account] = invitationsAccountRoutes;
+    expect(account.path).toBe('invitations');
+    expect(account.path.startsWith('/')).toBe(false);
+    expect(account.meta).toMatchObject({ requiresAuth: true });
+    expect(typeof account.component).toBe('function'); // lazy import
+  });
+
+  it('the two routes target distinct lazy-loaded views', () => {
+    const [admin] = invitationsAdminRoutes;
+    const [account] = invitationsAccountRoutes;
+    expect(admin.component).not.toBe(account.component);
+  });
+});

--- a/src/modules/invitations/tests/invitations.store.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.store.unit.tests.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useInvitationsStore } from '../stores/invitations.store';
+import axios from '../../../lib/services/axios';
+import { capture } from '../../../lib/helpers/analytics';
+
+// Mock axios
+vi.mock('../../../lib/services/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// Mock config
+vi.mock('../../../lib/services/config', () => ({
+  default: {
+    api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api' },
+    cookie: { prefix: 'devkit' },
+  },
+}));
+
+// Mock analytics so the PostHog re-emit can be asserted without a live SDK.
+vi.mock('../../../lib/helpers/analytics', () => ({
+  capture: vi.fn(),
+}));
+
+describe('invitations store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    axios.get.mockReset();
+    axios.post.mockReset();
+    axios.delete.mockReset();
+    capture.mockReset();
+  });
+
+  it('initializes with empty state', () => {
+    const store = useInvitationsStore();
+    expect(store.invitations).toEqual([]);
+    expect(store.error).toBeNull();
+  });
+
+  // ── Canonical mount: all actions hit /api/invitations (NOT /api/auth/invitations) ──
+
+  it('getInvitations loads the list from the canonical /api/invitations mount', async () => {
+    const store = useInvitationsStore();
+    axios.get.mockResolvedValueOnce({ data: { data: [{ id: '1', email: 'a@b.co', usedAt: null }] } });
+    await store.getInvitations();
+    expect(axios.get).toHaveBeenCalledWith(expect.stringMatching(/\/api\/invitations$/));
+    // Must NOT use the deprecated auth alias.
+    expect(axios.get).not.toHaveBeenCalledWith(expect.stringMatching(/\/auth\/invitations/));
+    expect(store.invitations).toEqual([{ id: '1', email: 'a@b.co', usedAt: null }]);
+  });
+
+  it('createInvitation POSTs to /api/invitations and returns the created invite', async () => {
+    const store = useInvitationsStore();
+    axios.post.mockResolvedValueOnce({ data: { data: { id: '2', email: 'new@b.co' } } });
+    const result = await store.createInvitation('new@b.co');
+    expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/api\/invitations$/), { email: 'new@b.co' });
+    expect(axios.post).not.toHaveBeenCalledWith(expect.stringMatching(/\/auth\/invitations/), expect.anything());
+    expect(result).toEqual({ id: '2', email: 'new@b.co' });
+  });
+
+  it('deleteInvitation DELETEs /api/invitations/:id by id', async () => {
+    const store = useInvitationsStore();
+    axios.delete.mockResolvedValueOnce({ data: { data: { id: '3' } } });
+    await store.deleteInvitation('3');
+    expect(axios.delete).toHaveBeenCalledWith(expect.stringMatching(/\/api\/invitations\/3$/));
+    expect(axios.delete).not.toHaveBeenCalledWith(expect.stringMatching(/\/auth\/invitations/));
+  });
+
+  // ── PostHog funnel parity (re-emit invitation_created on platform create) ──
+
+  it('createInvitation re-emits the invitation_created analytics event', async () => {
+    const store = useInvitationsStore();
+    axios.post.mockResolvedValueOnce({ data: { data: { id: '5', email: 'z@b.co' } } });
+    await store.createInvitation('z@b.co');
+    expect(capture).toHaveBeenCalledWith('invitation_created', { source: 'platform' });
+  });
+
+  it('createInvitation does NOT emit analytics when the request fails', async () => {
+    const store = useInvitationsStore();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.post.mockRejectedValueOnce(new Error('Server error'));
+    await expect(store.createInvitation('fail@b.co')).rejects.toThrow('Server error');
+    expect(capture).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  // ── Error handling (sanitized message, state reset, rethrow semantics) ──
+
+  it('getInvitations resets the list and sets a sanitized error on API failure', async () => {
+    const store = useInvitationsStore();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    store.invitations = [{ id: 'stale' }];
+    axios.get.mockRejectedValueOnce(new Error('Network error'));
+    await store.getInvitations();
+    expect(store.invitations).toEqual([]);
+    expect(store.error).toBe('Failed to load data. Please try again.');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('createInvitation sets error state and rethrows on API failure', async () => {
+    const store = useInvitationsStore();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.post.mockRejectedValueOnce(new Error('Server error'));
+    await expect(store.createInvitation('fail@b.co')).rejects.toThrow('Server error');
+    expect(store.error).toBe('Failed to load data. Please try again.');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('deleteInvitation sets error state and rethrows on API failure', async () => {
+    const store = useInvitationsStore();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.delete.mockRejectedValueOnce(new Error('Forbidden'));
+    await expect(store.deleteInvitation('99')).rejects.toThrow('Forbidden');
+    expect(store.error).toBe('Failed to load data. Please try again.');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('surfaces a safe API message when the backend returns a clean one', async () => {
+    const store = useInvitationsStore();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.get.mockRejectedValueOnce({ response: { data: { message: 'You are not allowed to invite users.' } } });
+    await store.getInvitations();
+    expect(store.error).toBe('You are not allowed to invite users.');
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('does NOT leak internal error details (stack/db paths) in the surfaced message', async () => {
+    const store = useInvitationsStore();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.get.mockRejectedValueOnce({ response: { data: { message: 'Error: at /app/modules/invitations/x.js:42 collection invitations' } } });
+    await store.getInvitations();
+    expect(store.error).toBe('Failed to load data. Please try again.');
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/modules/invitations/views/invitations.account.view.vue
+++ b/src/modules/invitations/views/invitations.account.view.vue
@@ -1,0 +1,178 @@
+<template>
+  <v-container fluid>
+    <v-row class="pa-2 mt-0">
+      <!-- Error banner (surfaced from the invitations store) -->
+      <v-col v-if="error" cols="12">
+        <v-alert
+          type="error"
+          variant="tonal"
+          density="compact"
+          closable
+          :class="config.vuetify.theme.rounded"
+          icon="fa-solid fa-circle-exclamation"
+          @click:close="clearError"
+        >
+          <span class="text-body-medium">{{ error }}</span>
+        </v-alert>
+      </v-col>
+
+      <!-- Invite a contact -->
+      <v-col cols="12">
+        <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-6">
+          <div class="d-flex align-center mb-2">
+            <v-icon icon="fa-solid fa-gift" color="primary" class="mr-3"></v-icon>
+            <span class="text-title-large">Invite a contact</span>
+          </div>
+          <p class="text-body-medium text-medium-emphasis mb-4">
+            Share the platform with someone you know. They'll receive an email invitation to join.
+          </p>
+          <v-form ref="inviteForm" v-model="inviteForm.valid" @submit.prevent="submitInvite">
+            <div class="d-flex flex-column flex-sm-row ga-3">
+              <v-text-field
+                v-model="inviteForm.email"
+                label="Email address"
+                :rules="[rules.required, rules.mail]"
+                variant="outlined"
+                density="comfortable"
+                hide-details="auto"
+                class="flex-grow-1"
+              ></v-text-field>
+              <v-btn
+                type="submit"
+                color="primary"
+                variant="flat"
+                size="large"
+                :class="config.vuetify.theme.rounded"
+                class="text-none"
+                :loading="inviteForm.loading"
+                :disabled="inviteForm.valid !== true"
+              >
+                <v-icon start icon="fa-solid fa-paper-plane"></v-icon>
+                Send invite
+              </v-btn>
+            </div>
+          </v-form>
+        </v-card>
+      </v-col>
+
+      <!-- My invitations -->
+      <v-col cols="12">
+        <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-6">
+          <div class="d-flex align-center mb-4">
+            <v-icon icon="fa-solid fa-envelope" color="primary" class="mr-3"></v-icon>
+            <span class="text-title-large">My invitations</span>
+          </div>
+          <coreDataTableComponent :headers="inviteHeaders" :items="invitations" :fetch-action="fetchInvitations" :search="false">
+            <template #status="{ item }">
+              <v-chip :color="inviteStatus(item).color" size="small" variant="tonal">{{ inviteStatus(item).label }}</v-chip>
+            </template>
+          </coreDataTableComponent>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+/**
+ * Module dependencies.
+ */
+import { useInvitationsStore } from '../stores/invitations.store';
+import coreDataTableComponent from '../../core/components/core.datatable.component.vue';
+
+/**
+ * Component definition — account "Referrals" tab.
+ *
+ * The user-facing surface of the standalone `invitations` module: invite a
+ * contact (platform invite via `/api/invitations`) + see the status of the
+ * invitations I've sent. Rendered inside the account layout as an injected
+ * `/users/invitations` child route + a config-contributed `users.extraTabs`
+ * entry, both gated by `isModuleActive('invitations')`.
+ *
+ * P8b expands this into the full referrals experience (referral attribution,
+ * rewards). This phase ships the invite-a-contact + my-invites foundation.
+ */
+export default {
+  name: 'InvitationsAccount',
+  components: { coreDataTableComponent },
+  /**
+   * @desc Reactive state: invite form, table headers, validation rules.
+   * @returns {Object}
+   */
+  data() {
+    return {
+      inviteForm: { email: '', valid: false, loading: false },
+      inviteHeaders: [
+        { text: 'Email', value: 'email', kind: 'email' },
+        { text: 'Status', value: 'status', kind: 'slot', slotName: 'status' },
+        { text: 'Sent', value: 'createdAt', kind: 'date', format: 'DD/MM/YY HH:mm' },
+        { text: 'Expires', value: 'expiresAt', kind: 'date', format: 'DD/MM/YY' },
+      ],
+      rules: {
+        required: (v) => !!v || 'Required',
+        mail: (v) => /\S+@\S+\.\S+/.test(v) || 'E-mail must be valid',
+      },
+    };
+  },
+  computed: {
+    /**
+     * @desc The invitations list from the invitations store.
+     * @returns {Array}
+     */
+    invitations() {
+      return useInvitationsStore().invitations;
+    },
+    /**
+     * @desc Global error from the invitations store (surfaced as a banner).
+     * @returns {string|null}
+     */
+    error() {
+      return useInvitationsStore().error;
+    },
+  },
+  methods: {
+    /**
+     * @desc Load the invitations list (passed to the datatable's fetch-action).
+     * @returns {Promise<void>}
+     */
+    async fetchInvitations() {
+      await useInvitationsStore().getInvitations();
+    },
+    /**
+     * @desc Derive a status label + color from an invitation's lifecycle fields.
+     * @param {Object} item - invitation
+     * @returns {{ label: string, color: string }}
+     */
+    inviteStatus(item) {
+      if (item.usedAt) return { label: 'Accepted', color: 'success' };
+      if (item.expiresAt && new Date(item.expiresAt).getTime() < Date.now()) return { label: 'Expired', color: 'error' };
+      return { label: 'Pending', color: 'warning' };
+    },
+    /**
+     * @desc Submit a new invitation, then refresh the list and reset the form.
+     * @returns {Promise<void>}
+     */
+    async submitInvite() {
+      if (this.inviteForm.valid !== true) return;
+      this.inviteForm.loading = true;
+      try {
+        await useInvitationsStore().createInvitation(this.inviteForm.email);
+        this.inviteForm.email = '';
+        this.$refs.inviteForm?.resetValidation?.();
+        await this.fetchInvitations();
+      } catch {
+        // error is surfaced via the store error banner
+      } finally {
+        this.inviteForm.loading = false;
+      }
+    },
+    /**
+     * @desc Clear the invitations store error banner.
+     * @returns {void}
+     */
+    clearError() {
+      useInvitationsStore().error = null;
+    },
+  },
+};
+</script>

--- a/src/modules/invitations/views/invitations.admin.view.vue
+++ b/src/modules/invitations/views/invitations.admin.view.vue
@@ -68,15 +68,21 @@
 /**
  * Module dependencies.
  */
-import { useAdminStore } from '../stores/admin.store';
+import { useInvitationsStore } from '../stores/invitations.store';
 import coreDataTableComponent from '../../core/components/core.datatable.component.vue';
 import coreConfirmDialog from '../../core/components/core.confirmDialog.component.vue';
 
 /**
- * Component definition — admin invitations management tab.
+ * Component definition — admin platform-invitations management tab.
+ *
+ * Moved out of the admin module into the standalone `invitations` module
+ * (invitations↔org decouple, P6). Renders inside the admin layout as an
+ * injected child route + config-contributed tab; the management UI itself is
+ * unchanged from the former `admin.invitations.view.vue`, only its store
+ * dependency is repointed to the dedicated invitations store.
  */
 export default {
-  name: 'AdminInvitations',
+  name: 'InvitationsAdmin',
   components: { coreDataTableComponent, coreConfirmDialog },
   /**
    * @desc Reactive state: table headers, create + revoke dialog state, form rules.
@@ -102,11 +108,11 @@ export default {
   },
   computed: {
     /**
-     * @desc The invitations list from the admin store.
+     * @desc The invitations list from the invitations store.
      * @returns {Array}
      */
     invitations() {
-      return useAdminStore().invitations;
+      return useInvitationsStore().invitations;
     },
   },
   methods: {
@@ -115,7 +121,7 @@ export default {
      * @returns {Promise<void>}
      */
     async fetchInvitations() {
-      await useAdminStore().getInvitations();
+      await useInvitationsStore().getInvitations();
     },
     /**
      * @desc Derive a status label + color from an invitation's lifecycle fields.
@@ -141,7 +147,7 @@ export default {
     async submitInvite() {
       this.createDialog.loading = true;
       try {
-        await useAdminStore().createInvitation(this.createDialog.email);
+        await useInvitationsStore().createInvitation(this.createDialog.email);
         await this.fetchInvitations();
         this.createDialog.show = false;
       } catch {
@@ -164,7 +170,7 @@ export default {
      */
     async confirmRevoke() {
       try {
-        await useAdminStore().deleteInvitation(this.deleteDialog.id);
+        await useInvitationsStore().deleteInvitation(this.deleteDialog.id);
         await this.fetchInvitations();
       } catch {
         // error surfaced via store.error

--- a/src/modules/users/router/users.router.js
+++ b/src/modules/users/router/users.router.js
@@ -3,6 +3,16 @@
  */
 import user from '../views/user.view.vue';
 
+/**
+ * @desc Path of the account parent route — the injection seam under which
+ *       optional modules (e.g. the standalone `invitations` module's "Referrals"
+ *       tab) register child routes via `injectModuleChildren`. Exported so the
+ *       host (`app.router.js`) and tests reference the constant instead of
+ *       hardcoding the string (mirrors `ORG_PARENT_PATH`).
+ * @type {string}
+ */
+export const ACCOUNT_PARENT_PATH = '/users';
+
 // TODO(remove one release after PR(c) merges AND after billing.store successUrl repointed):
 // legacy ?tab=subscriptions alias — one-release retention only.
 // IMPORTANT: this guard also actively bridges Stripe successUrl redirects —

--- a/src/modules/users/tests/user.view.unit.tests.js
+++ b/src/modules/users/tests/user.view.unit.tests.js
@@ -71,6 +71,23 @@ describe('UserView – layout shape (CorePageHeaderTabs + router-view)', () => {
     expect(tabs.map((t) => t.value)).toContain('organizations');
   });
 
+  it('merges config.users.extraTabs into the tabs (gap-fix A — the optional-module account-tab seam)', () => {
+    const mocks = sharedMocks();
+    // An optional module (e.g. invitations) contributes its account tab via the
+    // SEPARATE extraTabs key (deepMerge replaces arrays, so it can't append to users.tabs).
+    mocks.config.users.extraTabs = [
+      { value: 'invitations', label: 'Referrals', icon: 'fa-solid fa-gift', route: 'invitations' },
+    ];
+    const wrapper = shallowMount(UserView, {
+      global: { mocks, stubs: sharedStubs },
+    });
+    const values = wrapper.findComponent({ name: 'CorePageHeaderTabs' }).props('tabs').map((t) => t.value);
+    // base tabs preserved AND the module-contributed extra appended
+    expect(values).toContain('profile');
+    expect(values).toContain('organizations');
+    expect(values).toContain('invitations');
+  });
+
   it('passes /users as basePath to CorePageHeaderTabs', () => {
     const wrapper = shallowMount(UserView, {
       global: { mocks: sharedMocks(), stubs: sharedStubs },

--- a/src/modules/users/views/user.view.vue
+++ b/src/modules/users/views/user.view.vue
@@ -6,7 +6,7 @@
       <CorePageHeaderTabs
         icon="fa-solid fa-user"
         title="Account"
-        :tabs="config.users.tabs"
+        :tabs="allTabs"
         :can="userCan"
         :base-path="basePath"
       >
@@ -53,6 +53,22 @@ export default {
      */
     basePath() {
       return '/users';
+    },
+    /**
+     * @desc Merged account tab list (built-in + module-contributed extras),
+     *       passed to CoreSurfaceTabBar. Mirrors `admin.layout.vue`'s
+     *       built-in ∪ config.admin.tabs merge: `config.users.tabs` holds the
+     *       core tabs (Profile, Organizations) while optional modules append to
+     *       `config.users.extraTabs` (a separate key — generateConfig's
+     *       deepMerge REPLACES arrays, so a module fragment cannot push onto
+     *       `users.tabs` without clobbering the base set). Validation + CASL
+     *       filtering happen inside the bar via `resolveSurfaceTabs`.
+     * @returns {Array<object>}
+     */
+    allTabs() {
+      const tabs = Array.isArray(this.config?.users?.tabs) ? this.config.users.tabs : [];
+      const extras = Array.isArray(this.config?.users?.extraTabs) ? this.config.users.extraTabs : [];
+      return [...tabs, ...extras];
     },
     /**
      * @desc CASL predicate passed to CoreSurfaceTabBar. Account tabs (Profile,


### PR DESCRIPTION
## Phase 6 — invitations ↔ org decouple (epic #3808)

Extracts the platform-invitations UI into its own **optional** `src/modules/invitations/` module and adds the account-surface composition seams it needs. Pairs with P2 (Node, merged — `/api/invitations` canonical + `/api/auth/invitations` alias).

### What lands
- **`src/modules/invitations/`** — `invitations.admin.view.vue` (moved beta-gate admin UI), `invitations.account.view.vue` (new "Referrals" / invite-a-contact), `invitations.store.js` (the 3 actions **repointed `/api/auth/invitations` → `/api/invitations`** + a PostHog `invitation_created` emit on create), `invitations.router.js` (exports `invitationsAdminRoutes` + `invitationsAccountRoutes`, relative paths, lazy views), config fragment (`admin.tabs` + `users.extraTabs`).
- **Admin move-out:** `admin.invitations.view.vue` + the 3 admin-store actions/state + the admin child route + the hardcoded `BUILT_IN_TABS` entry all removed (zero leftovers — `grep invitation admin.store.js` empty).
- **Gap-fix A** (`user.view.vue`): `allTabs = [...config.users.tabs, ...config.users.extraTabs]` (a module can't append to `users.tabs` — deepMerge replaces arrays — so the account tab uses a separate `extraTabs` key).
- **Gap-fix B** (`app.router.js`): NEW `accountChildModules` injection seam under `/users` (mirrors the org-settings injection) + `registerDownstreamRoutes({accountChildModules})` + `ACCOUNT_PARENT_PATH` exported from `users.router.js`. Invitations admin/account routes injected, gated by `isModuleActive('invitations')`.

### Optional-module guarantee
A test proves that with the module inactive, NEITHER `/admin` NOR `/users` has an `invitations` child route, but BOTH parents still exist (admin/account surfaces unaffected). Plus a test that `config.users.extraTabs` genuinely merges into the account tabs.

### Verification
- `/verify`: lint clean, **build green** (3 lazy invitations chunks code-split), all module tests pass (store hits `/api/invitations` + negative-asserts `/auth/invitations`; account/admin views; router exports both arrays; the inactive-module guarantee; the extraTabs merge).
- Independent **spec-compliance** review ✅ (all 7 items; gap-fix B traced complete; zero admin leftovers) + **code-quality** review (0 critical/important; the move is byte-clean; the 2 minors — extraTabs-merge test + this MIGRATIONS note — folded).

### Notes
- MIGRATIONS.md documents the `admin.tabs` default removal — a downstream that overrides `admin.tabs` or relied on the global default must verify the admin Invitations tab post-`/update-stack` (now module-contributed).
- After this merges, the Node `/api/auth/invitations` deprecation alias (P2) can be dropped.

Closes #4279. Part of #3808.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Users can now manage invitations directly from their account area—send invitations and track their status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->