### PR TITLE
feat(billing): grouped feature sections + plan inheritance on pricing cards

### DIFF
--- a/src/modules/billing/components/billing.card.component.vue
+++ b/src/modules/billing/components/billing.card.component.vue
@@ -134,7 +134,7 @@
         v-if="item.features && item.features.length > 0"
         density="compact"
         bg-color="transparent"
-        class="pa-0"
+        class="pa-0 billing-card__flat-features"
       >
         <v-list-item
           v-for="feature in item.features"
@@ -210,8 +210,11 @@ export default {
   z-index: 2;
 }
 /* Allow `\n` in feature.text to render as line breaks (Vuetify v-list-item-title
-   clips by default). Used by ops-eval features that list scraps / autofixes / stealth. */
-.billing-card :deep(.v-list-item-title) {
+   clips by default). Used by ops-eval features that list multi-line descriptions.
+   Scoped to the FLAT features list only — grouped section items own their own
+   white-space rule (BillingPricingFeatureSectionComponent) and must not inherit
+   pre-line, which would otherwise cascade at equal specificity. */
+.billing-card__flat-features :deep(.v-list-item-title) {
   white-space: pre-line;
 }
 </style>

--- a/src/modules/billing/components/billing.card.component.vue
+++ b/src/modules/billing/components/billing.card.component.vue
@@ -124,7 +124,7 @@
       </p>
       <BillingPricingFeatureSectionComponent
         v-for="(section, idx) in item.sections"
-        :key="section.title || `section-${idx}`"
+        :key="`${section.title || 'section'}-${idx}`"
         :section="section"
       />
     </template>

--- a/src/modules/billing/components/billing.card.component.vue
+++ b/src/modules/billing/components/billing.card.component.vue
@@ -31,6 +31,16 @@
                 but worth flagging for downstream overrides.
     info      : string|null              — ops-eval line, shown between CTA and features
     features  : [{ icon: string, color: string, text: string }]
+                — flat feature list (legacy / default). Rendered when `sections` is empty/absent.
+    sections  : [{ title?: string, introText?: string, inheritsFrom?: string,
+                   items: [{ text, icon?, iconColor?, tooltip?, highlight?, enabled? }] }]
+                — OPTIONAL grouped feature sections. When present (length > 0) they REPLACE the
+                  flat `features` list — each section renders via BillingPricingFeatureSectionComponent.
+                  Note: item-level color key is `iconColor` (not `color`), and `enabled: false` greys an item.
+    inheritsFrom   : string|null         — OPTIONAL parent plan id (informational; the view resolves the name).
+    parentPlanName : string|null         — OPTIONAL resolved parent plan display name. When set AND
+                  `sections` is used, the card renders a single "Everything in {parentPlanName}, plus"
+                  heading above the sections. The card is DUMB — it never resolves this itself.
     badge     : string|null              — e.g. 'MOST POPULAR'
     highlight : boolean                  — elevated card variant
 
@@ -95,35 +105,61 @@
     <!-- Info line (ops-eval) -->
     <p v-if="item.info" class="text-body-small text-medium-emphasis mb-4">{{ item.info }}</p>
 
-    <!-- Features list -->
-    <v-list
-      v-if="item.features && item.features.length > 0"
-      density="compact"
-      bg-color="transparent"
-      class="pa-0"
-    >
-      <v-list-item
-        v-for="feature in item.features"
-        :key="feature.text"
-        class="px-0"
+    <!-- Features: grouped sections (inheritance-aware) OR flat fallback -->
+    <template v-if="item.sections && item.sections.length > 0">
+      <!-- Plan-level inheritance heading — rendered ONCE above the sections when the
+           view resolved a parent plan name. Styled like the section component's own
+           __inherits heading for visual consistency. -->
+      <p
+        v-if="item.parentPlanName"
+        class="text-body-small text-medium-emphasis mb-2"
       >
