### PR TITLE
feat(invitations): Referrals scaffold — summary header + credits placeholder (P8b)

### DIFF
--- a/src/modules/invitations/tests/invitations.account.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.account.view.unit.tests.js
@@ -124,4 +124,52 @@ describe('invitations.account.view', () => {
     expect(wrapper.vm.rules.mail('user@example.com')).toBe(true);
     expect(wrapper.vm.rules.mail('not-an-email')).toBe('E-mail must be valid');
   });
+
+  it('referralSummary derives counts by status from a mixed list', () => {
+    store.invitations = [
+      { id: '1', usedAt: '2026-01-01', expiresAt: '2999-01-01' }, // joined
+      { id: '2', usedAt: '2026-02-01', expiresAt: '2000-01-01' }, // joined (usedAt wins over expiry)
+      { id: '3', usedAt: null, expiresAt: '2000-01-01' }, // expired
+      { id: '4', usedAt: null, expiresAt: '2999-01-01' }, // pending
+    ];
+    const wrapper = mountView();
+    expect(wrapper.vm.referralSummary).toEqual({ total: 4, joined: 2, pending: 1, expired: 1 });
+  });
+
+  it('referralSummary on an empty list is all zeros', () => {
+    store.invitations = [];
+    const wrapper = mountView();
+    expect(wrapper.vm.referralSummary).toEqual({ total: 0, joined: 0, pending: 0, expired: 0 });
+  });
+
+  it('renders the My referrals summary chips (expired chip hidden at zero)', () => {
+    store.invitations = [
+      { id: '1', usedAt: '2026-01-01', expiresAt: '2999-01-01' },
+      { id: '2', usedAt: null, expiresAt: '2999-01-01' },
+      { id: '3', usedAt: null, expiresAt: '2999-01-01' },
+    ];
+    const wrapper = mountView();
+    expect(wrapper.text()).toContain('My referrals');
+    const summary = wrapper.find('[data-test="referrals-summary"]');
+    expect(summary.exists()).toBe(true);
+    expect(summary.text()).toContain('3 invited');
+    expect(summary.text()).toContain('1 joined');
+    expect(summary.text()).toContain('2 pending');
+    expect(summary.text()).not.toContain('expired');
+  });
+
+  it('renders the expired chip when expired invitations exist', () => {
+    store.invitations = [{ id: '1', usedAt: null, expiresAt: '2000-01-01' }];
+    const wrapper = mountView();
+    expect(wrapper.find('[data-test="referrals-summary"]').text()).toContain('1 expired');
+  });
+
+  it('renders the referral-rewards placeholder — honest, no numbers', () => {
+    const wrapper = mountView();
+    const placeholder = wrapper.find('[data-test="referral-rewards-placeholder"]');
+    expect(placeholder.exists()).toBe(true);
+    expect(placeholder.text()).toContain('Referral rewards — coming soon');
+    // Scaffold contract (#5 not built): the placeholder must never show numbers/fake math
+    expect(placeholder.text()).not.toMatch(/\d/);
+  });
 });

--- a/src/modules/invitations/views/invitations.account.view.vue
+++ b/src/modules/invitations/views/invitations.account.view.vue
@@ -55,18 +55,33 @@
         </v-card>
       </v-col>
 
-      <!-- My invitations -->
+      <!-- My referrals: summary header + the invitations list -->
       <v-col cols="12">
         <v-card color="surface" :flat="config.vuetify.theme.flat" :class="config.vuetify.theme.rounded" class="pa-6">
