### PR TITLE
docs(migrations): security headers must be applied in the real ingress, not the nginx example

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,21 +4,22 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
-## security headers: `nginx.example.conf` is an example — apply headers in your real ingress (2026-06-15, #4304)
+## security headers: shipped via the container nginx — tune the report-only CSP (2026-06-15, #4304)
 
-The Vue security hardening bundle (#4304) added a baseline security-header block to `nginx.example.conf` (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, HSTS, and a `Content-Security-Policy-Report-Only` starter). **This file is illustrative — it is not the config that terminates traffic in most deployments.**
+The Vue security hardening bundle (#4304) added a baseline security-header block to `nginx.example.conf` (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, HSTS, and a `Content-Security-Policy-Report-Only` starter). **The stack `Dockerfile` bakes this file into the image** (`COPY nginx.example.conf … → envsubst > /etc/nginx/conf.d/default.conf`), so with the default serving setup the headers are emitted by the container's own nginx and reach the browser through any ingress that forwards backend response headers (Traefik, ingress-nginx, and most CDNs do by default). **No ingress change is required for the default deployment** — the `.example` name is historical, the file is the live config.
 
 ### What changed (this repo)
 
-- `nginx.example.conf` gained an `add_header … always;` block (5 headers + a report-only CSP). Tune the CSP to your asset origins before promoting it to an enforcing `Content-Security-Policy`.
+- `nginx.example.conf` (the image's live nginx config) gained an `add_header … always;` block: 5 headers + a report-only CSP.
 - Same bundle, devkit-owned (arrive automatically via `/update-stack`): `window.open(…, 'noopener,noreferrer')` on the header's external link; an `http`/`https`-only scheme allowlist (`safeHref`) on external article hrefs; removal of credential/error `console` logging in the auth store; `npm install` → `npm ci` in `Dockerfile` + the release workflow; and deletion of a stale committed Travis deploy key.
 
 ### Action required for downstream projects (`/update-stack`)
 
-1. **⚠️ The security headers do NOT auto-apply in production — and nothing flags it.** The example file merges cleanly, so `/update-stack` reports no conflict, but if your app is fronted by anything other than this exact nginx — a Kubernetes ingress (**Traefik**, ingress-nginx), a CDN, or a project-specific reverse proxy — the merged change has zero runtime effect. You must add the equivalent header block to your **actual** ingress. For a **Traefik** ingress: define a `headers` middleware (`customResponseHeaders`, `stsSeconds`, `contentSecurityPolicy`) and attach it to the route/IngressRoute. Verify with `curl -I https://<host>` that the headers are present.
-2. If you have **customized `core.header.component.vue` or `home.articles.component.vue`** (common branding / home-page points), `/update-stack` will surface a conflict on those files — re-apply the `noopener,noreferrer` and `safeHref` security fixes onto your version rather than blindly taking either side.
-3. `npm ci` requires a committed `package-lock.json` in the build context — ensure your `Dockerfile` `COPY`s it (the stack one does via `COPY package*.json`).
-4. If your repo also committed a Travis-era encrypted deploy key, remove it and treat the underlying key as compromised → rotate/revoke it.
+1. **Tighten the CSP before enforcing it.** The shipped policy is `Content-Security-Policy-Report-Only` — it observes but never blocks, so it has no protective effect as-is. Review it against your asset origins (APIs, CDNs, fonts, analytics, inline styles), then promote it to an enforcing `Content-Security-Policy` header once clean.
+2. **Only if you replaced the serving layer** (a static host / CDN instead of the stack's nginx container, or an edge that strips backend response headers) the merged headers will NOT reach the browser — re-add the equivalent block at your actual edge (e.g. a Traefik `headers` middleware: `customResponseHeaders`, `stsSeconds`, `contentSecurityPolicy`), and verify with `curl -I https://<host>`. The default Dockerfile-based deployment needs none of this.
+3. If you have **customized `core.header.component.vue` or `home.articles.component.vue`** (common branding / home-page points), `/update-stack` will surface a conflict on those files — re-apply the `noopener,noreferrer` and `safeHref` security fixes onto your version rather than blindly taking either side.
+4. `npm ci` requires a committed `package-lock.json` in the build context — ensure your `Dockerfile` `COPY`s it (the stack one does via `COPY package*.json`).
+5. If your repo also committed a Travis-era encrypted deploy key, remove it and treat the underlying key as compromised → rotate/revoke it.
 
 ---
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,24 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## security headers: `nginx.example.conf` is an example — apply headers in your real ingress (2026-06-15, #4304)
+
+The Vue security hardening bundle (#4304) added a baseline security-header block to `nginx.example.conf` (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, HSTS, and a `Content-Security-Policy-Report-Only` starter). **This file is illustrative — it is not the config that terminates traffic in most deployments.**
+
+### What changed (this repo)
+
+- `nginx.example.conf` gained an `add_header … always;` block (5 headers + a report-only CSP). Tune the CSP to your asset origins before promoting it to an enforcing `Content-Security-Policy`.
+- Same bundle, devkit-owned (arrive automatically via `/update-stack`): `window.open(…, 'noopener,noreferrer')` on the header's external link; an `http`/`https`-only scheme allowlist (`safeHref`) on external article hrefs; removal of credential/error `console` logging in the auth store; `npm install` → `npm ci` in `Dockerfile` + the release workflow; and deletion of a stale committed Travis deploy key.
+
+### Action required for downstream projects (`/update-stack`)
+
+1. **⚠️ The security headers do NOT auto-apply in production — and nothing flags it.** The example file merges cleanly, so `/update-stack` reports no conflict, but if your app is fronted by anything other than this exact nginx — a Kubernetes ingress (**Traefik**, ingress-nginx), a CDN, or a project-specific reverse proxy — the merged change has zero runtime effect. You must add the equivalent header block to your **actual** ingress. For a **Traefik** ingress: define a `headers` middleware (`customResponseHeaders`, `stsSeconds`, `contentSecurityPolicy`) and attach it to the route/IngressRoute. Verify with `curl -I https://<host>` that the headers are present.
+2. If you have **customized `core.header.component.vue` or `home.articles.component.vue`** (common branding / home-page points), `/update-stack` will surface a conflict on those files — re-apply the `noopener,noreferrer` and `safeHref` security fixes onto your version rather than blindly taking either side.
+3. `npm ci` requires a committed `package-lock.json` in the build context — ensure your `Dockerfile` `COPY`s it (the stack one does via `COPY package*.json`).
+4. If your repo also committed a Travis-era encrypted deploy key, remove it and treat the underlying key as compromised → rotate/revoke it.
+
+---
+
 ## surface-tabs: activation-aware tab filtering (2026-06-12, #4295)
 
 Module-contributed surface tabs now respect `config.modules.{name}.activated`. Previously a downstream setting `modules: { invitations: { activated: false } }` still rendered the admin "Invitations" tab + the account "Referrals" tab (the module fragment's `admin.tabs` / `users.extraTabs` merge unconditionally at generation time) while the routes were correctly NOT injected — clicking the tab landed on a 404.


### PR DESCRIPTION
Follow-up to #4304 (Vue security hardening bundle). The bundle added a security-header block to `nginx.example.conf`, but that file is an **example** — in most deployments traffic is terminated by a Kubernetes ingress (Traefik, ingress-nginx), a CDN, or a project-specific reverse proxy, so the merged change has **zero runtime effect** and `/update-stack` reports no conflict to flag it.

This adds a `MIGRATIONS.md` entry so downstream maintainers absorbing #4304 via `/update-stack` know to apply the equivalent headers in their **actual** ingress (with a Traefik `headers` middleware recipe), plus notes on re-applying the `noopener`/`safeHref` fixes if `core.header`/`home.articles` are customized, the `npm ci` lockfile requirement, and rotating any stale committed deploy key.

Docs-only — no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for the security hardening update, including new baseline nginx security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, HSTS) and a starter Content-Security-Policy *Report-Only* for tuning.
  * Documented follow-up production action items for reviewing/promoting the CSP and safely reapplying headers through the update/ingress path.

* **Chores**
  * Removed stale credentials/keys from the repository and updated the Docker dependency install step for more reliable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->