-        <template #prepend>
-          <v-icon
-            :icon="feature.icon || 'fa-solid fa-check'"
-            :color="feature.color || 'primary'"
-            size="small"
-            class="mr-3"
-          />
-        </template>
-        <v-list-item-title>{{ feature.text }}</v-list-item-title>
-      </v-list-item>
-    </v-list>
+        Everything in {{ item.parentPlanName }}, plus
+      </p>
+      <BillingPricingFeatureSectionComponent
+        v-for="(section, idx) in item.sections"
+        :key="section.title || `section-${idx}`"
+        :section="section"
+        :parent-plan-name="item.parentPlanName"
+      />
+    </template>
+    <template v-else>
+      <!-- Features list -->
+      <v-list
+        v-if="item.features && item.features.length > 0"
+        density="compact"
+        bg-color="transparent"
+        class="pa-0"
+      >
+        <v-list-item
+          v-for="feature in item.features"
+          :key="feature.text"
+          class="px-0"
+        >
+          <template #prepend>
+            <v-icon
+              :icon="feature.icon || 'fa-solid fa-check'"
+              :color="feature.color || 'primary'"
+              size="small"
+              class="mr-3"
+            />
+          </template>
+          <v-list-item-title>{{ feature.text }}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </template>
   </v-card>
 </template>
 
 <script>
