### PR TITLE
fix(invitations): inert referrals state when public signup is open

### DIFF
--- a/src/modules/invitations/tests/invitations.account.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.account.view.unit.tests.js
@@ -12,6 +12,11 @@ vi.mock('../../../lib/services/config', () => ({
   },
 }));
 
+const authStoreMock = vi.hoisted(() => ({ serverConfig: null }));
+vi.mock('../../auth/stores/auth.store', () => ({
+  useAuthStore: () => authStoreMock,
+}));
+
 const stubs = {
   // Render the #status slot so the chip template function is invoked
   coreDataTableComponent: {
@@ -44,6 +49,7 @@ const mountView = () =>
 describe('invitations.account.view', () => {
   let store;
   beforeEach(() => {
+    authStoreMock.serverConfig = { sign: { in: true, up: false } };
     setActivePinia(createPinia());
     store = useInvitationsStore();
     store.getInvitations = vi.fn().mockResolvedValue();
@@ -180,5 +186,35 @@ describe('invitations.account.view', () => {
     expect(placeholder.text()).toContain('Referral rewards — coming soon');
     // Scaffold contract (#5 not built): the placeholder must never show numbers/fake math
     expect(placeholder.text()).not.toMatch(/\d/);
+  });
+
+  it('signup open: replaces the invite form with the informational alert', () => {
+    authStoreMock.serverConfig = { sign: { in: true, up: true } };
+    const wrapper = mountView();
+    const alert = wrapper.find('[data-test="referrals-open-signup-alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text()).toContain('Referral invitations are inactive on this deployment because public signup is open.');
+    expect(wrapper.find('form').exists()).toBe(false);
+  });
+
+  it('signup closed: renders the invite form, no open-signup alert', () => {
+    const wrapper = mountView();
+    expect(wrapper.find('[data-test="referrals-open-signup-alert"]').exists()).toBe(false);
+    expect(wrapper.find('form').exists()).toBe(true);
+  });
+
+  it('unknown server config (null) is treated as closed — form stays (backend CASL is the real gate)', () => {
+    authStoreMock.serverConfig = null;
+    const wrapper = mountView();
+    expect(wrapper.vm.signupOpen).toBe(false);
+    expect(wrapper.find('form').exists()).toBe(true);
+  });
+
+  it('keeps the My referrals list visible read-only when signup is open', () => {
+    authStoreMock.serverConfig = { sign: { in: true, up: true } };
+    store.invitations = [{ id: '1', usedAt: null, expiresAt: '2999-01-01' }];
+    const wrapper = mountView();
+    expect(wrapper.text()).toContain('My referrals');
+    expect(wrapper.find('[data-test="referrals-summary"]').exists()).toBe(true);
   });
 });

--- a/src/modules/invitations/views/invitations.account.view.vue
+++ b/src/modules/invitations/views/invitations.account.view.vue
@@ -193,8 +193,8 @@ export default {
      * global router guard for any logged-in navigation). When open, the referral
      * substrate is inert by design — a presented token is resolved but never
      * claimed/finalized — so the invite form is replaced by an informational
-     * state. Strict === true: an unknown/missing serverConfig keeps the form
-     * (the backend policy remains the actual gate).
+     * state. Uses strict equality (`=== true`) so an unknown/missing
+     * serverConfig keeps the form shown (the backend policy is the actual gate).
      * @returns {boolean}
      */
     signupOpen() {

--- a/src/modules/invitations/views/invitations.account.view.vue
+++ b/src/modules/invitations/views/invitations.account.view.vue
@@ -23,35 +23,51 @@
             <v-icon icon="fa-solid fa-gift" color="primary" class="mr-3"></v-icon>
             <span class="text-title-large">Invite a contact</span>
           </div>
-          <p class="text-body-medium text-medium-emphasis mb-4">
-            Share the platform with someone you know. They'll receive an email invitation to join.
-          </p>
-          <v-form ref="inviteForm" v-model="inviteForm.valid" @submit.prevent="submitInvite">
-            <div class="d-flex flex-column flex-sm-row ga-3">
-              <v-text-field
-                v-model="inviteForm.email"
-                label="Email address"
-                :rules="[rules.required, rules.mail]"
-                variant="outlined"
-                density="comfortable"
-                hide-details="auto"
-                class="flex-grow-1"
-              ></v-text-field>
-              <v-btn
-                type="submit"
-                color="primary"
-                variant="flat"
-                size="large"
-                :class="config.vuetify.theme.rounded"
-                class="text-none"
-                :loading="inviteForm.loading"
-                :disabled="inviteForm.valid !== true"
-              >
-                <v-icon start icon="fa-solid fa-paper-plane"></v-icon>
-                Send invite
-              </v-btn>
-            </div>
-          </v-form>
+          <!-- #3833 open-signup state: the server never claims/finalizes an invite
+               token while public signup is open (invitation.accepted never fires),
+               so soliciting invites here would promise a referral that can never
+               convert. Informational state instead of the form; list stays below. -->
+          <v-alert
+            v-if="signupOpen"
+            type="info"
+            variant="tonal"
+            density="compact"
+            :class="config.vuetify.theme.rounded"
+            data-test="referrals-open-signup-alert"
+          >
+            <span class="text-body-medium">Referral invitations are inactive on this deployment because public signup is open.</span>
+          </v-alert>
+          <template v-else>
+            <p class="text-body-medium text-medium-emphasis mb-4">
+              Share the platform with someone you know. They'll receive an email invitation to join.
+            </p>
+            <v-form ref="inviteForm" v-model="inviteForm.valid" @submit.prevent="submitInvite">
+              <div class="d-flex flex-column flex-sm-row ga-3">
+                <v-text-field
+                  v-model="inviteForm.email"
+                  label="Email address"
+                  :rules="[rules.required, rules.mail]"
+                  variant="outlined"
+                  density="comfortable"
+                  hide-details="auto"
+                  class="flex-grow-1"
+                ></v-text-field>
+                <v-btn
+                  type="submit"
+                  color="primary"
+                  variant="flat"
+                  size="large"
+                  :class="config.vuetify.theme.rounded"
+                  class="text-none"
+                  :loading="inviteForm.loading"
+                  :disabled="inviteForm.valid !== true"
+                >
+                  <v-icon start icon="fa-solid fa-paper-plane"></v-icon>
+                  Send invite
+                </v-btn>
+              </div>
+            </v-form>
+          </template>
         </v-card>
       </v-col>
 
@@ -96,6 +112,7 @@
  * Module dependencies.
  */
 import { useInvitationsStore } from '../stores/invitations.store';
+import { useAuthStore } from '../../auth/stores/auth.store';
 import { inviteStatus as deriveInviteStatus } from '../lib/invitations.status';
 import coreDataTableComponent from '../../core/components/core.datatable.component.vue';
 
@@ -169,6 +186,19 @@ export default {
         },
         { total: this.invitations.length, joined: 0, pending: 0, expired: 0, revoked: 0 },
       );
+    },
+    /**
+     * @desc Whether the deployment has PUBLIC signup open, from the server auth
+     * config (GET /api/auth/config → authStore.serverConfig.sign.up; loaded by the
+     * global router guard for any logged-in navigation). When open, the referral
+     * substrate is inert by design — a presented token is resolved but never
+     * claimed/finalized — so the invite form is replaced by an informational
+     * state. Strict === true: an unknown/missing serverConfig keeps the form
+     * (the backend policy remains the actual gate).
+     * @returns {boolean}
+     */
+    signupOpen() {
+      return useAuthStore().serverConfig?.sign?.up === true;
     },
   },
   methods: {


### PR DESCRIPTION
## Summary

- What changed: The account Referrals view now detects open public signup (`serverConfig.sign.up === true`) and replaces the invite form with an informational state, keeping the My-referrals list read-only. On closed signup nothing changes.
- Why: The server never claims/finalizes an invite token while public signup is open, so soliciting invites there was a dead end — the UI was presenting a broken flow to the user.
- Related issues: `Refs pierreb-devkit/Node#3833`

## Scope

- Modules impacted: `src/modules/invitations/`
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [ ] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Optional: Infra/Stack alignment details

> Delete this section if not applicable.

### Before vs After (key changes only)

| Area | Before | After | Notes |
| ---- | ------ | ----- | ----- |
| Referrals view (signup open) | Invite form shown (dead-end — server ignores invites) | Informational inert state shown | `serverConfig.sign.up === true` guard |
| Referrals view (signup closed) | Invite form shown | Invite form shown (unchanged) | No behaviour change |
| My-referrals list | Always visible | Always read-only visible | No behaviour change |

- Upstream parity target / source: cross-repo Vue half of `pierreb-devkit/Node#3833`
- Automation or policy impact (CI, Dependabot, auto-merge, majors, permissions): none
- Rollback plan: revert single commit `7e7b356f`

## Notes for reviewers

- Security considerations: none — purely presentational guard on a client-side config value already exposed via `/server-config` endpoint
- Mergeability considerations: none
- Follow-up tasks: downstream propagation via `/update-stack` on consumer projects after both Node#3833 and this PR are merged

## Test plan

- `invitations.account.view` unit suite 20/20 (signup-open inert state, signup-closed form shown, unknown-config safe-default, list read-only)

Refs pierreb-devkit/Node#3833