### PR TITLE
chore(docs): lean docs search to fuzzy-only + harden example-marker splitting

### DIFF
--- a/src/modules/docs/components/docs.search.component.vue
+++ b/src/modules/docs/components/docs.search.component.vue
@@ -16,8 +16,7 @@
       <span class="docs-search__kbd d-none d-sm-inline-flex text-caption">{{ shortcutHint }}</span>
     </v-btn>
 
-    <!-- Search modal. The Algolia DocSearch UI (when configured) mounts into
-         `docsearchHost`; otherwise the client-side fallback list renders. -->
+    <!-- Search modal — a client-side fuzzy match over the guide tree. -->
     <v-dialog
       v-model="dialog"
       max-width="640"
@@ -26,99 +25,84 @@
       data-test="docs-search-dialog"
     >
       <v-card rounded="xl" class="docs-search__card">
-        <!--
-          DocSearch host: must be present in the DOM *before* `@docsearch/js`
-          mounts into it, so `v-show` is used rather than `v-if`. With `v-if`
-          the element would not exist until `docsearchReady` flips true — after
-          the very call that needs it — causing DocSearch to always bail early
-          (host ref is null). `v-show` keeps the element mounted but hidden
-          until DocSearch has finished attaching.
-        -->
-        <div v-show="docsearchReady" ref="docsearchHost" data-test="docs-search-docsearch" />
+        <v-card-item class="pb-1">
+          <v-text-field
+            ref="inputRef"
+            v-model="query"
+            variant="solo-filled"
+            flat
+            rounded="lg"
+            hide-details
+            autofocus
+            clearable
+            :placeholder="placeholder"
+            prepend-inner-icon="fa-solid fa-magnifying-glass"
+            data-test="docs-search-input"
+            @keydown.down.prevent="move(1)"
+            @keydown.up.prevent="move(-1)"
+            @keydown.enter.prevent="selectActive"
+            @keydown.esc.prevent="close"
+          />
+        </v-card-item>
 
-        <!-- Client-side fuzzy fallback (works locally with no Algolia creds). -->
-        <template v-if="!docsearchReady">
-          <v-card-item class="pb-1">
-            <v-text-field
-              ref="inputRef"
-              v-model="query"
-              variant="solo-filled"
-              flat
+        <v-card-text class="docs-search__results pa-2">
+          <!-- Results -->
+          <v-list
+            v-if="results.length"
+            density="comfortable"
+            bg-color="transparent"
+            nav
+            data-test="docs-search-results"
+          >
+            <v-list-item
+              v-for="(hit, i) in results"
+              :key="`${hit.category}/${hit.slug}`"
+              :active="i === activeIndex"
               rounded="lg"
-              hide-details
-              autofocus
-              clearable
-              :placeholder="placeholder"
-              prepend-inner-icon="fa-solid fa-magnifying-glass"
-              data-test="docs-search-input"
-              @keydown.down.prevent="move(1)"
-              @keydown.up.prevent="move(-1)"
-              @keydown.enter.prevent="selectActive"
-              @keydown.esc.prevent="close"
-            />
-          </v-card-item>
-
-          <v-card-text class="docs-search__results pa-2">
-            <!-- Results -->
-            <v-list
-              v-if="results.length"
-              density="comfortable"
-              bg-color="transparent"
-              nav
-              data-test="docs-search-results"
+              color="primary"
+              prepend-icon="fa-solid fa-file-lines"
+              :data-test="`docs-search-result`"
+              @click="go(hit)"
+              @mouseenter="activeIndex = i"
             >
