### PR TITLE
chore(docs): remove dead Redoc /api/docs affordance + record decommission

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,23 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## docs: Redoc /api/docs reference UI decommissioned (2026-06-17, #4333)
+
+The docs module's in-theme OpenAPI reference (`/docs/api`) renders the merged spec at `GET /api/spec.json` natively — it is now the **only** reference surface. The dead "Open in Redoc" affordance (a header button + an empty-state fallback link, both pointing at the decommissioned backend `/api/docs` Redoc UI) has been removed.
+
+### What changed (this repo)
+
+- `docs.reference.view.vue`: removed the "Open in Redoc" header action, the empty-state Redoc fallback link (now a plain "not available right now" message), and the `redocUrl` computed.
+- `docs.config.js` / `docs.router.js` / `docs.service.js`: scrubbed the stale "`/api/docs` … untouched fallback" comments — the route is gone (the backend mounts only `/api/spec.json`).
+- Dropped the `links to the standalone Redoc reference` unit test.
+
+### Action required for downstream projects (`/update-stack`)
+
+1. All files are devkit-owned → arrive via `/update-stack`. No action unless you self-host a standalone Redoc UI at `/api/docs` (none expected — the backend mounts only `/api/spec.json`).
+2. If you genuinely need an external API-reference link, add it as a config-driven affordance rather than restoring the Redoc-named one.
+
+---
+
 ## security headers: shipped via the container nginx — tune the report-only CSP (2026-06-15, #4304)
 
 The Vue security hardening bundle (#4304) added a baseline security-header block to `nginx.example.conf` (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, HSTS, and a `Content-Security-Policy-Report-Only` starter). **The stack `Dockerfile` bakes this file into the image** (`COPY nginx.example.conf … → envsubst > /etc/nginx/conf.d/default.conf`), so with the default serving setup the headers are emitted by the container's own nginx and reach the browser through any ingress that forwards backend response headers (Traefik, ingress-nginx, and most CDNs do by default). **No ingress change is required for the default deployment** — the `.example` name is historical, the file is the live config.

--- a/src/modules/docs/config/docs.config.js
+++ b/src/modules/docs/config/docs.config.js
@@ -100,8 +100,7 @@ export default {
     },
 
     // In-theme OpenAPI reference (/docs/api). Renders the merged spec served at
-    // `GET /api/spec.json` natively (no embedded Redoc) for brand parity — the
-    // standalone backend `/api/docs` Redoc UI stays as the untouched fallback.
+    // `GET /api/spec.json` natively for brand parity — the only reference surface.
     // `tagGuides` maps OpenAPI tag names → docs category slugs; when both the
     // tag and the category exist, the group shows a "Read the guide" cross-link
     // (resolved to the category's first article). Downstream owns the tag↔guide

--- a/src/modules/docs/router/docs.router.js
+++ b/src/modules/docs/router/docs.router.js
@@ -8,8 +8,7 @@
  *
  * `/docs/api` is declared BEFORE the `/docs/:category/:slug` catch-all so the
  * static segment wins (vue-router prefers static over dynamic, but order keeps
- * the intent explicit). The standalone backend Redoc UI (`/api/docs`) stays
- * untouched as the fallback reference.
+ * the intent explicit).
  *
  * No CASL `action`/`subject`: docs are public (mirrors the legal pages, which
  * carry no auth meta). Activation is gated by `config.modules.docs.activated`

--- a/src/modules/docs/services/docs.service.js
+++ b/src/modules/docs/services/docs.service.js
@@ -50,7 +50,7 @@ export const getDocArticle = (slug) =>
 /**
  * Fetch the merged OpenAPI 3 spec served by the backend.
  * Served at `${api.base}/spec.json` (sibling of `public/`, not under it) — the
- * same JSON the standalone Redoc UI (`/api/docs`) consumes.
+ * same merged spec the in-theme `/docs/api` reference renders.
  * @returns {Promise<import('axios').AxiosResponse>}
  */
 export const getSpec = () => axios.get(`${apiBaseUrl()}/spec.json`);

