### PR TITLE
fix(invitations): pre-P9 UI hardening — revoked status, admin error banner, canonical verifyInvite

### DIFF
--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -394,13 +394,15 @@ export const useAuthStore = defineStore('auth', {
     /**
      * @desc Verify a signup invite token (public). Used by the signup page to
      * reveal the form + prefill the invited email when public signup is closed.
+     * Canonical mount (modules/invitations); the legacy /auth/invitations alias
+     * is removed post-P9.
      * @param {string} token
      * @returns {Promise<{valid: boolean, email: string|null}>}
      */
     async verifyInvite(token) {
       const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
       try {
-        const res = await axios.get(`${api}/${config.api.endPoints.auth}/invitations/verify/${encodeURIComponent(token)}`);
+        const res = await axios.get(`${api}/invitations/verify/${encodeURIComponent(token)}`);
         return res.data.data;
       } catch {
         return { valid: false, email: null };

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -964,11 +964,12 @@ describe('Auth Store', () => {
       expect(axios.post.mock.calls[0][0]).toMatch(/\/signup$/);
     });
 
-    it('verifyInvite returns { valid, email } from the API', async () => {
+    it('verifyInvite hits the canonical /api/invitations/verify (NOT the legacy /auth/invitations alias)', async () => {
       const authStore = useAuthStore();
       axios.get.mockResolvedValueOnce({ data: { data: { valid: true, email: 'a@b.co' } } });
       const r = await authStore.verifyInvite('tok123');
-      expect(axios.get.mock.calls[0][0]).toContain('/invitations/verify/tok123');
+      expect(axios.get).toHaveBeenCalledWith(expect.stringMatching(/\/api\/invitations\/verify\/tok123$/));
+      expect(axios.get).not.toHaveBeenCalledWith(expect.stringContaining('/auth/invitations/'));
       expect(r).toEqual({ valid: true, email: 'a@b.co' });
     });
 

--- a/src/modules/invitations/lib/invitations.status.js
+++ b/src/modules/invitations/lib/invitations.status.js
@@ -1,0 +1,20 @@
+/**
+ * Shared invitation status derivation — single source of truth for the admin
+ * view, the account view, and the account referral summary (they must never
+ * disagree). Order matters:
+ *   accepted (usedAt/status) > revoked (revokedAt/status, E8 soft-delete)
+ *   > expired (expiresAt past) > pending.
+ * Reads BOTH the lifecycle timestamps and the Node `status` enum so it stays
+ * correct whichever the API populates.
+ * @param {Object} item - invitation row from /api/invitations
+ * @returns {{ label: 'Accepted'|'Revoked'|'Expired'|'Pending', color: string }}
+ */
+export const inviteStatus = (item) => {
+  if (item.usedAt || item.status === 'accepted') return { label: 'Accepted', color: 'success' };
+  // Neutral chip: a revoked invite is an inert historical row, not an error state.
+  if (item.revokedAt || item.status === 'revoked') return { label: 'Revoked', color: '' };
+  if (item.expiresAt && new Date(item.expiresAt).getTime() < Date.now()) return { label: 'Expired', color: 'error' };
+  return { label: 'Pending', color: 'warning' };
+};
+
+export default { inviteStatus };

--- a/src/modules/invitations/tests/invitations.account.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.account.view.unit.tests.js
@@ -75,6 +75,12 @@ describe('invitations.account.view', () => {
     expect(wrapper.vm.inviteStatus({ usedAt: null, expiresAt: '2999-01-01' }).label).toBe('Pending');
   });
 
+  it('inviteStatus derives Revoked (revokedAt or status) ahead of expiry', () => {
+    const wrapper = mountView();
+    expect(wrapper.vm.inviteStatus({ revokedAt: '2026-01-01', expiresAt: '2000-01-01' }).label).toBe('Revoked');
+    expect(wrapper.vm.inviteStatus({ status: 'revoked' }).label).toBe('Revoked');
+  });
+
   it('submitInvite no-ops when the form is invalid', async () => {
     const wrapper = mountView();
     wrapper.vm.inviteForm.valid = false;
@@ -131,15 +137,18 @@ describe('invitations.account.view', () => {
       { id: '2', usedAt: '2026-02-01', expiresAt: '2000-01-01' }, // joined (usedAt wins over expiry)
       { id: '3', usedAt: null, expiresAt: '2000-01-01' }, // expired
       { id: '4', usedAt: null, expiresAt: '2999-01-01' }, // pending
+      { id: '5', usedAt: null, revokedAt: '2026-03-01', expiresAt: '2999-01-01' }, // revoked — NOT pending
     ];
     const wrapper = mountView();
-    expect(wrapper.vm.referralSummary).toEqual({ total: 4, joined: 2, pending: 1, expired: 1 });
+    expect(wrapper.vm.referralSummary).toEqual({ total: 5, joined: 2, pending: 1, expired: 1, revoked: 1 });
+    expect(wrapper.vm.referralSummary.revoked).toBe(1);
+    expect(wrapper.vm.referralSummary.pending).toBe(1);
   });
 
   it('referralSummary on an empty list is all zeros', () => {
     store.invitations = [];
     const wrapper = mountView();
-    expect(wrapper.vm.referralSummary).toEqual({ total: 0, joined: 0, pending: 0, expired: 0 });
+    expect(wrapper.vm.referralSummary).toEqual({ total: 0, joined: 0, pending: 0, expired: 0, revoked: 0 });
   });
 
   it('renders the My referrals summary chips (expired chip hidden at zero)', () => {

--- a/src/modules/invitations/tests/invitations.admin.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.admin.view.unit.tests.js
@@ -77,6 +77,14 @@ describe('invitations.admin.view', () => {
     expect(wrapper.vm.invitations).toEqual([{ id: '1', email: 'a@b.co', usedAt: null, expiresAt: null }]);
   });
 
+  it('exposes the store error and clearError nulls it (banner contract)', () => {
+    store.error = 'boom';
+    const wrapper = mountView();
+    expect(wrapper.vm.error).toBe('boom');
+    wrapper.vm.clearError();
+    expect(store.error).toBeNull();
+  });
+
   it('fetchInvitations delegates to the store', async () => {
     const wrapper = mountView();
     await wrapper.vm.fetchInvitations();

--- a/src/modules/invitations/tests/invitations.admin.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.admin.view.unit.tests.js
@@ -90,6 +90,12 @@ describe('invitations.admin.view', () => {
     expect(wrapper.vm.inviteStatus({ usedAt: null, expiresAt: '2999-01-01' }).label).toBe('Pending');
   });
 
+  it('inviteStatus derives Revoked (revokedAt or status) ahead of expiry', () => {
+    const wrapper = mountView();
+    expect(wrapper.vm.inviteStatus({ revokedAt: '2026-01-01', expiresAt: '2000-01-01' }).label).toBe('Revoked');
+    expect(wrapper.vm.inviteStatus({ status: 'revoked' }).label).toBe('Revoked');
+  });
+
   it('submitInvite calls createInvitation then refreshes the list', async () => {
     const wrapper = mountView();
     wrapper.vm.createDialog.email = 'new@b.co';

--- a/src/modules/invitations/tests/invitations.status.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.status.unit.tests.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { inviteStatus } from '../lib/invitations.status';
+
+describe('invitations.status — shared 4-state derivation', () => {
+  it('accepted wins over everything (usedAt or status)', () => {
+    expect(inviteStatus({ usedAt: '2026-01-01', revokedAt: '2026-02-01', expiresAt: '2000-01-01' }).label).toBe('Accepted');
+    expect(inviteStatus({ status: 'accepted' }).label).toBe('Accepted');
+  });
+  it('revoked wins over expiry (revokedAt or status)', () => {
+    expect(inviteStatus({ revokedAt: '2026-01-01', expiresAt: '2000-01-01' }).label).toBe('Revoked');
+    expect(inviteStatus({ status: 'revoked', expiresAt: '2999-01-01' }).label).toBe('Revoked');
+  });
+  it('expired then pending as before', () => {
+    expect(inviteStatus({ expiresAt: '2000-01-01' }).label).toBe('Expired');
+    expect(inviteStatus({ expiresAt: '2999-01-01' }).label).toBe('Pending');
+    expect(inviteStatus({}).label).toBe('Pending');
+  });
+});

--- a/src/modules/invitations/views/invitations.account.view.vue
+++ b/src/modules/invitations/views/invitations.account.view.vue
@@ -68,6 +68,9 @@
               <v-chip size="small" variant="tonal" color="success">{{ referralSummary.joined }} joined</v-chip>
               <v-chip size="small" variant="tonal" color="warning">{{ referralSummary.pending }} pending</v-chip>
               <v-chip v-if="referralSummary.expired" size="small" variant="tonal" color="error">{{ referralSummary.expired }} expired</v-chip>
+              <v-chip v-if="referralSummary.revoked" size="small" variant="tonal">
+                {{ referralSummary.revoked }} revoked
+              </v-chip>
             </div>
           </div>
           <coreDataTableComponent :headers="inviteHeaders" :items="invitations" :fetch-action="fetchInvitations" :search="false">
@@ -93,6 +96,7 @@
  * Module dependencies.
  */
 import { useInvitationsStore } from '../stores/invitations.store';
+import { inviteStatus as deriveInviteStatus } from '../lib/invitations.status';
 import coreDataTableComponent from '../../core/components/core.datatable.component.vue';
 
 /**
@@ -151,7 +155,7 @@ export default {
      * the SAME per-row derivation as the table's status chips (`inviteStatus`)
      * so the header and the list can never disagree. Pure derivation — no
      * endpoint, no credit math (rewards are a later phase, #5).
-     * @returns {{ total: number, joined: number, pending: number, expired: number }}
+     * @returns {{ total: number, joined: number, pending: number, expired: number, revoked: number }}
      */
     referralSummary() {
       return this.invitations.reduce(
@@ -159,10 +163,11 @@ export default {
           const { label } = this.inviteStatus(item);
           if (label === 'Accepted') counts.joined += 1;
           else if (label === 'Expired') counts.expired += 1;
+          else if (label === 'Revoked') counts.revoked += 1;
           else counts.pending += 1;
           return counts;
         },
-        { total: this.invitations.length, joined: 0, pending: 0, expired: 0 },
+        { total: this.invitations.length, joined: 0, pending: 0, expired: 0, revoked: 0 },
       );
     },
   },
@@ -175,14 +180,12 @@ export default {
       await useInvitationsStore().getInvitations();
     },
     /**
-     * @desc Derive a status label + color from an invitation's lifecycle fields.
+     * @desc Shared status derivation (lib/invitations.status — revoked-aware).
      * @param {Object} item - invitation
      * @returns {{ label: string, color: string }}
      */
     inviteStatus(item) {
-      if (item.usedAt) return { label: 'Accepted', color: 'success' };
-      if (item.expiresAt && new Date(item.expiresAt).getTime() < Date.now()) return { label: 'Expired', color: 'error' };
-      return { label: 'Pending', color: 'warning' };
+      return deriveInviteStatus(item);
     },
     /**
      * @desc Submit a new invitation, then refresh the list and reset the form.

--- a/src/modules/invitations/views/invitations.admin.view.vue
+++ b/src/modules/invitations/views/invitations.admin.view.vue
@@ -1,6 +1,21 @@
 <template>
   <v-container fluid>
     <v-row class="pa-2 mt-0">
+      <!-- Error banner (surfaced from the invitations store) -->
+      <v-col v-if="error" cols="12">
+        <v-alert
+          type="error"
+          variant="tonal"
+          density="compact"
+          closable
+          :class="config.vuetify.theme.rounded"
+          icon="fa-solid fa-circle-exclamation"
+          @click:close="clearError"
+        >
+          <span class="text-body-medium">{{ error }}</span>
+        </v-alert>
+      </v-col>
+
       <v-col cols="12" class="d-flex justify-end">
         <v-btn color="primary" variant="flat" :class="config.vuetify.theme.rounded" class="text-none" @click="openCreate">
           <v-icon start icon="fa-solid fa-envelope"></v-icon>
@@ -115,6 +130,13 @@ export default {
     invitations() {
       return useInvitationsStore().invitations;
     },
+    /**
+     * @desc Global error from the invitations store (surfaced as a banner).
+     * @returns {string|null}
+     */
+    error() {
+      return useInvitationsStore().error;
+    },
   },
   methods: {
     /**
@@ -150,7 +172,7 @@ export default {
         await this.fetchInvitations();
         this.createDialog.show = false;
       } catch {
-        // error is surfaced via the admin layout banner (store.error)
+        // error is surfaced via the view's own error banner (invitations store)
       } finally {
         this.createDialog.loading = false;
       }
@@ -172,10 +194,17 @@ export default {
         await useInvitationsStore().deleteInvitation(this.deleteDialog.id);
         await this.fetchInvitations();
       } catch {
-        // error surfaced via store.error
+        // error is surfaced via the view's own error banner (invitations store)
       } finally {
         this.deleteDialog.show = false;
       }
+    },
+    /**
+     * @desc Clear the invitations store error banner.
+     * @returns {void}
+     */
+    clearError() {
+      useInvitationsStore().error = null;
     },
   },
 };

--- a/src/modules/invitations/views/invitations.admin.view.vue
+++ b/src/modules/invitations/views/invitations.admin.view.vue
@@ -21,7 +21,7 @@
               size="small"
               variant="text"
               color="error"
-              :disabled="!!item.usedAt"
+              :disabled="!!item.usedAt || !!item.revokedAt || item.status === 'revoked'"
               @click="openRevoke(item)"
             ></v-btn>
           </template>
@@ -69,6 +69,7 @@
  * Module dependencies.
  */
 import { useInvitationsStore } from '../stores/invitations.store';
+import { inviteStatus as deriveInviteStatus } from '../lib/invitations.status';
 import coreDataTableComponent from '../../core/components/core.datatable.component.vue';
 import coreConfirmDialog from '../../core/components/core.confirmDialog.component.vue';
 
@@ -124,14 +125,12 @@ export default {
       await useInvitationsStore().getInvitations();
     },
     /**
-     * @desc Derive a status label + color from an invitation's lifecycle fields.
+     * @desc Shared status derivation (lib/invitations.status — revoked-aware).
      * @param {Object} item - invitation
      * @returns {{ label: string, color: string }}
      */
     inviteStatus(item) {
-      if (item.usedAt) return { label: 'Accepted', color: 'success' };
-      if (item.expiresAt && new Date(item.expiresAt).getTime() < Date.now()) return { label: 'Expired', color: 'error' };
-      return { label: 'Pending', color: 'warning' };
+      return deriveInviteStatus(item);
     },
     /**
      * @desc Open the create-invite dialog (reset fields).


### PR DESCRIPTION
## Pre-P9 fixes (epic #3808) — Vue PR-B

From the 2026-06-11 cross-PR review (plan `infra/docs/superpowers/plans/2026-06-11-pre-p9-fixes-invitations.md`). Both this and the Node PR-A gate P9 (#3815).

### T5 — Shared revoked-aware status (closes #4291)
Node E8 made delete a soft-revoke, but both views derived status from `usedAt`/`expiresAt` only → a revoked row rendered **"Pending"**, the admin trash stayed enabled (revoke looked broken), and the P8b summary counted revoked as pending. New single source `src/modules/invitations/lib/invitations.status.js` (accepted > revoked > expired > pending, neutral chip), consumed by both views; trash disabled on revoked; `referralSummary` gains a revoked bucket + conditional chip.

### T6 — Admin error banner (P6 move regression)
The admin layout reads `adminStore.error`; the moved view's failures land in the invitations store nobody rendered → silently empty table. Banner copied verbatim from the account view (+ `clearError`), stale catch comments fixed.

### T7 — `verifyInvite` → canonical mount
The signup-page verify still hit the legacy `/api/auth/invitations/verify` alias — the documented alias-removal TODO would have silently killed invite links (flagged independently by 3 reviewers). Now `/api/invitations/verify/:token`; test positively asserts canonical + negatively asserts the alias. Makes the Node alias genuinely removable post-P9.

### Verification
Lint clean, build green, 256/256 across invitations+auth modules (incl. signup view); plan-anchored TDD; spec-reviewed against the plan (single-source derivation confirmed — no second status path survives).

Closes #4291. Part of #3808. Pairs with Node PR-A.