### PR TITLE
style(billing): strengthen pricing section-title hierarchy

### DIFF
--- a/src/modules/billing/components/billing.pricingFeatureSection.component.vue
+++ b/src/modules/billing/components/billing.pricingFeatureSection.component.vue
@@ -20,7 +20,7 @@
   <div class="billing-pricing-feature-section">
     <h4
       v-if="section.title"
-      class="billing-pricing-feature-section__title text-title-small font-weight-medium mb-2"
+      class="billing-pricing-feature-section__title text-body-large font-weight-bold mb-2"
     >
       {{ section.title }}
     </h4>
@@ -106,6 +106,12 @@ export default {
 </script>
 
 <style scoped>
+/* Separate stacked sections so each category title reads as a group label,
+   not as another feature row. Uniform top margin gives the card vertical rhythm;
+   the first section sits below the price/CTA/heading so the extra space reads clean. */
+.billing-pricing-feature-section {
+  margin-top: 1.25rem;
+}
 /* Allow feature/pack item text to wrap — Vuetify default v-list-item-title
    has white-space: nowrap + text-overflow: ellipsis which truncates substantive
    descriptions like "Stacks on top of subscription quota" into "… q…". */


### PR DESCRIPTION
## What
Strengthen the visual hierarchy of category section titles on grouped pricing cards (`billing.pricingFeatureSection.component.vue`).

## Why
The section title (`text-title-small`, medium weight) rendered *smaller and lighter* than the feature items beneath it, and sat tight against the previous section, so a group label read like just another feature row. Inverted hierarchy.

## Change
- Title → `text-body-large font-weight-bold` (a real group-label weight/size, at least as prominent as its items).
- Add a top margin on the section root so stacked sections separate cleanly and gain vertical rhythm.

Generic, applies to any downstream using grouped pricing cards. No API/schema change; existing consumers get the improved styling for free.

## Tests
Full suite green (144 files / 2437 tests), lint clean. (Styling-only; no behavioural change.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of optional section titles in billing feature sections for a clearer, more prominent look.
  * Added consistent vertical spacing between stacked billing feature sections to improve layout readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->