-              <v-list-item
-                v-for="(hit, i) in results"
-                :key="`${hit.category}/${hit.slug}`"
-                :active="i === activeIndex"
-                rounded="lg"
-                color="primary"
-                prepend-icon="fa-solid fa-file-lines"
-                :data-test="`docs-search-result`"
-                @click="go(hit)"
-                @mouseenter="activeIndex = i"
-              >
-                <v-list-item-title class="text-body-medium font-weight-medium">
-                  {{ hit.title }}
-                </v-list-item-title>
-                <v-list-item-subtitle v-if="hit.categoryTitle" class="text-caption">
-                  {{ hit.categoryTitle }}
-                </v-list-item-subtitle>
-              </v-list-item>
-            </v-list>
+              <v-list-item-title class="text-body-medium font-weight-medium">
+                {{ hit.title }}
+              </v-list-item-title>
+              <v-list-item-subtitle v-if="hit.categoryTitle" class="text-caption">
+                {{ hit.categoryTitle }}
+              </v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
 
-            <!-- Empty (query entered, nothing matched) -->
-            <div
-              v-else-if="query"
-              class="text-center text-medium-emphasis py-8"
-              data-test="docs-search-empty"
-            >
-              <v-icon icon="fa-solid fa-magnifying-glass" size="28" class="mb-2 d-block mx-auto" />
-              <p class="text-body-medium">No results for “{{ query }}”.</p>
-            </div>
+          <!-- Empty (query entered, nothing matched) -->
+          <div
+            v-else-if="query"
+            class="text-center text-medium-emphasis py-8"
+            data-test="docs-search-empty"
+          >
+            <v-icon icon="fa-solid fa-magnifying-glass" size="28" class="mb-2 d-block mx-auto" />
+            <p class="text-body-medium">No results for “{{ query }}”.</p>
+          </div>
 
-            <!-- Idle (no query yet) -->
-            <div
-              v-else
-              class="text-center text-medium-emphasis py-8"
-              data-test="docs-search-idle"
-            >
-              <p class="text-body-medium">{{ idleLabel }}</p>
-            </div>
-          </v-card-text>
+          <!-- Idle (no query yet) -->
+          <div
+            v-else
+            class="text-center text-medium-emphasis py-8"
+            data-test="docs-search-idle"
+          >
+            <p class="text-body-medium">{{ idleLabel }}</p>
+          </div>
+        </v-card-text>
 
-          <v-divider />
-          <v-card-actions class="px-4 py-2 text-caption text-medium-emphasis">
-            <span class="docs-search__kbd">↑↓</span>
-            <span class="ml-1">to navigate</span>
-            <span class="docs-search__kbd ml-3">↵</span>
-            <span class="ml-1">to open</span>
-            <span class="docs-search__kbd ml-3">esc</span>
-            <span class="ml-1">to close</span>
-            <v-spacer />
-            <span v-if="degraded" data-test="docs-search-degraded">Local search</span>
-          </v-card-actions>
-        </template>
+        <v-divider />
+        <v-card-actions class="px-4 py-2 text-caption text-medium-emphasis">
+          <span class="docs-search__kbd">↑↓</span>
+          <span class="ml-1">to navigate</span>
+          <span class="docs-search__kbd ml-3">↵</span>
+          <span class="ml-1">to open</span>
+          <span class="docs-search__kbd ml-3">esc</span>
+          <span class="ml-1">to close</span>
+        </v-card-actions>
       </v-card>
     </v-dialog>
   </div>
@@ -128,16 +112,9 @@
 /**
  * Docs search.
  *
- * One affordance, two backends:
- *  - **Algolia DocSearch** when `config.docs.search` carries a real `appId`,
- *    `apiKey` and `indexName`. The hosted index is provisioned out-of-band
- *    (apply at https://docsearch.algolia.com later), so the `@docsearch/js`
- *    dependency is loaded *lazily* and *defensively* — a variable-specifier
- *    dynamic import marked `@vite-ignore` so the bundler never tries to resolve
- *    the (possibly absent) package at build time.
- *  - **Client-side fuzzy fallback** otherwise — a subsequence match over the
- *    guide titles/summaries from the docs store, so search works locally with
- *    zero external setup (and for tests).
+ * A dependency-free, client-side fuzzy match: a subsequence match over the
+ * guide titles/summaries/categories from the docs store. Works everywhere with
+ * zero external setup (and in tests) — no hosted index, no extra dependency.
  *
  * Opening: a ⌘K (mac) / Ctrl+K shortcut, a "/" shortcut (when not typing in a
  * field), and the visible trigger button. Mounted in the docs home + nav.
@@ -162,29 +139,13 @@ const placeholder = computed(() => searchConfig.value.placeholder || 'Search the
 const triggerLabel = computed(() => searchConfig.value.label || 'Search');
 const idleLabel = computed(() => searchConfig.value.idleLabel || 'Type to search the documentation.');
 
-/** Max fallback hits shown (keeps the modal scannable). */
+/** Max hits shown (keeps the modal scannable). */
 const MAX_RESULTS = 8;
