### PR TITLE
fix(e2e): resolve flaky Playwright webServer boot-race

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:coverage": "npm run test:unit:coverage",
-    "test:e2e": "npx playwright test --config playwright.config.js",
+    "test:e2e": "npm run generateConfig && npx playwright test --config playwright.config.js",
     "lint": "eslint src scripts *.config.js",
     "lint:fix": "eslint src scripts *.config.js --fix",
     "format": "prettier --write .",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,7 +13,12 @@ export default defineConfig({
   },
   webServer: {
     command: `npx vite --port ${port}`,
-    port,
+    // Gate readiness on an HTTP response (url), not a TCP bind (port): vite accepts
+    // the socket before it serves routes, so a port gate lets the first test race
+    // the not-yet-serving server (ERR_CONNECTION_REFUSED, #4372). reuseExistingServer
+    // stays true: CI pre-starts vite on this port via `npm run dev`; flipping to !CI
+    // would self-launch `npx vite` on the occupied port (strictPort:false → :8081 drift).
+    url: BASE_URL,
     cwd: '.',
     reuseExistingServer: true,
     stdout: 'pipe',

--- a/scripts/generateConfig.js
+++ b/scripts/generateConfig.js
@@ -185,7 +185,8 @@ export default ${configJSON};
   let existingConfig = null;
   try {
     existingConfig = fs.readFileSync(configPath, 'utf8');
-  } catch {
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
     // File absent (gitignored / fresh checkout) — fall through and write.
   }
   if (existingConfig === esmConfigFile) {

--- a/scripts/generateConfig.js
+++ b/scripts/generateConfig.js
@@ -176,10 +176,24 @@ const getConfiguration = async () => {
 export default ${configJSON};
 `;
 
-  // Write ESM file
-  fs.writeFileSync('./src/config/index.js', esmConfigFile);
-
-  console.log('+ Configuration file generated: index.js');
+  // Write ESM file — idempotently. Vite's dev server watches src/config/index.js;
+  // rewriting it with identical content still bumps mtime, restarting a running
+  // dev server mid-run and racing the first E2E test (ERR_CONNECTION_REFUSED, #4372).
+  // Skip the write when on-disk content is byte-identical so no-op regens (each
+  // Playwright worker re-importing the e2e config helper) never touch the watched file.
+  const configPath = './src/config/index.js';
+  let existingConfig = null;
+  try {
+    existingConfig = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    // File absent (gitignored / fresh checkout) — fall through and write.
+  }
+  if (existingConfig === esmConfigFile) {
+    console.log('+ Configuration unchanged: index.js (write skipped)');
+  } else {
+    fs.writeFileSync(configPath, esmConfigFile);
+    console.log('+ Configuration file generated: index.js');
+  }
 };
 
 getConfiguration();

--- a/src/lib/helpers/tests/generateConfig.unit.tests.js
+++ b/src/lib/helpers/tests/generateConfig.unit.tests.js
@@ -37,6 +37,54 @@ const deserialize = (esmBody) => {
   return JSON.parse(json);
 };
 
+/**
+ * Idempotent-write guard logic extracted from generateConfig.js.
+ *
+ * The script skips `fs.writeFileSync` when the on-disk content is byte-identical
+ * to the newly generated content, preventing a spurious mtime bump that would
+ * restart vite's watcher mid Playwright run (regression: #4372).
+ *
+ * These tests verify the decision predicate and the ENOENT-only catch contract
+ * without performing real I/O.
+ */
+
+/** Mirror of the write-skip predicate in generateConfig.js */
+const shouldWrite = (existingContent, newContent) => existingContent !== newContent;
+
+/**
+ * Mirror of the ENOENT-narrow catch in generateConfig.js:
+ * rethrows anything that isn't a missing-file error.
+ */
+const handleReadError = (err) => {
+  if (err.code !== 'ENOENT') throw err;
+  return null; // file absent — fall through to write
+};
+
+describe('generateConfig idempotent write', () => {
+  it('skips write when content is byte-identical', () => {
+    const content = 'export default {};\n';
+    expect(shouldWrite(content, content)).toBe(false);
+  });
+
+  it('writes when content differs', () => {
+    expect(shouldWrite('export default {"old":true};\n', 'export default {"new":true};\n')).toBe(true);
+  });
+
+  it('writes when file is absent (null existingContent)', () => {
+    expect(shouldWrite(null, 'export default {};\n')).toBe(true);
+  });
+
+  it('rethrows non-ENOENT read errors so permission failures surface loudly', () => {
+    const permError = Object.assign(new Error('Permission denied'), { code: 'EACCES' });
+    expect(() => handleReadError(permError)).toThrow('Permission denied');
+  });
+
+  it('returns null for ENOENT so a missing file falls through to the write path', () => {
+    const notFoundError = Object.assign(new Error('No such file'), { code: 'ENOENT' });
+    expect(handleReadError(notFoundError)).toBeNull();
+  });
+});
+
 describe('generateConfig serializer', () => {
   it('round-trips a string value containing quotes, braces, colons, commas, and newlines', () => {
     const nastyCommand = [


### PR DESCRIPTION
## Summary

- Fix intermittent `net::ERR_CONNECTION_REFUSED` on the first Playwright E2E test caused by two independent root causes.
- `generateConfig` now writes `src/config/index.js` idempotently (byte-compare, skip on match) so Playwright worker processes re-importing the e2e helper no longer bump the file's mtime and restart vite mid-run.
- `playwright.config.js` gates readiness on `url` (HTTP response) instead of `port` (TCP bind), eliminating the window where vite accepts the socket before serving routes.
- `package.json` prefixes `test:e2e` with `npm run generateConfig` for parity with `dev`/`build`/`preview`.

## Why

Two root causes for the boot-race (#4372):

1. **Mid-run config rewrite → dev-server restart.** `src/lib/helpers/e2e/config.js` runs `generateConfig` at module-import time, rewriting the gitignored, vite-watched `src/config/index.js`. The helper is imported by both `playwright.config.js` (main process, before vite boots) AND by each test spec (worker processes, after vite is up). Worker imports re-fire the regen → rewrite the watched file (even identical content bumps mtime) → vite restarts mid-run → first test races the restart.

2. **TCP-ready ≠ HTTP-ready.** `webServer` gated readiness on `port` (TCP bind); vite accepts the socket before it serves routes.

## Scope

- Modules impacted: `scripts/generateConfig.js`, `playwright.config.js`, `package.json` (test:e2e script only)
- Cross-module impact: `none`
- Risk level: `low` — test harness only, no production code path changed

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [ ] `npm run build`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- `reuseExistingServer: true` is kept intentionally in `playwright.config.js`: CI pre-starts vite on this port via `npm run dev`; flipping to `!CI` would self-launch `npx vite` on an already-occupied port (`strictPort:false` → silent port drift to `:8081`).
- Idempotent write proven locally: second `generateConfig` run prints "Configuration unchanged: index.js (write skipped)", mtime unchanged.
- The broad `catch {}` in `generateConfig.js` (for reading existing config) only catches ENOENT (file absent on fresh checkout / gitignored) — non-ENOENT errors would surface as an unhandled throw from `fs.readFileSync`, which is the correct fail-loud behavior.

Closes #4372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * End-to-end tests now wait for the app to respond over HTTP before starting, which improves reliability in local and CI runs.
  * Configuration generation now avoids rewriting files when nothing has changed, reducing unnecessary file churn.

* **Chores**
  * The end-to-end test workflow now includes a configuration generation step before running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->