### PR TITLE
feat(seo): per-route self-referential canonical + og:url

### DIFF
--- a/src/lib/helpers/canonical.js
+++ b/src/lib/helpers/canonical.js
@@ -1,0 +1,27 @@
+/**
+ * Canonical URL helper.
+ */
+
+/**
+ * @desc Build a self-referential canonical (or og:url) URL for a given route path.
+ * Joins a base origin with the route's pathname only — any query string or hash
+ * is dropped, and slashes are normalised so every route yields a single, stable
+ * absolute URL. Used at runtime by the app head so each prerendered page
+ * canonicalises to itself rather than to the homepage.
+ * @param {string} baseUrl - Absolute origin (e.g. 'https://example.com'); trailing slashes are stripped
+ * @param {string} [path='/'] - Route path (e.g. '/docs/a'); query/hash are ignored
+ * @returns {string} Absolute canonical URL, or '' when baseUrl is falsy
+ */
+export const buildCanonicalUrl = (baseUrl, path = '/') => {
+  if (!baseUrl) return '';
+  const base = String(baseUrl).replace(/\/+$/, '');
+  const raw = String(path ?? '/').split(/[?#]/)[0];
+  const cleanPath = `/${raw.replace(/^\/+/, '').replace(/\/+$/, '')}`;
+  // Root path → bare base (no trailing slash); otherwise append the normalised path.
+  return cleanPath === '/' ? base : base + cleanPath;
+};
+
+/**
+ * Exports.
+ */
+export default { buildCanonicalUrl };

--- a/src/lib/helpers/canonical.js
+++ b/src/lib/helpers/canonical.js
@@ -5,11 +5,12 @@
 /**
  * @desc Build a self-referential canonical (or og:url) URL for a given route path.
  * Joins a base origin with the route's pathname only — any query string or hash
- * is dropped, and slashes are normalised so every route yields a single, stable
- * absolute URL. Used at runtime by the app head so each prerendered page
- * canonicalises to itself rather than to the homepage.
+ * is dropped. Leading and trailing slashes in both the base URL and path are
+ * trimmed (internal duplicate slashes in the path are not collapsed) so every
+ * route yields a single, stable absolute URL. Used at runtime by the app head
+ * so each prerendered page canonicalises to itself rather than to the homepage.
  * @param {string} baseUrl - Absolute origin (e.g. 'https://example.com'); trailing slashes are stripped
- * @param {string} [path='/'] - Route path (e.g. '/docs/a'); query/hash are ignored
+ * @param {string} [path='/'] - Route path (e.g. '/docs/a'); leading/trailing slashes trimmed, query/hash ignored
  * @returns {string} Absolute canonical URL, or '' when baseUrl is falsy
  */
 export const buildCanonicalUrl = (baseUrl, path = '/') => {

--- a/src/lib/helpers/tests/canonical.unit.tests.js
+++ b/src/lib/helpers/tests/canonical.unit.tests.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { buildCanonicalUrl } from '../canonical';
+
+describe('buildCanonicalUrl Helper', () => {
+  it('returns the bare base for the root path', () => {
+    expect(buildCanonicalUrl('https://x.com', '/')).toBe('https://x.com');
+  });
+
+  it('appends a nested path to the base', () => {
+    expect(buildCanonicalUrl('https://x.com', '/docs/x')).toBe('https://x.com/docs/x');
+  });
+
+  it('normalises a trailing-slash base and a trailing-slash path', () => {
+    expect(buildCanonicalUrl('https://x.com/', '/docs/a/')).toBe('https://x.com/docs/a');
+  });
+
+  it('strips a query string from the path', () => {
+    expect(buildCanonicalUrl('https://x.com', '/p?q=1')).toBe('https://x.com/p');
+  });
+
+  it('strips a hash fragment from the path', () => {
+    expect(buildCanonicalUrl('https://x.com', '/p#section')).toBe('https://x.com/p');
+  });
+
+  it('returns an empty string when the base is empty', () => {
+    expect(buildCanonicalUrl('', '/x')).toBe('');
+  });
+
+  it('returns an empty string when the base is undefined', () => {
+    expect(buildCanonicalUrl(undefined, '/x')).toBe('');
+  });
+
+  it('defaults to the bare base when the path is undefined', () => {
+    expect(buildCanonicalUrl('https://x.com')).toBe('https://x.com');
+  });
+
+  it('defaults to the bare base when the path is null', () => {
+    expect(buildCanonicalUrl('https://x.com', null)).toBe('https://x.com');
+  });
+
+  it('returns the bare base when the path is an empty string', () => {
+    expect(buildCanonicalUrl('https://x.com', '')).toBe('https://x.com');
+  });
+});

--- a/src/lib/plugins/seo-inject.js
+++ b/src/lib/plugins/seo-inject.js
@@ -81,8 +81,9 @@ export function seoInjectPlugin(config) {
         tags.push(`  <meta name="keywords" content="${escapeHtml(app.keywords)}">`);
       if (app.author)
         tags.push(`  <meta name="author" content="${escapeHtml(app.author)}">`);
-      if (app.url)
-        tags.push(`  <link rel="canonical" href="${escapeHtml(app.url)}">`);
+      // canonical + og:url are emitted per-route at runtime (app.vue useHead) so the
+      // prerenderer captures the correct self-referential URL for each page; a single
+      // static app.url here would make every prerendered page canonicalize to the homepage.
 
       // Theme color — explicit override wins over Vuetify primary
       const themeColor = seo.themeColor || getPrimaryColor(config);
@@ -100,8 +101,7 @@ export function seoInjectPlugin(config) {
       if (app.description)
         tags.push(`  <meta property="og:description" content="${escapeHtml(app.description)}">`);
       tags.push(`  <meta property="og:type" content="${escapeHtml(og.type || 'website')}">`);
-      if (app.url)
-        tags.push(`  <meta property="og:url" content="${escapeHtml(app.url)}">`);
+      // og:url is emitted per-route at runtime (see canonical note above).
       if (og.image)
         tags.push(`  <meta property="og:image" content="${escapeHtml(og.image)}">`);
 

--- a/src/lib/plugins/tests/seo-inject.unit.tests.js
+++ b/src/lib/plugins/tests/seo-inject.unit.tests.js
@@ -68,9 +68,13 @@ describe('seoInjectPlugin', () => {
   });
 
   describe('canonical link', () => {
-    it('injects canonical link when app.url is set', () => {
+    // canonical is now emitted per-route at runtime (app.vue useHead) so the
+    // prerenderer captures a self-referential URL per page. seo-inject must NOT
+    // inject a static homepage canonical (it would make every page canonicalize
+    // to the homepage and collide with the runtime per-route one).
+    it('does not inject a canonical link even when app.url is set', () => {
       const result = transform(testConfig);
-      expect(result).toContain('<link rel="canonical" href="https://example.com">');
+      expect(result).not.toContain('rel="canonical"');
     });
 
     it('does not inject canonical when app.url is not set', () => {
@@ -100,9 +104,9 @@ describe('seoInjectPlugin', () => {
       expect(result).toContain('<meta property="og:type" content="profile">');
     });
 
-    it('injects og:url when app.url is set', () => {
+    it('does not inject og:url (emitted per-route at runtime, see canonical link)', () => {
       const result = transform(testConfig);
-      expect(result).toContain('<meta property="og:url" content="https://example.com">');
+      expect(result).not.toContain('property="og:url"');
     });
 
     it('injects og:image when set', () => {

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -54,6 +54,7 @@
  */
 import { useHead } from '@unhead/vue';
 import { useTheme } from 'vuetify';
+import { buildCanonicalUrl } from '@/lib/helpers/canonical.js';
 import { useAuthStore } from '../auth/stores/auth.store';
 import { useBillingStore } from '../billing/stores/billing.store';
 import { setupInterceptors } from '../../lib/services/axios';
@@ -229,7 +230,9 @@ export default {
     const seo = app.seo || {};
     const og = seo.og || {};
 
-    const meta = [
+    // Route-invariant meta — built once; og:url and canonical are appended
+    // per-route inside the useHead getter below.
+    const baseMeta = [
       ...(app.description ? [{ name: 'description', content: app.description }] : []),
       ...(app.keywords ? [{ name: 'keywords', content: app.keywords }] : []),
       ...(app.author ? [{ name: 'author', content: app.author }] : []),
@@ -237,7 +240,6 @@ export default {
       { property: 'og:type', content: og.type || 'website' },
       ...(app.title ? [{ property: 'og:title', content: app.title }] : []),
       ...(app.description ? [{ property: 'og:description', content: app.description }] : []),
-      ...(app.url ? [{ property: 'og:url', content: app.url }] : []),
       ...(og.image ? [{ property: 'og:image', content: og.image }] : []),
       // Twitter Card
       { name: 'twitter:card', content: og.twitterCard || 'summary' },
@@ -247,17 +249,26 @@ export default {
       ...(og.image ? [{ name: 'twitter:image', content: og.image }] : []),
     ];
 
-    const link = app.url ? [{ rel: 'canonical', href: app.url }] : [];
-
     // JSON-LD structured data is handled at build time by seo-inject when
     // schema.enabled is true, so the runtime useHead call must not inject a
     // second block.  See #3677.
 
-    useHead({
-      title: app.title,
-      htmlAttrs: { lang: app.lang || 'en' },
-      meta,
-      link,
+    // Whole-getter form: unhead resolves it inside a watchEffect (walkResolver),
+    // so reading this.$route.path here makes canonical + og:url self-referential
+    // and re-emit on every navigation — which is what the prerenderer captures
+    // per route. Avoids two static canonicals (the homepage one removed from
+    // seo-inject) which unhead would not dedupe.
+    useHead(() => {
+      const canonicalHref = app.url ? buildCanonicalUrl(app.url, this.$route?.path || '/') : '';
+      return {
+        title: app.title,
+        htmlAttrs: { lang: app.lang || 'en' },
+        meta: [
+          ...baseMeta,
+          ...(canonicalHref ? [{ property: 'og:url', content: canonicalHref }] : []),
+        ],
+        link: canonicalHref ? [{ rel: 'canonical', href: canonicalHref }] : [],
+      };
     });
 
     // Configure axios interceptors

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -258,6 +258,12 @@ export default {
     // and re-emit on every navigation — which is what the prerenderer captures
     // per route. Avoids two static canonicals (the homepage one removed from
     // seo-inject) which unhead would not dedupe.
+    /**
+     * @desc Build per-route head tags so canonical and og:url stay self-referential on every navigation.
+     * Whole-getter form so unhead resolves it inside a watchEffect (walkResolver), re-emitting
+     * on route change — which is what the prerenderer captures per route.
+     * @returns {{title: string, htmlAttrs: {lang: string}, meta: Array<object>, link: Array<object>}}
+     */
     useHead(() => {
       const canonicalHref = app.url ? buildCanonicalUrl(app.url, this.$route?.path || '/') : '';
       return {

--- a/src/modules/app/tests/app.vue.unit.tests.js
+++ b/src/modules/app/tests/app.vue.unit.tests.js
@@ -105,60 +105,80 @@ describe('App.vue — SEO (useHead)', () => {
     useHeadMock.mockClear();
   });
 
-  const mountApp = (config) =>
+  /**
+   * @desc Mount App with a mocked config + route. The component now passes a
+   * getter to useHead (so canonical/og:url recompute per route), so tests must
+   * invoke the captured getter to read the resolved head object.
+   * @param {Object} config - app config (from makeConfig)
+   * @param {String} path - mocked $route.path (default '/')
+   * @returns {import('@vue/test-utils').VueWrapper} Mounted wrapper
+   */
+  const mountApp = (config, path = '/') =>
     mount(App, {
       global: {
-        mocks: { config },
+        mocks: { config, $route: { path } },
         stubs: { RouterView: true, 'v-app': true, 'v-snackbar': true, 'v-main': true },
       },
     });
 
+  /**
+   * @desc Resolve the head object from the last useHead call. The component
+   * passes a getter, so this invokes it (binding does not matter — the getter
+   * closes over `this` via an arrow function inside created()).
+   * @returns {Object} resolved head object ({ title, htmlAttrs, meta, link })
+   */
+  const resolveHead = () => {
+    const arg = useHeadMock.mock.calls[0][0];
+    return typeof arg === 'function' ? arg() : arg;
+  };
+
+  it('passes a getter to useHead (per-route reactivity)', () => {
+    mountApp(makeConfig());
+    expect(typeof useHeadMock.mock.calls[0][0]).toBe('function');
+  });
+
   it('sets title from config', () => {
     mountApp(makeConfig());
-    const call = useHeadMock.mock.calls[0][0];
-    expect(call.title).toBe('Test App');
+    expect(resolveHead().title).toBe('Test App');
   });
 
   it('sets lang from config.app.lang', () => {
     mountApp(makeConfig());
-    const call = useHeadMock.mock.calls[0][0];
-    expect(call.htmlAttrs.lang).toBe('fr');
+    expect(resolveHead().htmlAttrs.lang).toBe('fr');
   });
 
   it('defaults lang to "en" when not set', () => {
     const config = makeConfig({ lang: undefined });
     mountApp(config);
-    const call = useHeadMock.mock.calls[0][0];
-    expect(call.htmlAttrs.lang).toBe('en');
+    expect(resolveHead().htmlAttrs.lang).toBe('en');
   });
 
   it('includes description meta', () => {
     mountApp(makeConfig());
-    const { meta } = useHeadMock.mock.calls[0][0];
+    const { meta } = resolveHead();
     expect(meta).toContainEqual({ name: 'description', content: 'Test description' });
   });
 
   it('includes Open Graph tags', () => {
     mountApp(makeConfig());
-    const { meta } = useHeadMock.mock.calls[0][0];
+    const { meta } = resolveHead();
     expect(meta).toContainEqual({ property: 'og:title', content: 'Test App' });
     expect(meta).toContainEqual({ property: 'og:description', content: 'Test description' });
     expect(meta).toContainEqual({ property: 'og:type', content: 'website' });
-    expect(meta).toContainEqual({ property: 'og:url', content: 'https://example.com' });
     expect(meta).toContainEqual({ property: 'og:image', content: 'https://example.com/og.jpg' });
   });
 
   it('omits og:url and og:image when not configured', () => {
     const config = makeConfig({ url: '', seo: { og: { image: '' } } });
     mountApp(config);
-    const { meta } = useHeadMock.mock.calls[0][0];
+    const { meta } = resolveHead();
     expect(meta.find((m) => m.property === 'og:url')).toBeUndefined();
     expect(meta.find((m) => m.property === 'og:image')).toBeUndefined();
   });
 
   it('includes Twitter Card tags', () => {
     mountApp(makeConfig());
-    const { meta } = useHeadMock.mock.calls[0][0];
+    const { meta } = resolveHead();
     expect(meta).toContainEqual({ name: 'twitter:card', content: 'summary_large_image' });
     expect(meta).toContainEqual({ name: 'twitter:title', content: 'Test App' });
     expect(meta).toContainEqual({ name: 'twitter:site', content: '@testhandle' });
@@ -167,29 +187,54 @@ describe('App.vue — SEO (useHead)', () => {
   it('omits twitter:site when not configured', () => {
     const config = makeConfig({ seo: { og: { twitterSite: '' } } });
     mountApp(config);
-    const { meta } = useHeadMock.mock.calls[0][0];
+    const { meta } = resolveHead();
     expect(meta.find((m) => m.name === 'twitter:site')).toBeUndefined();
   });
 
-  it('sets canonical link when url is configured', () => {
-    mountApp(makeConfig());
-    const { link } = useHeadMock.mock.calls[0][0];
-    expect(link).toContainEqual({ rel: 'canonical', href: 'https://example.com' });
-  });
+  describe('per-route canonical + og:url (self-referential)', () => {
+    it('sets a self-referential canonical for a nested route', () => {
+      mountApp(makeConfig(), '/docs/x');
+      const { link } = resolveHead();
+      expect(link).toContainEqual({ rel: 'canonical', href: 'https://example.com/docs/x' });
+    });
 
-  it('sets no canonical link when url is empty', () => {
-    const config = makeConfig({ url: '' });
-    mountApp(config);
-    const { link } = useHeadMock.mock.calls[0][0];
-    expect(link).toHaveLength(0);
+    it('emits og:url matching the per-route canonical', () => {
+      mountApp(makeConfig(), '/docs/x');
+      const { meta } = resolveHead();
+      expect(meta).toContainEqual({ property: 'og:url', content: 'https://example.com/docs/x' });
+    });
+
+    it('canonicalises the root route to the bare base url', () => {
+      mountApp(makeConfig(), '/');
+      const { link, meta } = resolveHead();
+      expect(link).toContainEqual({ rel: 'canonical', href: 'https://example.com' });
+      expect(meta).toContainEqual({ property: 'og:url', content: 'https://example.com' });
+    });
+
+    it('produces a different canonical per route (proves it is not the static homepage)', () => {
+      mountApp(makeConfig(), '/pricing');
+      const pricing = resolveHead().link.find((l) => l.rel === 'canonical')?.href;
+      useHeadMock.mockClear();
+      mountApp(makeConfig(), '/docs/x');
+      const docs = resolveHead().link.find((l) => l.rel === 'canonical')?.href;
+      expect(pricing).toBe('https://example.com/pricing');
+      expect(docs).toBe('https://example.com/docs/x');
+      expect(pricing).not.toBe(docs);
+    });
+
+    it('sets no canonical link when url is empty', () => {
+      const config = makeConfig({ url: '' });
+      mountApp(config, '/docs/x');
+      const { link } = resolveHead();
+      expect(link).toHaveLength(0);
+    });
   });
 
   describe('Schema.org JSON-LD', () => {
     it('does not inject runtime JSON-LD (handled by seo-inject at build time)', () => {
       const config = makeConfig({ seo: { schema: { enabled: true, type: 'Person', name: 'Test App', sameAs: ['https://github.com/test-user'] } } });
       mountApp(config);
-      const call = useHeadMock.mock.calls[0][0];
-      expect(call.script).toBeUndefined();
+      expect(resolveHead().script).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## What

Make the canonical link + og:url **per-route self-referential** instead of a single static `app.url` (the homepage) on every page.

## Why

Canonical and og:url were injected twice with the same static `app.url`: at build time in `seo-inject` (into the shared index.html) and once at runtime in `app.vue` `useHead`. Every prerendered route (`/x`, `/y/z`) therefore advertised the homepage as its canonical, so search engines deduplicate them — only the homepage gets indexed. The prerenderer captures `page.content()` after the SPA renders each route, so per-route head set at runtime is captured per route.

## How

- New pure helper `buildCanonicalUrl(baseUrl, path)` — joins origin + pathname (drops query/hash, normalises slashes; root → bare base).
- `app.vue`: compute canonical + og:url per-route from `app.url` + the current route path, via the whole-getter `useHead(() => …)` form so unhead re-emits on navigation (verified against `@unhead/vue` `walkResolver`/`watchEffect`).
- `seo-inject`: remove the static canonical + og:url injections (a single static value leaves every prerendered page with the homepage canonical; a second static tag unhead would not dedupe). `og:type/title/description/image` stay.

## Tests

- `buildCanonicalUrl` unit tests (root, nested, trailing-slash, query/hash strip, empty base).
- `seo-inject` no longer injects canonical/og:url.
- `app.vue` emits a per-route canonical (`/` → bare base, `/docs/x` → base + `/docs/x`; distinct per route).
- Lint clean, full unit suite passes (2392).

## Compat note

Non-prerendering apps now get canonical/og:url at runtime only (not in the static shell); prerendering apps get the correct per-route value baked in. Fixes the latent "every page canonicalizes to the homepage" bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canonical URLs and Open Graph URL tags are now dynamically generated per route at runtime rather than statically at build time, ensuring prerendered pages always have correct self-referential URLs.

* **Tests**
  * Added comprehensive unit test coverage for canonical URL generation and runtime SEO metadata emission across various route scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->