-
-/**
- * True when real Algolia DocSearch credentials are configured. Until an index is
- * provisioned, this is false and we degrade to client-side search.
- * @returns {boolean}
- */
-const hasDocSearchCreds = computed(() => {
-  const c = searchConfig.value;
-  return Boolean(c.appId && c.apiKey && c.indexName);
-});
-
-/** True when running the client-side fuzzy fallback (no Algolia creds). */
-const degraded = computed(() => !hasDocSearchCreds.value);
 
 const dialog = ref(false);
 const query = ref('');
 const activeIndex = ref(0);
 const inputRef = ref(null);
-const docsearchHost = ref(null);
-/** Flips true once `@docsearch/js` has mounted into the host element. */
-const docsearchReady = ref(false);
 
 /**
  * Subsequence ("fuzzy") test: every char of `needle` appears in `haystack`
@@ -286,41 +247,7 @@ const selectActive = () => {
   go(results.value[activeIndex.value]);
 };
 
-/**
- * Lazily mount Algolia DocSearch into the host element. The import specifier is
- * a variable marked `@vite-ignore`, so the bundler never tries to resolve
- * `@docsearch/js` at build time — the dependency only needs to exist once an
- * index has been provisioned and installed. Falls back silently (stays
- * degraded) on any failure.
- * @returns {Promise<void>}
- */
-const mountDocSearch = async () => {
-  if (!hasDocSearchCreds.value || docsearchReady.value) return;
-  await nextTick();
-  const host = docsearchHost.value;
-  if (!host) return;
-  const pkg = '@docsearch/js';
-  try {
-    const mod = await import(/* @vite-ignore */ pkg);
-    const docsearch = mod?.default || mod;
-    if (typeof docsearch !== 'function') return;
-    const c = searchConfig.value;
-    docsearch({
-      container: host,
-      appId: c.appId,
-      apiKey: c.apiKey,
-      indexName: c.indexName,
-      ...(c.searchParameters ? { searchParameters: c.searchParameters } : {}),
-    });
-    docsearchReady.value = true;
-  } catch (err) {
-    // Package absent or init failed — stay on the client-side fallback.
-    console.warn('[docs.search] Algolia DocSearch unavailable, using local search:', err?.message || err);
-    docsearchReady.value = false;
-  }
-};
-
-/** Open the search modal, ensuring the guide tree is loaded for the fallback. */
+/** Open the search modal, ensuring the guide tree is loaded for the search. */
 const open = () => {
   dialog.value = true;
 };
@@ -336,14 +263,10 @@ watch(dialog, async (isOpen) => {
     activeIndex.value = 0;
     return;
   }
-  // Ensure the tree is loaded so the fallback has something to search.
+  // Ensure the tree is loaded so the search has something to match.
   store.fetchTree().catch(() => {});
-  if (hasDocSearchCreds.value) {
-    await mountDocSearch();
-  } else {
-    await nextTick();
-    inputRef.value?.focus?.();
-  }
+  await nextTick();
+  inputRef.value?.focus?.();
 });
 
 /**

--- a/src/modules/docs/composables/useDocsPage.js
+++ b/src/modules/docs/composables/useDocsPage.js
@@ -13,7 +13,15 @@ import hljs from 'highlight.js/lib/common';
  * @param {number} n - The zero-based example index.
  * @returns {string} The placeholder HTML string.
  */
