### PR TITLE
feat(auth): frame the post-verification workspace-setup step

### DIFF
--- a/src/modules/auth/components/organizationSetup.component.vue
+++ b/src/modules/auth/components/organizationSetup.component.vue
@@ -6,7 +6,7 @@
           <v-icon icon="fa-solid fa-building" size="x-large" color="primary" class="mb-4"></v-icon>
           <h3 class="text-headline-small font-weight-bold mb-2">Set up your workspace</h3>
           <p class="text-body-medium text-medium-emphasis">
-            Create or join an organization to start collaborating.
+            A workspace keeps your projects and teammates together — create one or join an existing organization to get started.
           </p>
         </div>
 

--- a/src/modules/auth/tests/auth.organizationSetup.component.unit.tests.js
+++ b/src/modules/auth/tests/auth.organizationSetup.component.unit.tests.js
@@ -55,6 +55,13 @@ describe('auth.organizationSetup.component', () => {
     expect(wrapper.text()).toContain('Organization Name');
   });
 
+  it('shows a friendly helper line explaining why a workspace is needed', async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('keeps your projects and teammates together');
+  });
+
   it('calls createOrganization with the entered name on submit', async () => {
     const mockOrg = { name: 'Test Org', _id: '123' };
     createOrganizationMock.mockResolvedValueOnce(mockOrg);

--- a/src/modules/auth/views/signup.view.vue
+++ b/src/modules/auth/views/signup.view.vue
@@ -10,7 +10,7 @@
           <router-link to="/signin" class="text-primary font-weight-bold text-decoration-none">Sign in</router-link>
         </template>
         <template v-else-if="signupStep === 'emailVerification'">We sent a verification link to <strong>{{ email }}</strong></template>
-        <template v-else-if="signupStep === 'organizationSetup'">Almost there. Join or create your workspace.</template>
+        <template v-else-if="signupStep === 'organizationSetup'">One last step — set up the workspace where your work will live.</template>
         <template v-else-if="signupStep === 'organizationWelcome'">{{ organizationWelcomeMessage }}</template>
       </p>
 
@@ -222,7 +222,7 @@ export default {
         case 'emailVerification':
           return 'Check your inbox';
         case 'organizationSetup':
-          return 'Set up your organization';
+          return 'Set up your workspace';
         case 'organizationWelcome':
           return "You're all set!";
         default:


### PR DESCRIPTION
The post-verification org-setup step was unframed (a bureaucratic interruption between verifying and activating). Reframe it with clear, friendly framing + a one-line rationale, kept config-gated by the existing org-enabled config (no new friction when org is not required).

Closes #4371