### PR TITLE
feat(docs): cross-guide #anchor link rewrite in the article renderer

### DIFF
--- a/src/modules/docs/composables/useDocsPage.js
+++ b/src/modules/docs/composables/useDocsPage.js
@@ -98,15 +98,22 @@ export const slugifyHeading = (text) =>
 
 /**
  * Build a marked renderer that:
- *  - assigns stable anchor ids to h2/h3 headings (so the ToC can deep-link), and
+ *  - assigns stable anchor ids to h2/h3 headings (so the ToC can deep-link),
+ *  - rewrites bare `#anchor` links that target *another* guide to that guide's
+ *    `/docs/:category/:slug#anchor` route (cross-guide deep-links), and
  *  - syntax-highlights fenced code blocks via highlight.js.
  *
  * Collects the heading anchors into `toc` as a side effect.
  *
  * @param {Array<{ level: number, text: string, id: string }>} toc - Mutated in place.
+ * @param {Object} [opts]
+ * @param {Set<string>} [opts.localIds] - Every heading id in THIS article (prescanned). A
+ *   `#anchor` whose id is in this set is in-file and left untouched. Omit to disable rewrites.
+ * @param {(id: string) => ({ category: string, slug: string }|null)} [opts.resolveCrossLink] -
+ *   Resolve an anchor id to the guide that owns it, or null. Omit to disable rewrites (fail-soft).
  * @returns {import('marked').MarkedExtension} A marked extension (renderer overrides).
  */