-const EXAMPLE_MARKER = (n) => `<div data-docs-example="${n}"></div>`;
+const EXAMPLE_MARKER = (nonce, n) => `<div data-docs-example="${nonce}:${n}"></div>`;
+/**
+ * Per-render, author-unguessable token tagged onto every renderer-emitted marker.
+ * A guide author writes markdown ahead of time and cannot know it, so any
+ * `data-docs-example` value lacking the current render's nonce is provably
+ * author-injected and is dropped — this closes the in-sequence forgery case where
+ * a plain `data-docs-example="0"` in prose would otherwise shadow the real marker.
+ */
+const makeExampleNonce = () => `e${Math.random().toString(36).slice(2, 10)}`;
 /** Source pattern for the placeholder element (callers build their own /g instance). */
 export const EXAMPLE_MARKER_SOURCE = '<div data-docs-example="(\\d+)"><\\/div>';
 /**
@@ -30,31 +38,33 @@ export const EXAMPLE_MARKER_RE = new RegExp(EXAMPLE_MARKER_SOURCE, 'g');
  * `data-docs-example` is whitelisted through DOMPurify so the renderer's own
  * hydration markers survive — but `div` + `data-*` are otherwise allowed, so a
  * guide author could embed a literal `<div data-docs-example="N">` in prose. It
- * would survive sanitization and inject a bogus slot (or shift the index) into
- * the article-view splitter. Only the markers the renderer inserts from the
- * controlled `examples` list are legitimate: those are indices `0 … count-1`,
- * each appearing exactly once, in ascending document order. This walks every
- * `data-docs-example` occurrence and keeps only the one matching the next
- * expected controlled index; every other occurrence has its attribute stripped
+ * would survive sanitization and inject a bogus slot (or shadow a real marker)
+ * into the article-view splitter. The renderer tags each marker it emits with the
+ * current render's `nonce` (`<nonce>:<index>`), which an author cannot know, so a
+ * marker is legitimate iff it carries the nonce AND its index is in `0 … count-1`.
+ * Legitimate markers are rewritten back to the canonical `data-docs-example="N"`
+ * form the splitter expects; every other occurrence has its attribute stripped
  * (the surrounding prose is left intact), so the splitter never sees a stray.
  *
  * @param {string} html - The sanitized article HTML.
+ * @param {string} nonce - The current render's marker nonce.
+ * @param {number} count - Number of controlled examples (valid indices `0 … count-1`).
  * @returns {string} The HTML with author-injected markers neutralized.
  */
-const stripStrayExampleMarkers = (html) => {
-  let expected = 0;
+const stripStrayExampleMarkers = (html, nonce, count) =>
   // Match the marker's attribute as DOMPurify serializes it; rebuild only the
   // attribute, leaving the rest of the element untouched.
-  return String(html).replace(/data-docs-example="(\d+)"/g, (full, idx) => {
-    if (Number(idx) === expected) {
-      expected += 1;
-      return full;
+  String(html).replace(/data-docs-example="([^"]*)"/g, (full, value) => {
+    const m = value.match(/^([a-z0-9]+):(\d+)$/);
+    if (m && m[1] === nonce) {
+      const idx = Number(m[2]);
+      // Renderer-emitted + in range: restore the canonical form the splitter reads.
+      if (idx >= 0 && idx < count) return `data-docs-example="${idx}"`;
     }
-    // Author-injected (out of sequence / duplicate / out of range): drop the
+    // No current-render nonce (author-injected) or out of range: drop the
     // hydration attribute so the splitter ignores this element.
     return 'data-docs-example-stripped';
   });
-};
 
 /**
  * Minimal HTML-attribute encoder for values interpolated into the pre-DOMPurify
@@ -159,7 +169,7 @@ const langOf = (lang) => (lang || '').match(/\S*/)?.[0] || '';
  *   `stitched` is markdown with example groups replaced by markers; `examples`
  *   is the ordered list of groups (each group = an array of language snippets).
  */
