### PR TITLE
feat(docs): link the OpenAPI reference from the docs nav

### DIFF
--- a/src/modules/docs/components/docs.nav.component.vue
+++ b/src/modules/docs/components/docs.nav.component.vue
@@ -11,6 +11,27 @@
       <span class="text-title-small font-weight-medium">{{ homeTitle }}</span>
     </RouterLink>
 
+    <!-- Persistent link to the in-theme OpenAPI reference (/docs/api). The route
+         is hidden from the MAIN app sidenav (meta.display:false), so this is the
+         in-surface entry point. Always shown — the module ships the view. -->
+    <v-list
+      density="compact"
+      bg-color="transparent"
+      nav
+      class="docs-nav__list py-0 mb-5"
+      slim
+    >
+      <v-list-item
+        to="/docs/api"
+        :title="referenceTitle"
+        :prepend-icon="referenceIcon"
+        rounded="lg"
+        color="primary"
+        class="docs-nav__item text-body-medium"
+        data-test="docs-nav-reference"
+      />
+    </v-list>
+
     <div
       v-for="category in categories"
       :key="category.slug"
@@ -69,6 +90,8 @@ import config from '@/config';
 const store = useDocsStore();
 
 const homeTitle = computed(() => config?.docs?.home?.title || 'Documentation');
+const referenceTitle = computed(() => config?.docs?.reference?.title || 'API reference');
+const referenceIcon = computed(() => config?.docs?.reference?.icon || 'fa-solid fa-code');
 
 /**
  * Categories in contract order, each with its articles order-sorted.

--- a/src/modules/docs/tests/docs.home.view.unit.tests.js
+++ b/src/modules/docs/tests/docs.home.view.unit.tests.js
@@ -41,6 +41,7 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/docs', name: 'docs', component: { template: '<div />' } },
+    { path: '/docs/api', name: 'reference', component: { template: '<div />' } },
     { path: '/docs/:category/:slug', name: 'article', component: { template: '<div />' } },
   ],
 });
@@ -124,6 +125,15 @@ describe('docs.home.view', () => {
     expect(resEl.text()).toContain('config-driven-result');
     // Confirm the OLD hardcoded strings ("Example Domain", "text") are absent.
     expect(resEl.text()).not.toContain('Example Domain');
+  });
+
+  it('links the OpenAPI reference (/docs/api) from the quickstart hero', async () => {
+    const wrapper = mountHome();
+    await flushPromises();
+    const cta = wrapper.find('[data-test="docs-home-reference-cta"]');
+    expect(cta.exists()).toBe(true);
+    expect(cta.text()).toContain('API reference');
+    expect(cta.attributes('href')).toBe('/docs/api');
   });
 
   it('renders the job-first category grid from the tree', async () => {

--- a/src/modules/docs/tests/docs.nav.component.unit.tests.js
+++ b/src/modules/docs/tests/docs.nav.component.unit.tests.js
@@ -8,7 +8,12 @@ import { setActivePinia, createPinia } from 'pinia';
 import { useDocsStore } from '../stores/docs.store';
 
 vi.mock('@/config', () => ({
-  default: { docs: { home: { title: 'Documentation' } } },
+  default: {
+    docs: {
+      home: { title: 'Documentation' },
+      reference: { title: 'API reference', icon: 'fa-solid fa-code' },
+    },
+  },
 }));
 
 import DocsNav from '../components/docs.nav.component.vue';
@@ -19,6 +24,7 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/docs', name: 'docs', component: { template: '<div />' } },
+    { path: '/docs/api', name: 'reference', component: { template: '<div />' } },
     { path: '/docs/:category/:slug', name: 'article', component: { template: '<div />' } },
   ],
 });
@@ -73,6 +79,19 @@ describe('docs.nav.component', () => {
     const wrapper = mountNav();
     const links = wrapper.findAll('[data-test="docs-nav-article"]');
     expect(links.map((l) => l.text())).toEqual(['Install', 'Quickstart', 'Webhooks']);
+  });
+
+  it('links the OpenAPI reference (/docs/api) with the config-driven title', () => {
+    const wrapper = mountNav();
+    const link = wrapper.find('[data-test="docs-nav-reference"]');
+    expect(link.exists()).toBe(true);
+    expect(link.text()).toContain('API reference');
+    expect(link.attributes('href')).toBe('/docs/api');
+  });
+
+  it('shows the reference link even when there are no categories', () => {
+    const wrapper = mountNav({ categories: [] });
+    expect(wrapper.find('[data-test="docs-nav-reference"]').exists()).toBe(true);
   });
 
   it('shows an empty state when there are no categories', () => {

--- a/src/modules/docs/views/docs.home.view.vue
+++ b/src/modules/docs/views/docs.home.view.vue
@@ -76,18 +76,32 @@
             <p class="text-overline text-primary mb-1">{{ quickstart.eyebrow }}</p>
             <h2 class="text-headline-medium font-weight-bold mb-3">{{ quickstart.title }}</h2>
             <p class="text-body-large text-medium-emphasis mb-4">{{ quickstart.subtitle }}</p>
-            <v-btn
-              v-if="quickstartCtaTo"
-              :to="quickstartCtaTo"
-              color="primary"
-              variant="flat"
-              rounded="lg"
-              class="text-none"
-              append-icon="fa-solid fa-arrow-right"
-              data-test="docs-home-quickstart-cta"
-            >
-              {{ quickstart.cta.label }}
-            </v-btn>
+            <div class="d-flex flex-wrap align-center ga-3">
+              <v-btn
+                v-if="quickstartCtaTo"
+                :to="quickstartCtaTo"
+                color="primary"
+                variant="flat"
+                rounded="lg"
+                class="text-none"
+                append-icon="fa-solid fa-arrow-right"
+                data-test="docs-home-quickstart-cta"
+              >
+                {{ quickstart.cta.label }}
+              </v-btn>
+              <!-- In-theme OpenAPI reference (/docs/api) — the natural next step
+                   after the first call. Config-driven title/icon; always shown. -->
+              <v-btn
+                to="/docs/api"
+                variant="text"
+                rounded="lg"
+                class="text-none"
+                :prepend-icon="reference.icon"
+                data-test="docs-home-reference-cta"
+              >
+                {{ reference.title }}
+              </v-btn>
+            </div>
           </v-col>
           <v-col cols="12" md="7">
             <div class="docs-quickstart__terminal">
@@ -164,6 +178,10 @@ import config from '@/config';
 
 const home = config?.docs?.home || { icon: 'fa-solid fa-book', title: 'Documentation', subtitle: '' };
 const quickstart = config?.docs?.quickstart || null;
+const reference = {
+  icon: config?.docs?.reference?.icon || 'fa-solid fa-code',
+  title: config?.docs?.reference?.title || 'API reference',
+};
 
 /**
  * Resolve the quickstart command snippet from config, joining array-of-lines


### PR DESCRIPTION
The docs module's own nav + home linked only the home + guides, never `/docs/api` (the in-theme OpenAPI reference, hidden from the main sidenav). Now the reference is reachable from WITHIN `/docs`: a persistent 'API reference' nav entry (→ `/docs/api`, config-driven title/icon) + a quiet home CTA next to the quickstart. Internal router-links, generic. 128 docs tests + 2376 full + build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent "API reference" link in the documentation sidebar, always available for quick access.
  * Added an "API reference" call-to-action button to the documentation home quickstart section.
  * Reference link title and icon are customizable through configuration with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->