-          <div class="d-flex align-center mb-4">
-            <v-icon icon="fa-solid fa-envelope" color="primary" class="mr-3"></v-icon>
-            <span class="text-title-large">My invitations</span>
+          <div class="d-flex align-center flex-wrap ga-2 mb-4">
+            <v-icon icon="fa-solid fa-users" color="primary" class="mr-1"></v-icon>
+            <span class="text-title-large">My referrals</span>
+            <v-spacer></v-spacer>
+            <!-- Counts derived from the list below (same derivation as the status chips) -->
+            <div class="d-flex align-center flex-wrap ga-2" data-test="referrals-summary">
+              <v-chip size="small" variant="tonal">{{ referralSummary.total }} invited</v-chip>
+              <v-chip size="small" variant="tonal" color="success">{{ referralSummary.joined }} joined</v-chip>
+              <v-chip size="small" variant="tonal" color="warning">{{ referralSummary.pending }} pending</v-chip>
+              <v-chip v-if="referralSummary.expired" size="small" variant="tonal" color="error">{{ referralSummary.expired }} expired</v-chip>
+            </div>
           </div>
           <coreDataTableComponent :headers="inviteHeaders" :items="invitations" :fetch-action="fetchInvitations" :search="false">
             <template #status="{ item }">
               <v-chip :color="inviteStatus(item).color" size="small" variant="tonal">{{ inviteStatus(item).label }}</v-chip>
             </template>
           </coreDataTableComponent>
+          <!-- Referral rewards placeholder — credits land here in a later phase (#5). No numbers, no math. -->
+          <div class="d-flex align-center mt-4" data-test="referral-rewards-placeholder">
+            <v-chip size="small" variant="tonal" class="text-medium-emphasis">
+              <v-icon start icon="fa-solid fa-coins" size="x-small"></v-icon>
+              Referral rewards — coming soon
+            </v-chip>
+          </div>
         </v-card>
       </v-col>
     </v-row>
@@ -89,8 +104,10 @@ import coreDataTableComponent from '../../core/components/core.datatable.compone
  * `/users/invitations` child route + a config-contributed `users.extraTabs`
  * entry, both gated by `isModuleActive('invitations')`.
  *
- * P8b expands this into the full referrals experience (referral attribution,
- * rewards). This phase ships the invite-a-contact + my-invites foundation.
+ * P8b frames this as the referrals experience: a summary header (counts by
+ * status, derived from the same list the table shows) + a "Referral rewards —
+ * coming soon" placeholder marking where the credit grant (#5) will land.
+ * Scaffold only — ZERO credit math/logic lives here.
  */
 export default {
   name: 'InvitationsAccount',
@@ -128,6 +145,25 @@ export default {
      */
     error() {
       return useInvitationsStore().error;
+    },
+    /**
+     * @desc Referrals summary counts, derived from the invitations list through
+     * the SAME per-row derivation as the table's status chips (`inviteStatus`)
+     * so the header and the list can never disagree. Pure derivation — no
+     * endpoint, no credit math (rewards are a later phase, #5).
+     * @returns {{ total: number, joined: number, pending: number, expired: number }}
+     */
+    referralSummary() {
+      return this.invitations.reduce(
+        (counts, item) => {
+          const { label } = this.inviteStatus(item);
+          if (label === 'Accepted') counts.joined += 1;
+          else if (label === 'Expired') counts.expired += 1;
+          else counts.pending += 1;
+          return counts;
+        },
+        { total: this.invitations.length, joined: 0, pending: 0, expired: 0 },
+      );
     },
   },
   methods: {


### PR DESCRIPTION
## Phase 8b — invitations ↔ org decouple (epic #3808)

The Vue half of the referral substrate (P8a Node merged). **Scaffold only — zero credit math** (deferred #5).

### What lands (+96, 2 files)
- **Referrals summary header** on the account view's list card ("My referrals"): tonal chips `N invited · N joined · N pending (· N expired when >0)` — a `referralSummary` computed reducing the EXISTING store list through the SAME `inviteStatus` derivation the table chips use (single source of truth; `usedAt`-wins rule preserved). No new endpoint/action.
- **Credits placeholder**: one muted tonal chip — `fa-coins` + "Referral rewards — coming soon". No numbers; a **no-digits contractual test** (`not.toMatch(/\d/)`) breaks loudly if someone sneaks reward math in before #5.
- P6 invite-a-contact form + datatable untouched.

### Verification
- `/verify`: lint clean, build green, invitations module 48/48 (incl. mixed-list/usedAt-wins/empty-list/expired-chip-visibility/no-digits tests).
- Independent **spec-compliance** review ✅ + **code-quality** review (approved; strict scope discipline; 1 follow-up filed: revoked-as-Pending display — pre-existing P6 semantics the summary makes more visible → see the linked issue).

Closes #4282. Part of #3808.