### PR TITLE
chore(skills): /feature claim flips board status to In progress

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -53,6 +53,17 @@ gh issue comment <N> --body "WIP — session $(date -u +%Y%m%dT%H%M%SZ)-$(uuidge
 
 Where `<branch-name>` is the branch this `/feature` invocation will use (planned name, even if not yet created). If the branch isn't decided yet, use `branch TBD`. Posting a follow-up comment with the real branch name after `/pull-request` creates it is best-effort manual — the linked PR superseding the WIP comment is what matters in practice.
 
+### 3b. Board status → In progress (best-effort)
+
+After a successful claim, flip the issue's board item — and, if it's a sub-issue, its parent epic — to **In progress**:
+
+```bash
+_bs=/Users/pierrebrisorgueil/Documents/Dev/github/pierreb-projects/infra/marketplace/shared/board-status.sh
+[ -f "$_bs" ] && bash "$_bs" "$(gh repo view --json nameWithOwner -q .nameWithOwner)#<N>" "In progress" || true
+```
+
+Best-effort by design: script missing (machine without the infra checkout), org without a board (comes/montaine), or issue not yet on the board → silent no-op; `/dev:roadmap` in-progress-sync is the safety net. Never set Ready or Done from here.
+
 ### 4. Proceed to Phase 0
 
 Continue to scope analysis below.


### PR DESCRIPTION
## Summary

This is the **devkit Vue half** of the infra board-status auto-lifecycle feature (infra commit `58a076c` on `pierreb-projects/infra`).

- Adds **Phase 0.0 step 3b** to `.claude/skills/feature/SKILL.md`: after a successful `/feature #N` claim, a best-effort call to `board-status.sh` auto-flips the corresponding GitHub Project board item from Backlog/Ready → **In progress**.
- **Best-effort / silent no-op**: fails gracefully when run off-machine or in an org with no configured board (no error surfaced to the user).
- `/dev:roadmap` in-progress-sync remains the safety net for any misses.
- No code changes, no tests — pure docs/skill markdown.
- No linked issue (chore).

The Node sibling PR ships the byte-identical edit to `.claude/skills/feature/SKILL.md` in `pierreb-devkit/Node`.