### PR TITLE
fix(auth): failed login no longer shows a 'success: Signed out' toast

### DIFF
--- a/src/lib/services/axios.js
+++ b/src/lib/services/axios.js
@@ -14,16 +14,21 @@ const instance = axios.create({
  * Setup axios interceptors.
  * @param {Object} config - Application configuration
  * @param {Object} snackbar - Reactive snackbar object for notifications
- * @param {Function} onSignout - Callback to call on 401 error
+ * @param {Function} onSignout - Callback to call on a 401 of a live session
  * @param {Function} onRefreshAbilities - Callback to call on 403 error to refresh abilities
+ * @param {Function} [isLoggedIn] - Returns whether a session is currently live;
+ *   the 401 auto-signout only fires for an authenticated session, so a failed
+ *   login (POST /signin → 401, no live session) just shows the login error.
  */
 let isRefreshingAbilities = false;
 let refreshAbilitiesPromise = null;
 
-export function setupInterceptors(config, snackbar, onSignout, onRefreshAbilities) {
+export function setupInterceptors(config, snackbar, onSignout, onRefreshAbilities, isLoggedIn) {
   instance.interceptors.response.use(
     (response) => {
-      if (config.vuetify.theme.snackbar.status && response.config && config.vuetify.theme.snackbar.methods.indexOf(response.config.method) > -1) {
+      // `__silent` requests (e.g. a side-effect signout) suppress the success
+      // snackbar so they never raise a misleading "success: ..." toast.
+      if (config.vuetify.theme.snackbar.status && response.config && !response.config.__silent && config.vuetify.theme.snackbar.methods.indexOf(response.config.method) > -1) {
         snackbar.text = `${response.data.type}: ${response.data.message}`;
         snackbar.color = config.vuetify.theme.snackbar.successColor
           ?? config.vuetify.theme.snackbar.sucessColor;
@@ -33,7 +38,13 @@ export function setupInterceptors(config, snackbar, onSignout, onRefreshAbilitie
     },
     async (err) => {
       if (err && err.response && err.response.status === 401 && err.config && !err.config.__isRetryRequest) {
-        onSignout();
+        // Only auto-signout an actually-authenticated session. A failed login
+        // is a 401 too, but has no live session — signing out there triggers a
+        // /signout round-trip + state wipe and a wrong "success: Signed out"
+        // toast (see #4305). Just surface the login error and stop.
+        if (typeof isLoggedIn !== 'function' || isLoggedIn()) {
+          onSignout();
+        }
         snackbar.text = 'Signin failed';
         snackbar.color = config.vuetify.theme.snackbar.errorColor;
         snackbar.status = true;

--- a/src/lib/services/tests/axios.unit.tests.js
+++ b/src/lib/services/tests/axios.unit.tests.js
@@ -23,6 +23,7 @@ describe('Axios Service', () => {
   let mockSnackbar;
   let mockOnSignout;
   let mockOnRefreshAbilities;
+  let mockIsLoggedIn;
   let responseInterceptor;
   let errorInterceptor;
 
@@ -60,8 +61,12 @@ describe('Axios Service', () => {
     // Mock onRefreshAbilities callback
     mockOnRefreshAbilities = vi.fn().mockResolvedValue();
 
+    // Mock isLoggedIn getter — default to an authenticated session so existing
+    // 401 auto-signout behaviour (session expiry) is preserved.
+    mockIsLoggedIn = vi.fn(() => true);
+
     // Setup interceptors
-    setupInterceptors(mockConfig, mockSnackbar, mockOnSignout, mockOnRefreshAbilities);
+    setupInterceptors(mockConfig, mockSnackbar, mockOnSignout, mockOnRefreshAbilities, mockIsLoggedIn);
 
     // Get the interceptors that were registered
     const mockInstance = axios.create();
@@ -190,6 +195,67 @@ describe('Axios Service', () => {
       expect(mockSnackbar.text).toBe('Signin failed');
       expect(mockSnackbar.color).toBe('error');
       expect(mockSnackbar.status).toBe(true);
+    });
+
+    it('should NOT call onSignout on a 401 when there is no live session (failed login)', async () => {
+      // D1: a failed login (POST /signin → 401) is not a session expiry. The
+      // global auto-signout must not fire — it would POST /signout, wipe state,
+      // and surface a misleading "success: Signed out" toast. The user must see
+      // the login error instead.
+      mockIsLoggedIn.mockReturnValue(false);
+
+      const error = {
+        response: { status: 401 },
+        config: { url: 'http://localhost:3000/api/auth/signin' },
+      };
+
+      try {
+        await errorInterceptor(error);
+      } catch (err) {
+        expect(err).toEqual(error);
+      }
+
+      expect(mockOnSignout).not.toHaveBeenCalled();
+      // The login error must still be the message the user sees.
+      expect(mockSnackbar.text).toBe('Signin failed');
+      expect(mockSnackbar.color).toBe('error');
+      expect(mockSnackbar.status).toBe(true);
+    });
+
+    it('should still auto-signout on a 401 for an authenticated session (expiry)', async () => {
+      // D1 guard: a genuine session 401 (live session) must still sign out.
+      mockIsLoggedIn.mockReturnValue(true);
+
+      const error = {
+        response: { status: 401 },
+        config: { __isRetryRequest: false },
+      };
+
+      try {
+        await errorInterceptor(error);
+      } catch (err) {
+        expect(err).toEqual(error);
+      }
+
+      expect(mockOnSignout).toHaveBeenCalled();
+      expect(mockSnackbar.color).toBe('error');
+      expect(mockSnackbar.status).toBe(true);
+    });
+
+    it('should NOT raise a success snackbar for a silent (side-effect) request', () => {
+      // D2: a programmatic signout marks its /signout POST __silent so the
+      // success interceptor skips it — a side-effect signout must never show
+      // "success: Signed out".
+      const response = {
+        config: { method: 'post', __silent: true },
+        data: { type: 'success', message: 'Signed out' },
+      };
+
+      const result = responseInterceptor(response);
+
+      expect(mockSnackbar.text).toBe('');
+      expect(mockSnackbar.status).toBe(false);
+      expect(result).toEqual(response);
     });
 
     it('should not handle 401 error if retry request', async () => {

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -258,7 +258,10 @@ export default {
 
     // Configure axios interceptors
     const authStore = useAuthStore();
-    setupInterceptors(this.config, this.snackbar, () => authStore.signout(), () => authStore.refreshAbilities(), () => authStore.isLoggedIn);
+    // Pass `true` to signout() so the 401 side-effect path suppresses the success
+    // snackbar; explicit user logouts (nav / profile / org) call signout() with no
+    // arg and keep the "success: Signed out" toast (#4305).
+    setupInterceptors(this.config, this.snackbar, () => authStore.signout(true), () => authStore.refreshAbilities(), () => authStore.isLoggedIn);
   },
 };
 </script>

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -220,6 +220,10 @@ export default {
       }
     },
   },
+  /**
+   * @desc Initialize SEO metadata and wire global axios interceptors.
+   * @returns {void}
+   */
   created() {
     const { app } = this.config;
     const seo = app.seo || {};

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -258,7 +258,7 @@ export default {
 
     // Configure axios interceptors
     const authStore = useAuthStore();
-    setupInterceptors(this.config, this.snackbar, () => authStore.signout(), () => authStore.refreshAbilities());
+    setupInterceptors(this.config, this.snackbar, () => authStore.signout(), () => authStore.refreshAbilities(), () => authStore.isLoggedIn);
   },
 };
 </script>

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -263,10 +263,13 @@ export const useAuthStore = defineStore('auth', {
       // Swallow any error (older backends may not expose this endpoint, or the
       // server may be unreachable) — the local reset below must still run.
       // `__isRetryRequest: true` flags this request so the 401 interceptor does
-      // not re-enter signout() and recurse (see src/lib/services/axios.js).
+      // not re-enter signout() and recurse. `__silent: true` flags it so the
+      // success interceptor skips its snackbar — a signout is a side effect, not
+      // an action worth a "success: Signed out" toast (see src/lib/services/axios.js, #4305).
       try {
         await axios.post(`${api}/${config.api.endPoints.auth}/signout`, null, {
           __isRetryRequest: true,
+          __silent: true,
         });
       } catch {
         // Never trap the user logged-in on backend failure.

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -253,9 +253,14 @@ export const useAuthStore = defineStore('auth', {
      * @desc Sign out the current user: call backend to clear the httpOnly TOKEN cookie,
      * then reset auth state, abilities, and localStorage. Backend failures never trap the
      * user as logged-in on the client — local reset always runs.
+     * @param {boolean} [silent=false] - When true, suppress the success snackbar for the
+     *   /signout request. Pass true only from the 401 side-effect path (session expiry)
+     *   where the signout is an automatic consequence, not a deliberate user action.
+     *   Explicit user logouts (nav / profile / org screens) leave this false so the
+     *   "success: Signed out" toast is shown normally.
      * @returns {Promise<void>}
      */
-    async signout() {
+    async signout(silent = false) {
       const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
       const coreStore = useCoreStore();
 
@@ -263,13 +268,14 @@ export const useAuthStore = defineStore('auth', {
       // Swallow any error (older backends may not expose this endpoint, or the
       // server may be unreachable) — the local reset below must still run.
       // `__isRetryRequest: true` flags this request so the 401 interceptor does
-      // not re-enter signout() and recurse. `__silent: true` flags it so the
-      // success interceptor skips its snackbar — a signout is a side effect, not
-      // an action worth a "success: Signed out" toast (see src/lib/services/axios.js, #4305).
+      // not re-enter signout() and recurse. `__silent: true` is set only when
+      // `silent` is true (401 side-effect path) so the success interceptor skips
+      // its snackbar for that case; explicit user logouts preserve the toast.
+      // (see src/lib/services/axios.js, #4305).
       try {
         await axios.post(`${api}/${config.api.endPoints.auth}/signout`, null, {
           __isRetryRequest: true,
-          __silent: true,
+          ...(silent ? { __silent: true } : {}),
         });
       } catch {
         // Never trap the user logged-in on backend failure.

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -107,7 +107,9 @@ describe('Auth Store', () => {
   });
 
   describe('signout backend call', () => {
-    it('should call backend signout endpoint with the correct URL', async () => {
+    it('should call backend signout endpoint with the correct URL (explicit logout — no __silent)', async () => {
+      // Explicit user logout: signout() with no arg must NOT set __silent so the
+      // "success: Signed out" toast is preserved.
       const authStore = useAuthStore();
       authStore.auth = true;
       authStore.user = { id: 'u1' };
@@ -118,25 +120,41 @@ describe('Auth Store', () => {
       expect(axios.post).toHaveBeenCalledWith(
         'http://localhost:3000/api/auth/signout',
         null,
-        { __isRetryRequest: true, __silent: true },
+        { __isRetryRequest: true },
       );
     });
 
-    it('should flag the signout request __silent so it raises no success toast', async () => {
-      // D2 (#4305): a signout is a side effect — its /signout 200 must not flow
-      // through the success snackbar interceptor as "success: Signed out".
+    it('should flag the signout request __silent when called from the 401 side-effect path', async () => {
+      // D2 (#4305): the 401 interceptor calls signout(true) — the /signout POST
+      // must be marked __silent so the success snackbar is suppressed. A session
+      // expiry side-effect must never surface "success: Signed out".
       const authStore = useAuthStore();
       authStore.auth = true;
       authStore.user = { id: 'u1' };
 
       axios.post.mockResolvedValueOnce({ data: { type: 'success', message: 'Signed out' } });
-      await authStore.signout();
+      await authStore.signout(true);
 
       expect(axios.post).toHaveBeenCalledWith(
         'http://localhost:3000/api/auth/signout',
         null,
         expect.objectContaining({ __silent: true }),
       );
+    });
+
+    it('should NOT flag __silent for an explicit user logout (toast preserved)', async () => {
+      // Complement of the D2 test: explicit logout (signout() with no arg or
+      // signout(false)) must NOT set __silent, so the success interceptor can
+      // show the "success: Signed out" snackbar as expected.
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.user = { id: 'u1' };
+
+      axios.post.mockResolvedValueOnce({ data: { type: 'success', message: 'Signed out' } });
+      await authStore.signout(); // no arg → explicit logout
+
+      const callOptions = axios.post.mock.calls[0][2];
+      expect(callOptions).not.toHaveProperty('__silent');
     });
 
     it('should clear local state even when backend signout rejects', async () => {
@@ -154,12 +172,13 @@ describe('Auth Store', () => {
       axios.post.mockRejectedValueOnce(backendError);
 
       // Must not throw — signout always resolves so the user is never trapped as logged-in.
+      // Explicit signout (no arg) → no __silent flag.
       await expect(authStore.signout()).resolves.toBeUndefined();
 
       expect(axios.post).toHaveBeenCalledWith(
         'http://localhost:3000/api/auth/signout',
         null,
-        { __isRetryRequest: true, __silent: true },
+        { __isRetryRequest: true },
       );
       expect(authStore.auth).toBe(false);
       expect(authStore.cookieExpire).toBe(0);

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -118,7 +118,24 @@ describe('Auth Store', () => {
       expect(axios.post).toHaveBeenCalledWith(
         'http://localhost:3000/api/auth/signout',
         null,
-        { __isRetryRequest: true },
+        { __isRetryRequest: true, __silent: true },
+      );
+    });
+
+    it('should flag the signout request __silent so it raises no success toast', async () => {
+      // D2 (#4305): a signout is a side effect — its /signout 200 must not flow
+      // through the success snackbar interceptor as "success: Signed out".
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.user = { id: 'u1' };
+
+      axios.post.mockResolvedValueOnce({ data: { type: 'success', message: 'Signed out' } });
+      await authStore.signout();
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:3000/api/auth/signout',
+        null,
+        expect.objectContaining({ __silent: true }),
       );
     });
 
@@ -142,7 +159,7 @@ describe('Auth Store', () => {
       expect(axios.post).toHaveBeenCalledWith(
         'http://localhost:3000/api/auth/signout',
         null,
-        { __isRetryRequest: true },
+        { __isRetryRequest: true, __silent: true },
       );
       expect(authStore.auth).toBe(false);
       expect(authStore.cookieExpire).toBe(0);


### PR DESCRIPTION
## Summary

Fixes the inverted feedback on a failed login: wrong credentials surfaced a green **`success: Signed out`** toast instead of a login error. Root cause was a 3-step interceptor chain — a bad-credentials **401** tripped the global auto-signout, whose side-effect `/signout` 200 then overwrote the error toast with a success one.

- **D1 (behavior):** the global 401 auto-signout is now gated on a **live session** — an `isLoggedIn` predicate is threaded through `setupInterceptors` (backward-compatible: omitted → previous behavior). A failed login (no live session) shows the **error** snackbar and triggers **no** signout round-trip. A genuine session-expiry 401 still auto-signs-out as before.
- **D2 (feedback):** `signout(silent = false)` — only the **401 side-effect** path (`app.vue` → `signout(true)`) marks its `/signout` request to skip the success interceptor. **Explicit user logout** (nav / profile / org-required, calling `signout()` with no arg) keeps its `success: Signed out` toast — that UX is preserved.

## Test plan

`axios.unit` 24 · `auth.store.unit` 88 · `app.vue.unit` 14 — green; lint clean. New cases: failed-login → no signout + error toast; session-expiry → still signs out; side-effect signout → silent; explicit logout → toast preserved. (2 pre-existing billing v-progress-linear snapshot failures repo-wide are untouched.)

## Guardrails

- [x] `npm run lint` clean
- [x] Public-OSS clean
- [x] D1 preserves the legitimate 401-expiry auto-signout; D2 preserves explicit-logout feedback

Closes #4305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login error handling to prevent unexpected auto-signout when login attempts fail with an inactive session, allowing login errors to surface properly.
  * Improved session expiry notifications by removing redundant success messages when the system auto-signs you out due to session timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->