### PR TITLE
fix(docs): left-align /docs home search hero + uncap block trigger width

### DIFF
--- a/src/modules/docs/components/docs.search.component.vue
+++ b/src/modules/docs/components/docs.search.component.vue
@@ -7,6 +7,7 @@
       class="docs-search__trigger text-none justify-start"
       prepend-icon="fa-solid fa-magnifying-glass"
       :block="block"
+      :size="size"
       data-test="docs-search-trigger"
       @click="open"
     >
@@ -147,8 +148,10 @@ import { useDocsStore } from '../stores/docs.store';
 import config from '@/config';
 
 defineProps({
-  /** Render the trigger button full-width (used in the nav sidebar). */
+  /** Render the trigger button full-width (used in the nav sidebar + home hero). */
   block: { type: Boolean, default: false },
+  /** Vuetify size for the trigger button (e.g. 'large' for the home hero). */
+  size: { type: String, default: undefined },
 });
 
 const router = useRouter();
@@ -382,7 +385,9 @@ defineExpose({ open, close });
 </script>
 
 <style scoped>
-.docs-search__trigger {
+/* Floor only the inline (non-block) trigger; block usages (nav sidebar + home
+   hero) fill their container, so this must not override Vuetify's block width. */
+.docs-search__trigger:not(.v-btn--block) {
   min-width: 180px;
 }
 

--- a/src/modules/docs/views/docs.home.view.vue
+++ b/src/modules/docs/views/docs.home.view.vue
@@ -7,10 +7,12 @@
       avatar-color="primary"
     />
 
-    <!-- Search affordance (⌘K / "/") -->
-    <v-row class="mt-1" justify="center">
-      <v-col cols="12" sm="8" md="6">
-        <DocsSearch data-test="docs-home-search" />
+    <!-- Primary search affordance (⌘K / "/"): the landing's main entry point.
+         Left-aligned to the header + door axis (not floated centre) and width
+         capped so it reads as a search bar, not a full-bleed band. -->
+    <v-row class="mt-5 mb-2">
+      <v-col cols="12" sm="9" md="6" lg="5">
+        <DocsSearch block size="large" data-test="docs-home-search" />
       </v-col>
     </v-row>
 
@@ -28,7 +30,7 @@
 
     <template v-else>
       <!-- Persona doors: one per audience, accent differentiates rather than repeats -->
-      <v-row class="mt-3" data-test="docs-home-personas">
+      <v-row class="mt-8" data-test="docs-home-personas">
         <v-col
           v-for="persona in personas"
           :key="persona.key"


### PR DESCRIPTION
Generic layout fix for the docs module home. Left-aligns the search affordance to the header + persona-door axis (drops `justify=center`), renders it as a full-column `block size="large"` hero (mt-5/mb-2, personas mt-8), and adds a `size` prop passthrough on the search trigger. Fixes a latent CSS specificity bug: `.docs-search__trigger{min-width:180px}` was overriding Vuetify's `.v-btn--block{min-width:100%}` (capping block triggers at 180px) — scoped the floor to `:not(.v-btn--block)`.

Generic (no downstream refs). Lint + 125 docs tests + build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added flexible sizing options to the search button component for better control across different layout contexts
  * Enhanced search visibility on the docs home page with a larger, more prominent search button display
  * Refined page spacing and layout adjustments to improve visual hierarchy and user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->