--- a/src/modules/docs/tests/docs.reference.view.unit.tests.js
+++ b/src/modules/docs/tests/docs.reference.view.unit.tests.js
@@ -124,13 +124,6 @@ describe('docs.reference.view', () => {
     expect(wrapper.find('[data-test="docs-reference-guide-link"]').exists()).toBe(false);
   });
 
-  it('links to the standalone Redoc reference', async () => {
-    const wrapper = mountReference();
-    await flushPromises();
-    const link = wrapper.find('[data-test="docs-reference-redoc-link"]');
-    expect(link.attributes('href')).toBe('https://api.example.com/api/docs');
-  });
-
   it('shows the empty state when the spec is unavailable', async () => {
     const store = useDocsStore();
     store.tree = tree;

--- a/src/modules/docs/views/docs.reference.view.vue
+++ b/src/modules/docs/views/docs.reference.view.vue
@@ -13,22 +13,7 @@
           :title="header.title"
           :subtitle="header.subtitle"
           avatar-color="primary"
-        >
-          <template #actions>
-            <v-btn
-              :href="redocUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="text"
-              size="small"
-              class="text-none"
-              append-icon="fa-solid fa-arrow-up-right-from-square"
-              data-test="docs-reference-redoc-link"
-            >
-              Open in Redoc
-            </v-btn>
-          </template>
-        </PageHeader>
+        />
 
         <!-- Loading -->
         <v-row v-if="loading" justify="center" class="py-12">
@@ -53,8 +38,7 @@
         <v-row v-else-if="!groups.length" class="pa-2 mt-2">
           <v-col>
             <v-alert type="info" variant="tonal" data-test="docs-reference-empty">
-              The API reference is not available right now. You can still browse it on
-              <a :href="redocUrl" target="_blank" rel="noopener noreferrer">Redoc</a>.
+              The API reference is not available right now. Please try again later.
             </v-alert>
           </v-col>
         </v-row>
@@ -257,13 +241,6 @@ const header = {
 const tagGuides = reference.tagGuides && typeof reference.tagGuides === 'object'
   ? reference.tagGuides
   : {};
-
-/** Absolute URL to the standalone Redoc reference (the untouched fallback). */
-const redocUrl = computed(() => {
-  const api = config?.api || {};
-  const port = api.port && ![80, 443, '80', '443'].includes(api.port) ? `:${api.port}` : '';
-  return `${api.protocol}://${api.host}${port}/${api.base}/docs`;
-});
 
 const store = useDocsStore();
 const loading = computed(() => store.loading);


### PR DESCRIPTION
## What

The docs module carried a dead **"Open in Redoc"** affordance — a `PageHeader` action button **and** an empty-state fallback link — both pointing at the decommissioned backend `/api/docs` Redoc route. The in-theme `/docs/api` reference renders `/api/spec.json` natively and is now the **only** reference surface.

- `docs.reference.view.vue`: drop the Redoc header action, the empty-state Redoc link (→ plain "not available right now" message), and the `redocUrl` computed.
- `docs.config.js` / `docs.router.js` / `docs.service.js`: scrub the stale "`/api/docs` … untouched fallback" comments.
- Drop the `links to the standalone Redoc reference` unit test.
- `MIGRATIONS.md`: dated decommission entry.

## Why remove (vs gate behind a flag)

`redocUrl` is hardcoded to `${api.base}/docs` (the dead route), so a `showRedocFallback` flag would only gate a **broken** target in every consumer; `redocUrl` has no external reader; the decommission is upstream-wide. A future external API-doc link, if ever needed, is a clean additive config-driven affordance — not a Redoc-named dead flag. Resolved via a multi-agent design challenge (3 lenses + judge).

## Verification

- 129 docs unit tests pass · eslint clean · `grep [Rr]edoc` empty in `modules/docs`.
- Pre-push critical-review gate: **OK** (0 critical/high).

Closes #4333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Deprecations**
  * Standalone Redoc API reference interface at `/api/docs` has been decommissioned; the merged OpenAPI specification is now the primary reference surface.

* **Bug Fixes**
  * Removed "Open in Redoc" button and related fallback messaging from the API reference view.

* **Documentation**
  * Updated migration guidance for API documentation consolidation and reference UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->