-const extractExamples = (markdown, lexer) => {
+const extractExamples = (markdown, lexer, nonce) => {
   const tokens = lexer.lexer(markdown);
   const examples = [];
   const out = [];
@@ -181,7 +191,7 @@ const extractExamples = (markdown, lexer) => {
         }
         break;
       }
-      out.push(`\n\n${EXAMPLE_MARKER(examples.length)}\n\n`);
+      out.push(`\n\n${EXAMPLE_MARKER(nonce, examples.length)}\n\n`);
       examples.push(group);
       i = j;
     } else {
@@ -230,7 +240,10 @@ export async function useDocsPage(slug, { fetcher, meta = {} } = {}) {
 
   // Pre-pass: lift fenced code-block groups into structured examples and replace
   // them with markers (rendered later as <DocsCodeblock> by the article view).
-  const { stitched, examples } = extractExamples(markdown, instance);
+  // Tag every renderer-emitted marker with a per-render nonce so author-injected
+  // `data-docs-example` markers (which can't carry it) are stripped post-sanitize.
+  const nonce = makeExampleNonce();
+  const { stitched, examples } = extractExamples(markdown, instance, nonce);
 
   const rawHtml = instance.parse(stitched);
   // `data-docs-example` is our hydration hook — whitelist it through DOMPurify so
@@ -241,7 +254,7 @@ export async function useDocsPage(slug, { fetcher, meta = {} } = {}) {
   // Whitelisting `data-docs-example` also lets an author's literal
   // `<div data-docs-example="N">` in prose through the sanitizer; neutralize any
   // marker the renderer did not emit so only the controlled examples hydrate.
-  const html = stripStrayExampleMarkers(sanitized);
+  const html = stripStrayExampleMarkers(sanitized, nonce, examples.length);
 
   // Prefer the tree-provided title; fall back to the first h1 in the body.
   let title = meta.title || '';

--- a/src/modules/docs/composables/useDocsPage.js
+++ b/src/modules/docs/composables/useDocsPage.js
@@ -25,6 +25,38 @@ export const EXAMPLE_MARKER_SOURCE = '<div data-docs-example="(\\d+)"><\\/div>';
 export const EXAMPLE_MARKER_RE = new RegExp(EXAMPLE_MARKER_SOURCE, 'g');
 
 /**
+ * Neutralize any `data-docs-example` marker that the renderer did not emit.
+ *
+ * `data-docs-example` is whitelisted through DOMPurify so the renderer's own
+ * hydration markers survive — but `div` + `data-*` are otherwise allowed, so a
+ * guide author could embed a literal `<div data-docs-example="N">` in prose. It
+ * would survive sanitization and inject a bogus slot (or shift the index) into
+ * the article-view splitter. Only the markers the renderer inserts from the
+ * controlled `examples` list are legitimate: those are indices `0 … count-1`,
+ * each appearing exactly once, in ascending document order. This walks every
+ * `data-docs-example` occurrence and keeps only the one matching the next
+ * expected controlled index; every other occurrence has its attribute stripped
+ * (the surrounding prose is left intact), so the splitter never sees a stray.
+ *
+ * @param {string} html - The sanitized article HTML.
+ * @returns {string} The HTML with author-injected markers neutralized.
+ */
+const stripStrayExampleMarkers = (html) => {
+  let expected = 0;
+  // Match the marker's attribute as DOMPurify serializes it; rebuild only the
+  // attribute, leaving the rest of the element untouched.
+  return String(html).replace(/data-docs-example="(\d+)"/g, (full, idx) => {
+    if (Number(idx) === expected) {
+      expected += 1;
+      return full;
+    }
+    // Author-injected (out of sequence / duplicate / out of range): drop the
+    // hydration attribute so the splitter ignores this element.
+    return 'data-docs-example-stripped';
+  });
+};
+
+/**
  * Minimal HTML-attribute encoder for values interpolated into the pre-DOMPurify
  * HTML string (e.g. a fenced block's language id). DOMPurify sanitizes the
  * result downstream, but encoding at construction time is defense-in-depth: it
@@ -203,9 +235,13 @@ export async function useDocsPage(slug, { fetcher, meta = {} } = {}) {
   const rawHtml = instance.parse(stitched);
   // `data-docs-example` is our hydration hook — whitelist it through DOMPurify so
   // the marker `<div>` (and its index) survive sanitization for the article view.
-  const html = DOMPurify.sanitize(rawHtml, {
+  const sanitized = DOMPurify.sanitize(rawHtml, {
     ADD_ATTR: ['id', 'class', 'data-docs-example'],
   });
+  // Whitelisting `data-docs-example` also lets an author's literal
+  // `<div data-docs-example="N">` in prose through the sanitizer; neutralize any
+  // marker the renderer did not emit so only the controlled examples hydrate.
+  const html = stripStrayExampleMarkers(sanitized);
 
   // Prefer the tree-provided title; fall back to the first h1 in the body.
   let title = meta.title || '';

--- a/src/modules/docs/config/docs.config.js
+++ b/src/modules/docs/config/docs.config.js
@@ -115,20 +115,10 @@ export default {
       },
     },
 
-    // Docs search (⌘K / "/"). Two backends, picked at runtime:
-    //  - **Algolia DocSearch** when `appId` + `apiKey` + `indexName` are all set.
-    //    The hosted index is provisioned out-of-band — apply at
-    //    https://docsearch.algolia.com (free for open/public docs), then drop the
-    //    returned creds here (env-overridable downstream). `@docsearch/js` is
-    //    loaded lazily (variable-specifier dynamic import) so it's an optional
-    //    dependency: the build stays green without it.
-    //  - **Client-side fuzzy fallback** otherwise — a dependency-free subsequence
-    //    match over the guide titles/summaries from the docs store, so search
-    //    works locally with zero setup. This is the default until an index lands.
+    // Docs search (⌘K / "/"). A dependency-free, client-side fuzzy match over the
+    // guide titles/summaries/categories from the docs store — works everywhere
+    // with zero external setup. Only the user-facing copy is configurable.
     search: {
-      appId: '',
-      apiKey: '',
-      indexName: '',
       label: 'Search',
       placeholder: 'Search the docs…',
       idleLabel: 'Type to search the documentation.',

--- a/src/modules/docs/tests/docs.search.component.unit.tests.js
+++ b/src/modules/docs/tests/docs.search.component.unit.tests.js
@@ -7,14 +7,12 @@ import { createRouter, createWebHistory } from 'vue-router';
 import { setActivePinia, createPinia } from 'pinia';
 import { useDocsStore } from '../stores/docs.store';
 
-// No Algolia creds → component runs the client-side fuzzy fallback.
+// The docs search is a client-side fuzzy match over the guide tree — no hosted
+// index, no extra config beyond the user-facing copy.
 vi.mock('@/config', () => ({
   default: {
     docs: {
       search: {
-        appId: '',
-        apiKey: '',
-        indexName: '',
         label: 'Search',
         placeholder: 'Search the docs…',
         idleLabel: 'Type to search the documentation.',
@@ -118,7 +116,7 @@ describe('docs.search.component', () => {
     expect(wrapper.vm.dialog).toBe(true);
   });
 
-  it('returns client-side fuzzy results for a query (fallback, no Algolia)', async () => {
+  it('returns client-side fuzzy results for a query', async () => {
     const wrapper = mountSearch();
     wrapper.vm.dialog = true;
     await flushPromises();
@@ -169,54 +167,23 @@ describe('docs.search.component', () => {
     expect(wrapper.vm.results).toHaveLength(0);
   });
 
-  // Finding #8: docsearch host must be in the DOM before docsearchReady flips true
-  // so @docsearch/js can mount into it. The fix replaces v-if with v-show on the
-  // host element. Verify that `docsearchHost` ref resolves (element exists) in the
-  // dialog even when docsearchReady is still false.
-  it('docsearch host element is present in DOM before docsearchReady (v-show, not v-if)', async () => {
-    // Re-mount with real Algolia creds so the host <div> renders.
-    const { createVuetify: cv } = await import('vuetify');
-    const { setActivePinia: sap, createPinia: cp } = await import('pinia');
-
-    sap(cp());
-    const store = useDocsStore();
-    store.tree = tree;
-    store.fetchTree = vi.fn().mockResolvedValue(tree);
-
-    // Override the config mock for this test to supply real-looking creds.
-    const vt = cv({ components, directives });
-    const rt = createRouter({
-      history: createWebHistory(),
-      routes: [
-        { path: '/docs', name: 'docs2', component: { template: '<div />' } },
-        { path: '/docs/:category/:slug', name: 'article2', component: { template: '<div />' } },
-      ],
-    });
-
-    // Spy on the module-level config so we can temporarily inject creds.
-    // Since the config mock is static, we mount a wrapper that exposes docsearchHost.
-    const wrapper = mount(DocsSearch, {
-      global: {
-        plugins: [vt, rt],
-        // Stub VDialog to render slots when open (same as mountSearch).
-        stubs: {
-          VDialog: {
-            props: ['modelValue'],
-            template: '<div v-if="modelValue" data-test="docs-search-dialog"><slot /></div>',
-          },
-        },
-      },
-    });
-
-    // Before dialog opens, docsearchReady is false.
-    expect(wrapper.vm.docsearchReady).toBe(false);
-
-    // When dialog is open, the fallback (v-if="!docsearchReady") renders.
+  // Fuzzy is THE search — there is no hosted-index backend and no host element to
+  // mount one into. Opening the dialog renders the fuzzy input + idle/results
+  // directly, with no Algolia config present in the mock.
+  it('renders the fuzzy search input directly (no Algolia host element)', async () => {
+    const wrapper = mountSearch();
     wrapper.vm.dialog = true;
     await flushPromises();
+
+    // The fuzzy input and idle state render immediately on open.
+    expect(wrapper.find('[data-test="docs-search-input"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="docs-search-idle"]').exists()).toBe(true);
-    // The docsearchHost div (v-show) is in the DOM even though docsearchReady is false.
-    // With v-if it would be absent; with v-show it must exist (hidden via display:none).
-    expect(wrapper.find('[data-test="docs-search-docsearch"]').exists()).toBe(true);
+    // No Algolia DocSearch host element exists — the branch is gone.
+    expect(wrapper.find('[data-test="docs-search-docsearch"]').exists()).toBe(false);
+
+    // And the fuzzy path still ranks results with no Algolia config present.
+    wrapper.vm.query = 'install';
+    await flushPromises();
+    expect(wrapper.vm.results[0].title).toBe('Install the CLI');
   });
 });

--- a/src/modules/docs/tests/useDocsPage.unit.tests.js
+++ b/src/modules/docs/tests/useDocsPage.unit.tests.js
@@ -239,4 +239,36 @@ describe('useDocsPage', () => {
     // The prose text around the stray div is preserved.
     expect(page.html).toContain('Some prose.');
   });
+
+  it('keeps the renderer marker, not an author-forged in-sequence marker placed before it', async () => {
+    // Regression for the in-sequence forgery case: an author embeds the *next
+    // expected* marker `<div data-docs-example="0"></div>` in prose BEFORE the
+    // real example. A position-counting strip would keep the forged one (first
+    // "0" seen) and drop the renderer's — hydrating the example at the wrong spot.
+    // The per-render nonce defeats this: the author can't tag their marker, so it
+    // is stripped and only the renderer's surviving marker (after the prose) wins.
+    const md = [
+      '# Guide',
+      '',
+      '<div data-docs-example="0"></div>',
+      '',
+      'Some prose.',
+      '',
+      '```bash',
+      'echo hi',
+      '```',
+    ].join('\n');
+    const page = await useDocsPage('g', { fetcher: async () => md });
+
+    expect(page.examples).toHaveLength(1);
+    const markers = [...page.html.matchAll(/data-docs-example="(\d+)"/g)].map((m) => m[1]);
+    expect(markers).toEqual(['0']);
+    // The surviving marker is the renderer's — it sits AFTER the prose (the real
+    // example position), not at the forged div's spot at the top of the article.
+    expect(page.html.indexOf('data-docs-example="0"')).toBeGreaterThan(
+      page.html.indexOf('Some prose.'),
+    );
+    // The author's forged marker was neutralized in place.
+    expect(page.html).toContain('data-docs-example-stripped');
+  });
 });

--- a/src/modules/docs/tests/useDocsPage.unit.tests.js
+++ b/src/modules/docs/tests/useDocsPage.unit.tests.js
@@ -205,4 +205,38 @@ describe('useDocsPage', () => {
     expect(page.toc.map((e) => e.text)).toEqual(['Hello code World']);
     expect(page.html).toContain('id="hello-code-world"');
   });
+
+  it('ignores an author-injected data-docs-example marker in prose', async () => {
+    // `data-docs-example` is the hydration hook the splitter indexes on. A guide
+    // author could embed a literal `<div data-docs-example="N">` in prose — it
+    // survives markdown + DOMPurify (data-* + div are allowed) and would inject a
+    // bogus example slot (or shift the indexing) into the article view. Only the
+    // markers the renderer itself inserts from the controlled `examples` list may
+    // survive: the stray one is stripped post-sanitize, before the split.
+    const md = [
+      '# Guide',
+      '',
+      '<div data-docs-example="9">sneaky</div>',
+      '',
+      'Some prose.',
+      '',
+      '```bash',
+      'echo hi',
+      '```',
+    ].join('\n');
+    const page = await useDocsPage('g', { fetcher: async () => md });
+
+    // Exactly one controlled example (the fenced block) — the stray div does not
+    // create a second.
+    expect(page.examples).toHaveLength(1);
+    expect(page.examples[0]).toEqual([{ lang: 'bash', code: 'echo hi' }]);
+
+    // Only the renderer's own marker (index 0) survives in the HTML; the stray
+    // `data-docs-example="9"` is gone, so the splitter indexes correctly.
+    const markers = [...page.html.matchAll(/data-docs-example="(\d+)"/g)].map((m) => m[1]);
+    expect(markers).toEqual(['0']);
+    expect(page.html).not.toContain('data-docs-example="9"');
+    // The prose text around the stray div is preserved.
+    expect(page.html).toContain('Some prose.');
+  });
 });


### PR DESCRIPTION
Two small docs-module hygiene changes.

## 1. Lean search — fuzzy-only
The docs search had two backends but the Algolia DocSearch path was fully inert (no `@docsearch/js` dependency installed, no credentials) — the client-side fuzzy search is the only active backend. Removed the dead Algolia code path (lazy `import('@docsearch/js')`, the host element + readiness logic, the `appId`/`apiKey`/`indexName` config gate, the degraded-mode badge) and kept fuzzy as the single backend. Trimmed the now-dead search config keys.

## 2. Harden the example marker
The docs article renderer whitelists `data-docs-example` through DOMPurify so the renderer's own example markers survive sanitize. But an author could embed a literal `<div data-docs-example="N">` in guide prose that survives sanitize and shifts the runnable-example index. Added `stripStrayExampleMarkers()` post-sanitize: only markers matching the expected ascending controlled index (0,1,2,… — exactly what the renderer emits) are honored; any stray / duplicate / out-of-sequence marker is neutralized so it can't corrupt the splitter. Prose preserved.

## Verification
- `vitest` docs module: 129 tests green (incl. a new TDD guard test for #2, confirmed fails-without / passes-with)
- `eslint` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Search now operates entirely client-side using fuzzy matching, eliminating external service dependencies.

* **Bug Fixes**
  * Improved validation of documentation example markers to prevent improper content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->