+import BillingPricingFeatureSectionComponent from './billing.pricingFeatureSection.component.vue';
+
 export default {
   name: 'BillingCardComponent',
+
+  components: {
+    BillingPricingFeatureSectionComponent,
+  },
 
   props: {
     /**

--- a/src/modules/billing/components/billing.card.component.vue
+++ b/src/modules/billing/components/billing.card.component.vue
@@ -32,15 +32,19 @@
     info      : string|null              — ops-eval line, shown between CTA and features
     features  : [{ icon: string, color: string, text: string }]
                 — flat feature list (legacy / default). Rendered when `sections` is empty/absent.
-    sections  : [{ title?: string, introText?: string, inheritsFrom?: string,
+    sections  : [{ title?: string,
                    items: [{ text, icon?, iconColor?, tooltip?, highlight?, enabled? }] }]
                 — OPTIONAL grouped feature sections. When present (length > 0) they REPLACE the
                   flat `features` list — each section renders via BillingPricingFeatureSectionComponent.
-                  Note: item-level color key is `iconColor` (not `color`), and `enabled: false` greys an item.
+                  Note: item-level color key is `iconColor` (`color` is accepted as a back-compat
+                  alias), and `enabled: false` greys an item. Inheritance is PLAN-level only (see
+                  `inheritsFrom` / `parentPlanName` below) — a section never carries its own
+                  "Everything in …" heading.
     inheritsFrom   : string|null         — OPTIONAL parent plan id (informational; the view resolves the name).
     parentPlanName : string|null         — OPTIONAL resolved parent plan display name. When set AND
                   `sections` is used, the card renders a single "Everything in {parentPlanName}, plus"
-                  heading above the sections. The card is DUMB — it never resolves this itself.
+                  heading above the sections. The card is DUMB — it never resolves this itself, and it
+                  does NOT forward it to the section components (the plan-level heading is the only one).
     badge     : string|null              — e.g. 'MOST POPULAR'
     highlight : boolean                  — elevated card variant
 
@@ -109,7 +113,9 @@
     <template v-if="item.sections && item.sections.length > 0">
       <!-- Plan-level inheritance heading — rendered ONCE above the sections when the
            view resolved a parent plan name. Styled like the section component's own
-           __inherits heading for visual consistency. -->
+           __inherits heading for visual consistency. The card OWNS this heading and
+           deliberately does NOT pass parentPlanName down to the section components, so a
+           section that declares `inheritsFrom` can never emit a second identical heading. -->
       <p
         v-if="item.parentPlanName"
         class="text-body-small text-medium-emphasis mb-2"
@@ -120,7 +126,6 @@
         v-for="(section, idx) in item.sections"
         :key="section.title || `section-${idx}`"
         :section="section"
-        :parent-plan-name="item.parentPlanName"
       />
     </template>
     <template v-else>

--- a/src/modules/billing/components/billing.pricingFeatureSection.component.vue
+++ b/src/modules/billing/components/billing.pricingFeatureSection.component.vue
@@ -46,7 +46,7 @@
         <template #prepend>
           <v-icon
             :icon="item.icon || 'fa-solid fa-check'"
-            :color="item.enabled === false ? undefined : (item.iconColor || 'primary')"
+            :color="item.enabled === false ? undefined : (item.iconColor || item.color || 'primary')"
             :class="{ 'text-disabled': item.enabled === false }"
             size="small"
             class="mr-3"

--- a/src/modules/billing/config/billing.static-content.js
+++ b/src/modules/billing/config/billing.static-content.js
@@ -18,7 +18,41 @@
  *     monthlyPrice?, annualPrice?,         // optional raw numbers — when omitted card shows error or hides price
  *     info?: string|null,                  // ops-eval / per-cycle quota line, shown between CTA and features
  *     features: [{ icon, color, text }],   // flat list, icon (fa-solid fa-*) + Vuetify color + label
+ *     sections?: Section[],                // OPTIONAL grouped, inheritance-aware feature sections (see below).
+ *                                          // When present, REPLACES the flat `features` list on the card.
+ *     inheritsFrom?: string|null,          // OPTIONAL id of the parent plan. The view resolves it to the
+ *                                          // parent's `title` and the card renders one
+ *                                          // "Everything in {parent title}, plus" heading above the sections.
  *     meta?: object,                       // free-form per-plan metadata (Stripe IDs, quotas, etc.)
+ *   }
+ *
+ * Section shape (grouped feature list — opt-in, fully backward-compatible):
+ *   {
+ *     title?: string,                      // section heading, e.g. "Core", "Collaboration"
+ *     introText?: string,                  // overrides the inheritance heading for this section
+ *     inheritsFrom?: string,               // section-level "Everything in {parent}, plus" heading
+ *     items: [{
+ *       text,                              // required label
+ *       icon?: string,                     // fa-solid fa-* (defaults to fa-solid fa-check)
+ *       iconColor?: string,                // Vuetify color name OR hex (NOTE: `iconColor`, not `color`)
+ *       tooltip?: string,                  // optional info-icon tooltip
+ *       highlight?: boolean,               // emphasised row
+ *       enabled?: boolean,                 // `false` greys the row out (e.g. "not in this plan")
+ *     }],
+ *   }
+ *
+ * Minimal grouped-plan example (do NOT replace the flat demo plans below — kept for
+ * downstream fallback parity; downstreams opt in by authoring `sections` in their own content):
+ *   {
+ *     id: 'pro', title: 'Pro', subtitle: 'For professionals', cta: 'Get Started',
+ *     monthlyPrice: 49, annualPrice: 490, inheritsFrom: 'starter',
+ *     sections: [
+ *       { title: 'Everything in Starter', items: [{ text: 'Unlimited projects', icon: 'fa-solid fa-folder' }] },
+ *       { title: 'Pro only', items: [
+ *         { text: 'Advanced analytics', icon: 'fa-solid fa-chart-line', iconColor: 'warning', highlight: true },
+ *         { text: 'SSO', enabled: false },
+ *       ] },
+ *     ],
  *   }
  *
  * FAQ shape:

--- a/src/modules/billing/config/billing.static-content.js
+++ b/src/modules/billing/config/billing.static-content.js
@@ -29,25 +29,30 @@
  * Section shape (grouped feature list — opt-in, fully backward-compatible):
  *   {
  *     title?: string,                      // section heading, e.g. "Core", "Collaboration"
- *     introText?: string,                  // overrides the inheritance heading for this section
- *     inheritsFrom?: string,               // section-level "Everything in {parent}, plus" heading
  *     items: [{
  *       text,                              // required label
  *       icon?: string,                     // fa-solid fa-* (defaults to fa-solid fa-check)
- *       iconColor?: string,                // Vuetify color name OR hex (NOTE: `iconColor`, not `color`)
+ *       iconColor?: string,                // Vuetify color name OR hex. Canonical key for grouped
+ *                                          // items; the flat-list `color` key is accepted as a
+ *                                          // back-compat alias so a flat→grouped migration keeps colors.
  *       tooltip?: string,                  // optional info-icon tooltip
  *       highlight?: boolean,               // emphasised row
  *       enabled?: boolean,                 // `false` greys the row out (e.g. "not in this plan")
  *     }],
  *   }
+ *   Inheritance is PLAN-level only: set `plan.inheritsFrom` to render ONE
+ *   "Everything in {parent title}, plus" heading above the sections. Sections themselves carry
+ *   no inheritance heading — the card owns it.
  *
  * Minimal grouped-plan example (do NOT replace the flat demo plans below — kept for
  * downstream fallback parity; downstreams opt in by authoring `sections` in their own content):
  *   {
  *     id: 'pro', title: 'Pro', subtitle: 'For professionals', cta: 'Get Started',
- *     monthlyPrice: 49, annualPrice: 490, inheritsFrom: 'starter',
+ *     monthlyPrice: 49, annualPrice: 490,
+ *     inheritsFrom: 'starter',   // → card renders ONE "Everything in Starter, plus" heading
  *     sections: [
- *       { title: 'Everything in Starter', items: [{ text: 'Unlimited projects', icon: 'fa-solid fa-folder' }] },
+ *       // First (untitled) section lists the inherited features, right under the plan-level heading.
+ *       { items: [{ text: 'Unlimited projects', icon: 'fa-solid fa-folder' }] },
  *       { title: 'Pro only', items: [
  *         { text: 'Advanced analytics', icon: 'fa-solid fa-chart-line', iconColor: 'warning', highlight: true },
  *         { text: 'SSO', enabled: false },

--- a/src/modules/billing/tests/billing.card.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.card.component.unit.tests.js
@@ -91,11 +91,10 @@ describe('BillingCardComponent', () => {
 
   it('does not render info paragraph when info is null', () => {
     const wrapper = mountComponent(makeItem({ info: null }));
-    // No `p` with that class should exist unless it contains text
-    const infoEl = wrapper.find('p');
-    if (infoEl.exists()) {
-      expect(infoEl.text().trim()).toBe('For starters'); // subtitle only
-    }
+    // The info line is the only `<p class="text-body-small">` on a default card (no sections,
+    // no parentPlanName). Target it by class — `wrapper.find('p')` returns the always-present
+    // subtitle `<p class="text-body-medium">` and would pass even if the info `v-if` were removed.
+    expect(wrapper.find('p.text-body-small').exists()).toBe(false);
   });
 
   it('renders features list items', () => {
@@ -243,16 +242,23 @@ describe('BillingCardComponent — grouped feature sections', () => {
     expect(text.split('Everything in Starter, plus')).toHaveLength(2);
   });
 
-  it('forwards item.parentPlanName to each section component as parent-plan-name', () => {
+  it('does NOT forward parentPlanName to section components — the card owns the single plan-level heading', () => {
+    // Regression guard for the double-heading footgun: the card renders the
+    // "Everything in {parent}, plus" heading ONCE at plan level and must not pass parentPlanName
+    // down, or a section that declares `inheritsFrom` would emit a second identical heading.
     const item = makeItem({
       features: [],
       inheritsFrom: 'starter',
       parentPlanName: 'Starter',
-      sections: [{ title: 'Pro only', items: [{ text: 'A' }] }],
+      // A section that DECLARES inheritsFrom must still NOT produce a second heading, because the
+      // card no longer forwards parentPlanName (section.resolvedHeading stays null without it).
+      sections: [{ inheritsFrom: 'starter', items: [{ text: 'Inherited feature' }] }],
     });
     const wrapper = mountComponent(item);
     const section = wrapper.findComponent(BillingPricingFeatureSectionComponent);
-    expect(section.props('parentPlanName')).toBe('Starter');
+    expect(section.props('parentPlanName')).toBe(null);
+    // The inheritance heading appears exactly once (plan-level), never duplicated by the section.
+    expect(wrapper.text().split('Everything in Starter, plus')).toHaveLength(2);
   });
 
   it('does NOT render the flat features v-list when sections are present', () => {
@@ -283,6 +289,18 @@ describe('BillingCardComponent — flat fallback (no sections)', () => {
     const wrapper = mountComponent(item);
     expect(wrapper.text()).toContain('Flat feature one');
     expect(wrapper.text()).toContain('Flat feature two');
+    expect(wrapper.findAllComponents(BillingPricingFeatureSectionComponent)).toHaveLength(0);
+  });
+
+  it('falls back to the flat features list when sections is an empty array', () => {
+    // Guard `item.sections && item.sections.length > 0`: an empty array is truthy but
+    // length-0, so the flat fallback must still run (and no section components mount).
+    const item = makeItem({
+      features: [{ icon: 'fa-solid fa-check', color: 'primary', text: 'Flat only feature' }],
+      sections: [],
+    });
+    const wrapper = mountComponent(item);
+    expect(wrapper.text()).toContain('Flat only feature');
     expect(wrapper.findAllComponents(BillingPricingFeatureSectionComponent)).toHaveLength(0);
   });
 });

--- a/src/modules/billing/tests/billing.card.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.card.component.unit.tests.js
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 import BillingCardComponent from '../components/billing.card.component.vue';
+import BillingPricingFeatureSectionComponent from '../components/billing.pricingFeatureSection.component.vue';
 
 const vuetify = createVuetify();
 
@@ -194,5 +195,122 @@ describe('BillingCardComponent', () => {
     const wrapper = mountComponent(item);
     const icon = wrapper.findComponent({ name: 'VIcon' });
     expect(icon.props('icon')).toBe('fa-solid fa-check');
+  });
+});
+
+// ── Grouped feature sections + plan inheritance ──────────────────────────────
+
+describe('BillingCardComponent — grouped feature sections', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders one BillingPricingFeatureSectionComponent per section', () => {
+    const item = makeItem({
+      features: [],
+      sections: [
+        { title: 'Core', items: [{ text: 'A' }] },
+        { title: 'Collaboration', items: [{ text: 'B' }] },
+      ],
+    });
+    const wrapper = mountComponent(item);
+    expect(wrapper.findAllComponents(BillingPricingFeatureSectionComponent)).toHaveLength(2);
+    expect(wrapper.text()).toContain('A');
+    expect(wrapper.text()).toContain('B');
+  });
+
+  it('passes each section through to the section component as the `section` prop', () => {
+    const sections = [{ title: 'Core', items: [{ text: 'A' }] }];
+    const item = makeItem({ features: [], sections });
+    const wrapper = mountComponent(item);
+    const section = wrapper.findComponent(BillingPricingFeatureSectionComponent);
+    expect(section.props('section')).toEqual(sections[0]);
+  });
+
+  it('renders the plan-level inheritance heading ONCE when item.parentPlanName is set', () => {
+    const item = makeItem({
+      features: [],
+      inheritsFrom: 'starter',
+      parentPlanName: 'Starter',
+      // sections carry plain titles (no section-level inheritsFrom) so the only
+      // "Everything in …" heading comes from the card-level <p>.
+      sections: [{ title: 'Pro only', items: [{ text: 'Advanced analytics' }] }],
+    });
+    const wrapper = mountComponent(item);
+    const text = wrapper.text();
+    expect(text).toContain('Everything in Starter, plus');
+    // Exactly one occurrence (rendered once above the sections, not per section).
+    expect(text.split('Everything in Starter, plus')).toHaveLength(2);
+  });
+
+  it('forwards item.parentPlanName to each section component as parent-plan-name', () => {
+    const item = makeItem({
+      features: [],
+      inheritsFrom: 'starter',
+      parentPlanName: 'Starter',
+      sections: [{ title: 'Pro only', items: [{ text: 'A' }] }],
+    });
+    const wrapper = mountComponent(item);
+    const section = wrapper.findComponent(BillingPricingFeatureSectionComponent);
+    expect(section.props('parentPlanName')).toBe('Starter');
+  });
+
+  it('does NOT render the flat features v-list when sections are present', () => {
+    const item = makeItem({
+      // Even if a stray flat `features` array is present, sections take precedence.
+      features: [{ icon: 'fa-solid fa-check', color: 'primary', text: 'Stray flat feature' }],
+      sections: [{ title: 'Core', items: [{ text: 'Section feature' }] }],
+    });
+    const wrapper = mountComponent(item);
+    expect(wrapper.findAllComponents(BillingPricingFeatureSectionComponent)).toHaveLength(1);
+    expect(wrapper.text()).toContain('Section feature');
+    expect(wrapper.text()).not.toContain('Stray flat feature');
+  });
+});
+
+describe('BillingCardComponent — flat fallback (no sections)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders the flat v-list and NO section components when only features are given', () => {
+    const item = makeItem({
+      features: [
+        { icon: 'fa-solid fa-check', color: 'primary', text: 'Flat feature one' },
+        { icon: 'fa-solid fa-check', color: 'success', text: 'Flat feature two' },
+      ],
+    });
+    const wrapper = mountComponent(item);
+    expect(wrapper.text()).toContain('Flat feature one');
+    expect(wrapper.text()).toContain('Flat feature two');
+    expect(wrapper.findAllComponents(BillingPricingFeatureSectionComponent)).toHaveLength(0);
+  });
+});
+
+describe('BillingCardComponent — inheritance edge cases', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('does not render the inheritance heading (and does not crash) when inheritsFrom is set but parentPlanName is null', () => {
+    const item = makeItem({
+      features: [],
+      inheritsFrom: 'starter',
+      parentPlanName: null,
+      sections: [{ title: 'Pro only', items: [{ text: 'A' }] }],
+    });
+    const wrapper = mountComponent(item);
+    expect(wrapper.text()).not.toContain('Everything in');
+    // Sections still render fine.
+    expect(wrapper.findAllComponents(BillingPricingFeatureSectionComponent)).toHaveLength(1);
+  });
+
+  it('renders without crashing when neither sections nor features are present', () => {
+    const item = makeItem({ features: [], sections: undefined });
+    const wrapper = mountComponent(item);
+    expect(wrapper.find('.billing-card').exists()).toBe(true);
+    expect(wrapper.findAllComponents(BillingPricingFeatureSectionComponent)).toHaveLength(0);
+    // Title still rendered — card body is intact.
+    expect(wrapper.text()).toContain('Free');
   });
 });

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -578,3 +578,85 @@ describe('BillingPricingView — both-tabs: toggle :disabled when activeTab === 
     expect(toggle.props('disabled')).toBe(true);
   });
 });
+
+// ─── Suite: resolvedPlanItems — sections passthrough + inheritsFrom → parentPlanName ──
+
+describe('BillingPricingView — resolvedPlanItems sections + inheritsFrom resolution', () => {
+  let wrapper;
+  let store;
+
+  const plansWithSections = [
+    { id: 'starter', title: 'Starter', subtitle: 'For growing teams', highlight: false, badge: null, cta: 'Get started', features: [] },
+    {
+      id: 'pro',
+      title: 'Pro',
+      subtitle: 'For professionals',
+      highlight: true,
+      badge: null,
+      cta: 'Upgrade',
+      inheritsFrom: 'starter',
+      sections: [
+        { items: [{ text: 'Unlimited projects' }] },
+        { title: 'Pro only', items: [{ text: 'Advanced analytics' }] },
+      ],
+    },
+    { id: 'ghost', title: 'Ghost', subtitle: 'Dangling parent ref', highlight: false, badge: null, cta: 'Upgrade', inheritsFrom: 'does-not-exist', features: [] },
+  ];
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    pricingState.mode = 'subscription';
+    pricingState.plans = plansWithSections;
+    pricingState.hasPlans = true;
+    authState.isLoggedIn = true;
+    authState.serverConfig = { billing: { meterMode: false } };
+    store = useBillingStore();
+    seedStore(store);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    sessionStorage.clear();
+  });
+
+  it('resolves parentPlanName from an existing inheritsFrom id to the parent plan title', async () => {
+    wrapper = mountPricing();
+    await flushPromises();
+    const pro = wrapper.vm.resolvedPlanItems.find((i) => i.id === 'pro');
+    expect(pro.parentPlanName).toBe('Starter');
+    expect(pro.inheritsFrom).toBe('starter');
+  });
+
+  it('yields parentPlanName null when inheritsFrom points to a non-existent plan id', async () => {
+    wrapper = mountPricing();
+    await flushPromises();
+    const ghost = wrapper.vm.resolvedPlanItems.find((i) => i.id === 'ghost');
+    expect(ghost.parentPlanName).toBeNull();
+    // inheritsFrom is still forwarded verbatim (informational) even when unresolved.
+    expect(ghost.inheritsFrom).toBe('does-not-exist');
+  });
+
+  it('yields parentPlanName null and inheritsFrom null when the plan has no inheritsFrom', async () => {
+    wrapper = mountPricing();
+    await flushPromises();
+    const starter = wrapper.vm.resolvedPlanItems.find((i) => i.id === 'starter');
+    expect(starter.parentPlanName).toBeNull();
+    expect(starter.inheritsFrom).toBeNull();
+  });
+
+  it('forwards the sections array verbatim from static-content through resolvedPlanItems', async () => {
+    wrapper = mountPricing();
+    await flushPromises();
+    const pro = wrapper.vm.resolvedPlanItems.find((i) => i.id === 'pro');
+    expect(pro.sections).toEqual([
+      { items: [{ text: 'Unlimited projects' }] },
+      { title: 'Pro only', items: [{ text: 'Advanced analytics' }] },
+    ]);
+    // A plan without sections resolves to null (not undefined), matching the card contract.
+    const starter = wrapper.vm.resolvedPlanItems.find((i) => i.id === 'starter');
+    expect(starter.sections).toBeNull();
+  });
+});

--- a/src/modules/billing/tests/billing.pricingFeatureSection.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingFeatureSection.component.unit.tests.js
@@ -134,6 +134,30 @@ describe('BillingPricingFeatureSectionComponent', () => {
     expect(icon.attributes('style') || '').toMatch(/#ff6b6b/i);
   });
 
+  it('uses item.color as a back-compat alias when iconColor is absent', () => {
+    const wrapper = mount(BillingPricingFeatureSectionComponent, {
+      props: {
+        section: { title: null, items: [{ text: 'A', color: 'success' }] },
+        parentPlanName: null,
+      },
+      global: { plugins: [vuetify] },
+    });
+    // `color` (the flat-features key) is honored when `iconColor` is absent —
+    // eases a flat→grouped migration that kept its `color` keys.
+    expect(wrapper.find('.v-icon').classes()).toContain('text-success');
+  });
+
+  it('prefers iconColor over color when both are present', () => {
+    const wrapper = mount(BillingPricingFeatureSectionComponent, {
+      props: {
+        section: { title: null, items: [{ text: 'A', iconColor: 'success', color: 'error' }] },
+        parentPlanName: null,
+      },
+      global: { plugins: [vuetify] },
+    });
+    expect(wrapper.find('.v-icon').classes()).toContain('text-success');
+  });
+
   it('falls back to primary color when iconColor is absent', () => {
     const wrapper = mount(BillingPricingFeatureSectionComponent, {
       props: {

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -320,6 +320,14 @@ export default {
           ? { text: `Save ${annualSavingsPct}%`, color: 'success' }
           : null;
 
+        // Grouped feature sections (additive, optional). When a plan declares `sections`,
+        // the card renders them instead of the flat `features` list. `inheritsFrom` is the
+        // parent plan id; resolve it to a display name HERE (the card stays dumb) so the card
+        // can render a single "Everything in {parentPlanName}, plus" heading.
+        const parentPlanName = plan.inheritsFrom
+          ? (this.plans.find((p) => p.id === plan.inheritsFrom)?.title ?? null)
+          : null;
+
         return {
           id: plan.id,
           title: plan.title,
@@ -335,6 +343,9 @@ export default {
           },
           info: plan.info || null,
           features: plan.features || [],
+          sections: plan.sections || null,
+          inheritsFrom: plan.inheritsFrom || null,
+          parentPlanName,
           badge: plan.badge || null,
           highlight: !!plan.highlight,
           // Internal field — view's onCtaClick resolves priceId from here, not consumed by card.


### PR DESCRIPTION
## What
Wire the existing-but-orphaned generic `BillingPricingFeatureSectionComponent` into `billing.card.component.vue`. A pricing card now renders **grouped, inheritance-aware feature sections** when a plan carries an optional `sections[]` array (with a single plan-level "Everything in {parent}, plus" heading), and **falls back to the existing flat `features[]` list** when no sections are given.

## Why
The card previously only rendered a flat feature list. The grouping component already existed in the module but had zero consumers. This makes grouped + tiered pricing cards available to any downstream that wants them, with no change for those that don't.

## Shape (additive, backward-compatible)
- New optional plan fields: `sections: [{ title?, introText?, items: [{ text, icon?, iconColor?, tooltip?, highlight?, enabled? }] }]` and `inheritsFrom` (parent plan id).
- The view's `resolvedPlanItems` passes `sections`/`inheritsFrom` through and resolves `parentPlanName` from the sibling plan; the card stays dumb and owns the plan-level heading (does not forward `parentPlanName` to sections, so a section can't emit a duplicate heading).
- `BillingPricingFeatureSectionComponent` now accepts `color` as a back-compat alias for `iconColor` (eases a flat→grouped migration). `iconColor` keeps precedence.
- A consumer providing only flat `features[]` renders byte-identically to before.

## Tests
- New `billing.card.component.unit.tests.js`: grouped-sections path, flat fallback, empty `sections: []` → flat, missing/unresolved parent (no crash, no heading).
- `billing.pricing.view.unit.tests.js`: `parentPlanName` resolution (existing / non-existent / absent `inheritsFrom`) + verbatim `sections` passthrough.
- `billing.pricingFeatureSection`: `color` alias + `iconColor` precedence.
- Full suite green (144 files / 2437 tests), lint clean.

## Note
`billing.static-content.js` gains documentation-only JSDoc for the `sections` schema — the existing demo plans are untouched so default fallback content renders identically. The section component retains its standalone `inheritsFrom`/`parentPlanName` path (now unused by the card) for direct reuse; a possible follow-up is to prune it if no standalone consumer appears.

Closes #4381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing cards can now display grouped feature sections for plans, with a clear “Everything in {parent plan}, plus” header when a plan builds on another.
  * Feature icons now support a broader range of color settings for more consistent plan highlighting.

* **Bug Fixes**
  * Improved pricing display behavior so grouped sections and legacy flat feature lists render correctly in the right scenarios.
  * Refined billing pricing coverage to better verify plan inheritance and feature display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->