-const buildRenderer = (toc) => ({
+const buildRenderer = (toc, { localIds, resolveCrossLink } = {}) => ({
   renderer: {
     /**
      * Render a heading, registering h2/h3 anchors into the ToC.
@@ -123,6 +130,35 @@ const buildRenderer = (toc) => ({
       const id = slugifyHeading(plain);
       if (depth === 2 || depth === 3) toc.push({ level: depth, text: plain, id });
       return `<h${depth} id="${encodeAttr(id)}">${text}</h${depth}>\n`;
+    },
+    /**
+     * Rewrite a bare same-page `#anchor` link whose target lives in a DIFFERENT
+     * guide to that guide's `/docs/:category/:slug#anchor` route. Left untouched:
+     * in-file anchors (target heading is in THIS article), external/relative
+     * links, and — fail-soft — any `#anchor` that names no known guide. Returning
+     * `false` defers to marked's default link renderer (which keeps href cleaning).
+     *
+     * Membership is tested against the COMPLETE prescanned `localIds` set, not the
+     * partial ToC accumulator: marked emits links in document order, so a link can
+     * precede its own target heading, and the ToC holds only h2/h3 (an h1/h4 target
+     * would be misread as cross-guide).
+     * @param {{ href: string, title?: string, tokens: Array }} args - marked link token.
+     * @returns {string|false} Rewritten anchor HTML, or false to use the default renderer.
+     */
+    link({ href, title, tokens }) {
+      if (typeof href === 'string' && href.startsWith('#') && localIds && resolveCrossLink) {
+        const id = href.slice(1);
+        if (id && !localIds.has(id)) {
+          const target = resolveCrossLink(id);
+          if (target) {
+            const text = this.parser.parseInline(tokens);
+            const url = `/docs/${target.category}/${target.slug}#${id}`;
+            const titleAttr = title ? ` title="${encodeAttr(title)}"` : '';
+            return `<a href="${encodeAttr(url)}"${titleAttr}>${text}</a>`;
+          }
+        }
+      }
+      return false;
     },
     /**
      * Render a fenced code block with highlight.js when the language is known.
@@ -203,6 +239,90 @@ const extractExamples = (markdown, lexer, nonce) => {
   return { stitched: out.join(''), examples };
 };
 
+/**
+ * Prescan a markdown source for EVERY heading id (all depths), using the exact
+ * same plain-text derivation + `slugifyHeading` the renderer's `heading()` uses,
+ * so the set agrees with the emitted `id=""` by construction. Drives the `link()`
+ * renderer's in-file-vs-cross-guide decision (membership = "anchor lives here").
+ *
+ * A throwaway Marked instance is used so the scan can't perturb the real render's
+ * ToC accumulator; its heading renderer collects the id and emits nothing.
+ *
+ * @param {string} markdown - The (example-stitched) article markdown to scan.
+ * @returns {Set<string>} Every heading anchor id in the source.
+ */
+const collectHeadingIds = (markdown) => {
+  const ids = new Set();
+  const scanner = new Marked({ mangle: false, headerIds: false });
+  scanner.use({
+    renderer: {
+      heading({ tokens }) {
+        const plain = this.parser.parseInline(tokens, this.parser.textRenderer).trim();
+        ids.add(slugifyHeading(plain));
+        return '';
+      },
+    },
+  });
+  scanner.parse(markdown);
+  return ids;
+};
+
+/**
+ * Build a cross-guide anchor index from the docs tree: an `anchor id → owning
+ * guide` resolver used by the `link()` renderer to repoint a bare `#anchor` that
+ * targets a different guide.
+ *
+ * Two keyings, anchor authoritative:
+ *  - **slug** (best-effort): every guide is keyed by its own `slug`, so the common
+ *    `#some-guide` cross-reference (anchor === slug) resolves day-one with no
+ *    backend change.
+ *  - **anchor** (authoritative): a guide's optional `anchor` field (its real
+ *    top-of-file heading id, which need not equal its slug) is keyed too and WINS
+ *    at lookup, correcting the cases the slug heuristic can't.
+ *
+ * Fail-soft + deterministic: an id that two different guides claim within the same
+ * keying is dropped (ambiguous → no rewrite); an unknown id resolves to null
+ * (renderer leaves the link untouched). A null/empty tree yields a resolver that
+ * always returns null.
+ *
+ * @param {{ categories?: Array }} [tree] - The normalized docs tree (`store.tree`).
+ * @returns {{ resolve: (id: string) => ({ category: string, slug: string }|null) }}
+ */
+const buildCrossGuideIndex = (tree) => {
+  const slugMap = new Map();
+  const slugDup = new Set();
+  const anchorMap = new Map();
+  const anchorDup = new Set();
+  const put = (map, dup, key, target) => {
+    if (!key || dup.has(key)) return;
+    const prev = map.get(key);
+    if (prev && (prev.category !== target.category || prev.slug !== target.slug)) {
+      map.delete(key);
+      dup.add(key);
+      return;
+    }
+    map.set(key, target);
+  };
+  const categories = Array.isArray(tree?.categories) ? tree.categories : [];
+  for (const cat of categories) {
+    const articles = Array.isArray(cat?.articles) ? cat.articles : [];
+    for (const a of articles) {
+      if (!a?.slug) continue;
+      const target = { category: a.category ?? cat?.slug, slug: a.slug };
+      if (!target.category) continue;
+      put(slugMap, slugDup, a.slug, target);
+      if (a.anchor) put(anchorMap, anchorDup, a.anchor, target);
+    }
+  }
+  return {
+    resolve(id) {
+      if (anchorMap.has(id)) return anchorMap.get(id); // authoritative wins
+      if (slugMap.has(id)) return slugMap.get(id);
+      return null;
+    },
+  };
+};
+
 const NOT_FOUND = { title: '', html: '', toc: [], examples: [], notFound: true };
 
 /**
@@ -219,9 +339,11 @@ const NOT_FOUND = { title: '', html: '', toc: [], examples: [], notFound: true }
  * @param {Object} [options]
  * @param {(slug: string) => Promise<string|null>} [options.fetcher] - Markdown loader.
  * @param {{ title?: string }} [options.meta] - Optional article metadata (e.g. title from the tree).
+ * @param {{ categories?: Array }|null} [options.tree] - The normalized docs tree (`store.tree`),
+ *   used to rewrite cross-guide `#anchor` links. Omit/null → cross-link rewrite disabled (fail-soft).
  * @returns {Promise<{ title: string, html: string, toc: Array, examples: Array, notFound: boolean }>}
  */
-export async function useDocsPage(slug, { fetcher, meta = {} } = {}) {
+export async function useDocsPage(slug, { fetcher, meta = {}, tree = null } = {}) {
   if (!slug || typeof fetcher !== 'function') return { ...NOT_FOUND };
 
   let markdown;
@@ -232,18 +354,26 @@ export async function useDocsPage(slug, { fetcher, meta = {} } = {}) {
   }
   if (typeof markdown !== 'string' || !markdown.trim()) return { ...NOT_FOUND };
 
-  const toc = [];
   // marked.use is global+stateful; scope the renderer to a local instance so
   // concurrent renders don't share ToC accumulators.
   const instance = new Marked({ mangle: false, headerIds: false });
-  instance.use(buildRenderer(toc));
 
   // Pre-pass: lift fenced code-block groups into structured examples and replace
   // them with markers (rendered later as <DocsCodeblock> by the article view).
   // Tag every renderer-emitted marker with a per-render nonce so author-injected
   // `data-docs-example` markers (which can't carry it) are stripped post-sanitize.
+  // (Lexing only — independent of the renderer, so it runs before `use()`.)
   const nonce = makeExampleNonce();
   const { stitched, examples } = extractExamples(markdown, instance, nonce);
+
+  // Cross-link wiring: prescan the stitched source for every in-file heading id,
+  // and build the cross-guide resolver from the tree. Both fail-soft — an absent
+  // tree just disables the rewrite (links render unchanged).
+  const localIds = collectHeadingIds(stitched);
+  const crossIndex = buildCrossGuideIndex(tree);
+
+  const toc = [];
+  instance.use(buildRenderer(toc, { localIds, resolveCrossLink: (id) => crossIndex.resolve(id) }));
 
   const rawHtml = instance.parse(stitched);
   // `data-docs-example` is our hydration hook — whitelist it through DOMPurify so

--- a/src/modules/docs/stores/docs.store.js
+++ b/src/modules/docs/stores/docs.store.js
@@ -8,10 +8,17 @@ import docsService from '../services/docs.service';
  * Normalize the public docs API tree to the frontend's canonical shape.
  *
  * The backend (`GET /api/public/docs`) emits categories as
- *   `{ id, label, guides: [{ slug, title, persona, order, summary }] }`
+ *   `{ id, label, guides: [{ slug, title, persona, order, summary, anchor? }] }`
  * while every consumer in this module (home grid, nav, `useDocsNav`,
  * `orderedArticles`, search) reads the canonical
- *   `{ slug, title, order, articles: [{ slug, title, order, category, summary, persona }] }`.
+ *   `{ slug, title, order, articles: [{ slug, title, order, category, summary, persona, anchor? }] }`.
+ *
+ * `anchor` is OPTIONAL — a guide's top-of-file heading id, consumed by the
+ * article renderer's cross-link rewrite (`useDocsPage`) to resolve a bare
+ * `#anchor` that targets a *different* guide. Read fail-soft: absent →
+ * `undefined`, no consumer requires it, and a backend that doesn't emit it just
+ * disables the authoritative half of the cross-link index (the slug fallback
+ * still resolves the common `anchor === slug` case).
  *
  * Mapping here, at the single I/O boundary, keeps the rest of the module
  * decoupled from the wire shape. Defensive: tolerates an already-canonical
@@ -45,6 +52,9 @@ export function normalizeTree(raw) {
           category: g?.category ?? slug,
           summary: g?.summary,
           persona: g?.persona,
+          // Optional authoritative cross-link anchor (see header). `undefined`
+          // when the backend doesn't emit it — the renderer falls back to slug.
+          anchor: g?.anchor,
         })),
       };
     }),

--- a/src/modules/docs/tests/docs.store.unit.tests.js
+++ b/src/modules/docs/tests/docs.store.unit.tests.js
@@ -157,6 +157,10 @@ describe('Docs Store', () => {
       expect(art.category).toBe('get-started');
       expect(art.summary).toBe('What the API is and when to reach for it.');
       expect(art.persona).toEqual(['developer']);
+      // Optional cross-link anchor passes through fail-soft (present here, absent
+      // on the sibling guide → undefined).
+      expect(art.anchor).toBe('welcome-overview');
+      expect(cat.articles[1].anchor).toBeUndefined();
     });
 
     it('passes an already-canonical tree through intact (defensive)', () => {

--- a/src/modules/docs/tests/fixtures/docsTree.api.js
+++ b/src/modules/docs/tests/fixtures/docsTree.api.js
@@ -2,15 +2,20 @@
  * REAL `GET /api/public/docs` response shape — `data.categories`.
  *
  * The backend emits categories as `{ id, label, guides: [...] }` and each guide
- * as `{ slug, title, persona, order, summary }`. The frontend's canonical shape
- * (`{ slug, title, order, articles: [...] }`) is derived from this by the store's
- * `normalizeTree`. Tests that mocked the *canonical* shape masked the real-API
- * mismatch (empty grid / dead persona links / dead search) — this fixture is the
- * single source of truth for the wire contract so that mismatch can't regress.
+ * as `{ slug, title, persona, order, summary, anchor? }`. The frontend's canonical
+ * shape (`{ slug, title, order, articles: [...] }`) is derived from this by the
+ * store's `normalizeTree`. Tests that mocked the *canonical* shape masked the
+ * real-API mismatch (empty grid / dead persona links / dead search) — this fixture
+ * is the single source of truth for the wire contract so that mismatch can't regress.
+ *
+ * `anchor` is OPTIONAL: a guide's top-of-file heading id, consumed by the article
+ * renderer's cross-link rewrite to resolve a bare `#anchor` that targets a *different*
+ * guide (its id need not equal the slug). The `welcome` guide below carries one to
+ * lock the field into the wire contract; guides without it still resolve via slug.
  *
  * Minimal but representative: the 3 categories the default config's persona doors
  * target (`get-started`, `integrate`, `operate`), each with ≥1 guide carrying
- * every wire field (slug/title/persona/order/summary).
+ * every wire field (slug/title/persona/order/summary [+ optional anchor]).
  */
 export const docsTreeApiFixture = {
   categories: [
@@ -24,6 +29,7 @@ export const docsTreeApiFixture = {
           persona: ['developer'],
           order: 0,
           summary: 'What the API is and when to reach for it.',
+          anchor: 'welcome-overview',
         },
         {
           slug: 'quickstart',

--- a/src/modules/docs/tests/useDocsPage.unit.tests.js
+++ b/src/modules/docs/tests/useDocsPage.unit.tests.js
@@ -272,3 +272,110 @@ describe('useDocsPage', () => {
     expect(page.html).toContain('data-docs-example-stripped');
   });
 });
+
+describe('useDocsPage cross-guide link rewrite', () => {
+  // Normalized tree shape (what `store.tree` holds): categories → articles.
+  const tree = {
+    categories: [
+      {
+        slug: 'get-started',
+        title: 'Get Started',
+        order: 0,
+        articles: [{ slug: 'quickstart', title: 'Quickstart', order: 0, category: 'get-started' }],
+      },
+      {
+        slug: 'operate',
+        title: 'Operate',
+        order: 1,
+        articles: [
+          // Authoritative anchor (`rl-top`) deliberately differs from the slug.
+          { slug: 'rate-limits', title: 'Rate limits', order: 0, category: 'operate', anchor: 'rl-top' },
+        ],
+      },
+    ],
+  };
+
+  // A `#later` link placed BEFORE the `## Later` heading exercises the forward-
+  // reference case; `#webhooks` (h1) and `#deep-detail` (h4) exercise depths the
+  // ToC accumulator never holds — all must be classified in-file via the prescan.
+  const md = [
+    '# Webhooks',
+    '',
+    '[jump to setup](#setup) then [jump ahead](#later).',
+    '',
+    'See [the quickstart](#quickstart), [rate limits by anchor](#rl-top),',
+    '[rate limits by slug](#rate-limits), and [nowhere](#does-not-exist).',
+    'Back to [the top](#webhooks).',
+    '',
+    '## Setup',
+    '',
+    'Body.',
+    '',
+    '#### Deep detail',
+    '',
+    'Jump to [deep detail](#deep-detail).',
+    '',
+    '## Later',
+    '',
+    'End.',
+  ].join('\n');
+
+  const render = (overrides = {}) =>
+    useDocsPage('webhooks', { fetcher: async () => md, tree, ...overrides });
+
+  it('rewrites a cross-guide #anchor matching another guide slug to its route', async () => {
+    const page = await render();
+    expect(page.html).toContain('href="/docs/get-started/quickstart#quickstart"');
+    expect(page.html).toContain('href="/docs/operate/rate-limits#rate-limits"');
+  });
+
+  it('resolves an authoritative anchor id that differs from the slug', async () => {
+    const page = await render();
+    expect(page.html).toContain('href="/docs/operate/rate-limits#rl-top"');
+  });
+
+  it('leaves in-file anchors untouched — forward refs, h1 and h4 targets included', async () => {
+    const page = await render();
+    expect(page.html).toContain('href="#setup"'); // h2
+    expect(page.html).toContain('href="#later"'); // forward ref (link precedes heading)
+    expect(page.html).toContain('href="#webhooks"'); // h1 (never in the ToC)
+    expect(page.html).toContain('href="#deep-detail"'); // h4 (never in the ToC)
+  });
+
+  it('leaves an unknown #anchor untouched (fail-soft, no invented target)', async () => {
+    const page = await render();
+    expect(page.html).toContain('href="#does-not-exist"');
+  });
+
+  it('disables the rewrite fail-soft when no tree is provided', async () => {
+    const page = await useDocsPage('webhooks', { fetcher: async () => md });
+    expect(page.html).toContain('href="#quickstart"');
+    expect(page.html).not.toContain('/docs/get-started');
+  });
+
+  it('prefers the authoritative anchor over a colliding slug (anchor wins)', async () => {
+    const ambiguous = {
+      categories: [
+        { slug: 'a', order: 0, articles: [{ slug: 'dup', category: 'a' }] },
+        { slug: 'b', order: 1, articles: [{ slug: 'real', category: 'b', anchor: 'dup' }] },
+      ],
+    };
+    const src = ['# Doc', '', 'Go [there](#dup).'].join('\n');
+    const page = await useDocsPage('doc', { fetcher: async () => src, tree: ambiguous });
+    expect(page.html).toContain('href="/docs/b/real#dup"');
+    expect(page.html).not.toContain('/docs/a/dup');
+  });
+
+  it('skips an ambiguous id claimed by two guides within the same keying', async () => {
+    const collide = {
+      categories: [
+        { slug: 'a', order: 0, articles: [{ slug: 'same', category: 'a' }] },
+        { slug: 'b', order: 1, articles: [{ slug: 'same', category: 'b' }] },
+      ],
+    };
+    const src = ['# Doc', '', 'Go [there](#same).'].join('\n');
+    const page = await useDocsPage('doc', { fetcher: async () => src, tree: collide });
+    expect(page.html).toContain('href="#same"');
+    expect(page.html).not.toContain('/docs/');
+  });
+});

--- a/src/modules/docs/views/docs.article.view.vue
+++ b/src/modules/docs/views/docs.article.view.vue
@@ -197,6 +197,8 @@ const load = async (s) => {
   const result = await useDocsPage(s, {
     fetcher: (sl) => store.fetchArticle(sl),
     meta: meta.value,
+    // The tree feeds the cross-guide `#anchor` link rewrite (fetched just above).
+    tree: store.tree,
   });
   // Only commit if this load is still the latest one.
   if (token === _loadToken) {


### PR DESCRIPTION
## What

When a multi-guide docs set renders per-article (`/docs/:category/:slug`), a bare `#anchor` that cross-references a **different** guide resolved to nothing on the current page — the article renderer (`useDocsPage.js buildRenderer`) overrode only `heading()` + `code()`, with no `link()`. This adds a `link()` renderer that repoints such anchors to the owning guide's `/docs/:category/:slug#anchor` route, leaving in-file anchors untouched. Config-free, fail-soft, benefits every consumer of the module.

## Design (resolved via a multi-agent design challenge)

**Anchor index — tree-anchor + slug-fallback.** Keyed by each guide's `slug` (resolves the common `anchor === slug` cross-reference **day-one**, no backend change) **and** by an OPTIONAL authoritative per-guide `anchor` field that **wins on collision**. Ambiguous ids (claimed by two guides in one keying) are skipped; a null/absent tree disables the rewrite. `store.normalizeTree` reads `anchor` fail-soft.

> Scope note: the `GET /api/public/docs` backend is served by each **consumer**, not by this stack — so the module here only *defines + consumes* the optional `anchor` field fail-soft. Populating it server-side is a per-consumer follow-up; the slug fallback makes the feature useful before then.

**In-file vs cross-file — PRESCAN.** Every heading id (all depths) is collected before render via the same exported `slugifyHeading` the renderer emits (parity guaranteed). The ToC accumulator was rejected: it holds only h2/h3 in document order, so forward-reference links and h1/h4 targets would be misclassified as cross-guide → confidently-wrong navigation.

**marked v18:** a custom renderer returning `false` falls back to the default renderer (so non-rewritten links keep marked's href cleaning).

## Verification

- 137 docs unit tests pass (+8 new: cross-guide rewrite, authoritative-anchor-wins, forward-ref / h1 / h4 in-file untouched, unknown-untouched fail-soft, no-tree fail-soft, ambiguous-skip) · eslint clean.
- Pre-push critical-review gate: **OK** (0 critical/high; fail-soft + XSS surface verified).

Closes #4334