### PR TITLE
feat(billing): pricing feature rows wrap + explicit ✗ not-included marker

### DIFF
--- a/src/modules/billing/components/billing.pricingFeatureSection.component.vue
+++ b/src/modules/billing/components/billing.pricingFeatureSection.component.vue
@@ -48,6 +48,8 @@
         :class="{ 'text-medium-emphasis': item.enabled === false }"
         size="small"
         class="mt-1"
+        role="img"
+        :aria-label="item.enabled === false ? 'Not included' : 'Included'"
       ></v-icon>
       <span
         :class="[
@@ -63,6 +65,10 @@
               icon="fa-solid fa-circle-info"
               size="x-small"
               class="ml-1 text-medium-emphasis"
+              tabindex="0"
+              role="img"
+              :aria-label="item.tooltip"
+              style="cursor: help"
             ></v-icon>
           </template>
         </v-tooltip>

--- a/src/modules/billing/components/billing.pricingFeatureSection.component.vue
+++ b/src/modules/billing/components/billing.pricingFeatureSection.component.vue
@@ -5,68 +5,69 @@
 
   - Optional title (e.g. "Core", "Collaboration")
   - Optional "Everything in {parent}, plus" heading when section.inheritsFrom is set
-  - Bulleted list of items with optional icon, tooltip, and highlight flag
+    (or a project-owned introText override)
+  - Feature rows: icon + wrapping label, with optional tooltip, highlight, disabled
+
+  Full Vuetify: components + utility classes only, no scoped CSS. Rows use a
+  d-flex layout with a plain <span> so long labels wrap naturally (v-list-item-title
+  forces nowrap + ellipsis, which would truncate substantive descriptions).
 
   USAGE:
   <BillingPricingFeatureSectionComponent
-    :section="{ title, inheritsFrom, items: [{ text, icon, tooltip, highlight }] }"
+    :section="{ title, inheritsFrom, introText, items: [{ text, icon, iconColor, tooltip, highlight, enabled }] }"
     :parent-plan-name="'Starter'" />
 
   PROPS:
-  - section          (Object, required): { title?: string, inheritsFrom?: string, items: [...] }
-  - parentPlanName   (String, optional): Display name of the parent plan, used to render "Everything in {name}, plus"
+  - section          (Object, required): { title?, inheritsFrom?, introText?, items: [...] }
+  - parentPlanName   (String, optional): parent plan display name for "Everything in {name}, plus"
 -->
 <template>
-  <div class="billing-pricing-feature-section">
+  <div class="mt-3">
     <h4
       v-if="section.title"
-      class="billing-pricing-feature-section__title text-body-large font-weight-bold mb-2"
+      class="text-body-large font-weight-bold mb-2"
     >
       {{ section.title }}
     </h4>
     <p
       v-else-if="resolvedHeading"
-      class="billing-pricing-feature-section__inherits text-body-small text-medium-emphasis mb-2"
+      class="text-body-small text-medium-emphasis mb-2"
     >
       {{ resolvedHeading }}
     </p>
 
-    <v-list density="compact" bg-color="transparent" class="pa-0">
-      <v-list-item
-        v-for="(item, idx) in section.items"
-        :key="`${item.text}-${idx}`"
+    <div
+      v-for="(item, idx) in section.items"
+      :key="`${item.text}-${idx}`"
+      class="d-flex align-start ga-3 mb-2"
+    >
+      <v-icon
+        v-if="!item.highlight"
+        :icon="item.enabled === false ? 'fa-solid fa-xmark' : (item.icon || 'fa-solid fa-check')"
+        :color="item.enabled === false ? undefined : (item.iconColor || item.color || 'primary')"
+        :class="{ 'text-medium-emphasis': item.enabled === false }"
+        size="small"
+        class="mt-1"
+      ></v-icon>
+      <span
         :class="[
-          'px-0',
-          {
-            'billing-pricing-feature-section__item--highlight': item.highlight,
-            'billing-pricing-feature-section__item--disabled': item.enabled === false,
-          },
+          item.highlight ? 'text-body-1 font-weight-bold text-primary' : 'text-body-2',
+          { 'text-medium-emphasis': item.enabled === false },
         ]"
       >
-        <template #prepend>
-          <v-icon
-            :icon="item.icon || 'fa-solid fa-check'"
-            :color="item.enabled === false ? undefined : (item.iconColor || item.color || 'primary')"
-            :class="{ 'text-disabled': item.enabled === false }"
-            size="small"
-            class="mr-3"
-          ></v-icon>
-        </template>
-        <v-list-item-title :class="{ 'text-disabled': item.enabled === false, 'font-weight-semibold': item.highlight }">
-          <span>{{ item.text }}</span>
-          <v-tooltip v-if="item.tooltip" :text="item.tooltip" location="top">
-            <template #activator="{ props: tooltipProps }">
-              <v-icon
-                v-bind="tooltipProps"
-                icon="fa-solid fa-circle-info"
-                size="x-small"
-                class="ml-2 text-medium-emphasis"
-              ></v-icon>
-            </template>
-          </v-tooltip>
-        </v-list-item-title>
-      </v-list-item>
-    </v-list>
+        {{ item.text }}
+        <v-tooltip v-if="item.tooltip" :text="item.tooltip" location="top">
+          <template #activator="{ props: tooltipProps }">
+            <v-icon
+              v-bind="tooltipProps"
+              icon="fa-solid fa-circle-info"
+              size="x-small"
+              class="ml-1 text-medium-emphasis"
+            ></v-icon>
+          </template>
+        </v-tooltip>
+      </span>
+    </div>
   </div>
 </template>
 
@@ -104,21 +105,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-/* Separate stacked sections so each category title reads as a group label,
-   not as another feature row. Uniform top margin gives the card vertical rhythm;
-   the first section sits below the price/CTA/heading so the extra space reads clean. */
-.billing-pricing-feature-section {
-  margin-top: 1.25rem;
-}
-/* Allow feature/pack item text to wrap — Vuetify default v-list-item-title
-   has white-space: nowrap + text-overflow: ellipsis which truncates substantive
-   descriptions like "Stacks on top of subscription quota" into "… q…". */
-.billing-pricing-feature-section :deep(.v-list-item-title) {
-  white-space: normal;
-  overflow: visible;
-  text-overflow: clip;
-  line-height: 1.4;
-}
-</style>

--- a/src/modules/billing/components/billing.pricingFeatureSection.component.vue
+++ b/src/modules/billing/components/billing.pricingFeatureSection.component.vue
@@ -48,8 +48,7 @@
         :class="{ 'text-medium-emphasis': item.enabled === false }"
         size="small"
         class="mt-1"
-        role="img"
-        :aria-label="item.enabled === false ? 'Not included' : 'Included'"
+        aria-hidden="true"
       ></v-icon>
       <span
         :class="[
@@ -57,6 +56,10 @@
           { 'text-medium-emphasis': item.enabled === false },
         ]"
       >
+        <!-- The ✓/✗ icon is decorative (aria-hidden); this sr-only text carries the
+             included / not-included distinction to assistive tech. Skipped for
+             headline (highlight) rows, which have no inclusion semantics. -->
+        <span v-if="!item.highlight" class="sr-only">{{ item.enabled === false ? 'Not included: ' : 'Included: ' }}</span>
         {{ item.text }}
         <v-tooltip v-if="item.tooltip" :text="item.tooltip" location="top">
           <template #activator="{ props: tooltipProps }">
@@ -111,3 +114,20 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+/* Screen-reader-only text — announces the included / not-included state that the
+   ✓ / ✗ icon conveys visually (the icon is aria-hidden / decorative). Vuetify
+   4.x ships no sr-only utility, so the standard clip pattern is defined locally. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/src/modules/billing/tests/billing.pricingFeatureSection.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingFeatureSection.component.unit.tests.js
@@ -208,7 +208,7 @@ describe('BillingPricingFeatureSectionComponent', () => {
     expect(wrapper.find('.text-medium-emphasis').exists()).toBe(false);
   });
 
-  it('announces included / not-included state to assistive tech (icon is not decorative here)', () => {
+  it('announces included / not-included state via sr-only text; ✓/✗ icon stays decorative', () => {
     const wrapper = mount(BillingPricingFeatureSectionComponent, {
       props: {
         section: {
@@ -222,9 +222,12 @@ describe('BillingPricingFeatureSectionComponent', () => {
       },
       global: { plugins: [vuetify] },
     });
-    const labels = wrapper.findAll('.v-icon[role="img"]').map((i) => i.attributes('aria-label'));
-    expect(labels).toContain('Included');
-    expect(labels).toContain('Not included');
+    const srTexts = wrapper.findAll('.sr-only').map((s) => s.text().trim());
+    expect(srTexts).toContain('Included:');
+    expect(srTexts).toContain('Not included:');
+    // The state icon is decorative — hidden from assistive tech (Vuetify would
+    // aria-hidden a non-interactive icon anyway; we set it explicitly).
+    expect(wrapper.find('.v-icon').attributes('aria-hidden')).toBe('true');
   });
 
   it('makes the tooltip trigger keyboard-focusable with an accessible label', () => {

--- a/src/modules/billing/tests/billing.pricingFeatureSection.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingFeatureSection.component.unit.tests.js
@@ -207,4 +207,36 @@ describe('BillingPricingFeatureSectionComponent', () => {
     expect(wrapper.html()).not.toContain('fa-xmark');
     expect(wrapper.find('.text-medium-emphasis').exists()).toBe(false);
   });
+
+  it('announces included / not-included state to assistive tech (icon is not decorative here)', () => {
+    const wrapper = mount(BillingPricingFeatureSectionComponent, {
+      props: {
+        section: {
+          title: null,
+          items: [
+            { text: 'Included feature', enabled: true },
+            { text: 'Missing feature', enabled: false },
+          ],
+        },
+        parentPlanName: null,
+      },
+      global: { plugins: [vuetify] },
+    });
+    const labels = wrapper.findAll('.v-icon[role="img"]').map((i) => i.attributes('aria-label'));
+    expect(labels).toContain('Included');
+    expect(labels).toContain('Not included');
+  });
+
+  it('makes the tooltip trigger keyboard-focusable with an accessible label', () => {
+    const wrapper = mount(BillingPricingFeatureSectionComponent, {
+      props: {
+        section: { title: null, items: [{ text: 'A', tooltip: 'Extra detail' }] },
+        parentPlanName: null,
+      },
+      global: { plugins: [vuetify] },
+    });
+    const trigger = wrapper.findAll('.v-icon').find((i) => i.attributes('aria-label') === 'Extra detail');
+    expect(trigger).toBeTruthy();
+    expect(trigger.attributes('tabindex')).toBe('0');
+  });
 });

--- a/src/modules/billing/tests/billing.pricingFeatureSection.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricingFeatureSection.component.unit.tests.js
@@ -28,7 +28,7 @@ describe('BillingPricingFeatureSectionComponent', () => {
       },
       global: { plugins: [vuetify] },
     });
-    expect(wrapper.find('.billing-pricing-feature-section__title').exists()).toBe(false);
+    expect(wrapper.find('h4').exists()).toBe(false);
   });
 
   it('renders inheritsFrom heading when section has inheritsFrom and parentPlanName is provided', () => {
@@ -88,7 +88,7 @@ describe('BillingPricingFeatureSectionComponent', () => {
     expect(wrapper.findAll('.v-icon')).toHaveLength(2);
   });
 
-  it('applies highlight class to items flagged highlight=true', () => {
+  it('renders highlight rows as bold primary text with no leading icon', () => {
     const wrapper = mount(BillingPricingFeatureSectionComponent, {
       props: {
         section: {
@@ -102,9 +102,12 @@ describe('BillingPricingFeatureSectionComponent', () => {
       },
       global: { plugins: [vuetify] },
     });
-    const highlighted = wrapper.findAll('.billing-pricing-feature-section__item--highlight');
-    expect(highlighted).toHaveLength(1);
-    expect(highlighted[0].text()).toContain('Highlighted');
+    const highlighted = wrapper.find('.font-weight-bold');
+    expect(highlighted.exists()).toBe(true);
+    expect(highlighted.text()).toContain('Highlighted');
+    expect(highlighted.classes()).toContain('text-primary');
+    // Highlight rows are iconless — only the single normal row renders a check icon.
+    expect(wrapper.findAll('.v-icon')).toHaveLength(1);
   });
 
   it('applies iconColor when provided (Vuetify color name)', () => {
@@ -169,7 +172,7 @@ describe('BillingPricingFeatureSectionComponent', () => {
     expect(wrapper.find('.v-icon').classes()).toContain('text-primary');
   });
 
-  it('applies disabled class to items with enabled=false', () => {
+  it('renders enabled=false rows with an ✗ (xmark) icon and dimmed text', () => {
     const wrapper = mount(BillingPricingFeatureSectionComponent, {
       props: {
         section: {
@@ -183,12 +186,14 @@ describe('BillingPricingFeatureSectionComponent', () => {
       },
       global: { plugins: [vuetify] },
     });
-    const disabled = wrapper.findAll('.billing-pricing-feature-section__item--disabled');
-    expect(disabled).toHaveLength(1);
-    expect(disabled[0].text()).toContain('Disabled feature');
+    // enabled:false swaps the check for an explicit not-included ✗ marker.
+    expect(wrapper.html()).toContain('fa-xmark');
+    // ...and dims the label so the row reads as "not in this plan".
+    const dimmed = wrapper.findAll('.text-medium-emphasis').filter((el) => el.text().includes('Disabled feature'));
+    expect(dimmed.length).toBeGreaterThan(0);
   });
 
-  it('treats absent enabled as enabled (default true)', () => {
+  it('treats absent enabled as enabled — no xmark, no dimming', () => {
     const wrapper = mount(BillingPricingFeatureSectionComponent, {
       props: {
         section: {
@@ -199,6 +204,7 @@ describe('BillingPricingFeatureSectionComponent', () => {
       },
       global: { plugins: [vuetify] },
     });
-    expect(wrapper.find('.billing-pricing-feature-section__item--disabled').exists()).toBe(false);
+    expect(wrapper.html()).not.toContain('fa-xmark');
+    expect(wrapper.find('.text-medium-emphasis').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Presentational refactor of `BillingPricingFeatureSectionComponent` (generic devkit pricing card section), for pricing cards that render a **full comparable feature list** (all features per plan, included ✓ / not-included ✗).

- **Wrap long labels.** Feature rows switch from `v-list` / `v-list-item` / `v-list-item-title` to a `d-flex` row + a plain `<span>`. `v-list-item-title` forces `white-space: nowrap` + ellipsis, which truncated substantive descriptions (e.g. `"Stacks on top of subscription quota"` → `"… q…"`). A plain span wraps naturally, so the `:deep(.v-list-item-title)` scoped-CSS hack that patched this is removed.
- **Explicit not-included marker.** `enabled: false` rows now render a `fa-solid fa-xmark` (✗) with dimmed text instead of a dimmed check — so excluded features read clearly as "not in this plan" in a full comparable list (icon carries the affordance, not opacity alone).
- **Iconless headline rows.** `highlight: true` rows render bold primary text with no leading icon (unchanged intent, cleaner markup).
- **Scoped CSS dropped** in favour of Vuetify utility classes.

## Invariant

Presentation-only — no change to which features/props a plan declares, no change to `resolvedHeading` / `introText` / `inheritsFrom` priority logic. Backward-compatible: sections without `enabled` render exactly as before (check icon, no dimming).

## Tests

Unit tests updated to assert the new DOM (xmark path, iconless bold highlight rows, wrapping span). Full suite green (2437), lint clean.

## Note for reviewers

Section top spacing moves from a scoped `1.25rem` to `mt-3` (0.75rem) — deliberate, since a full comparable list stacks more sections per card. Flagged for visual eyeball; trivially bumpable if it reads cramped downstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the billing pricing feature list to use a simpler row-based layout and cleaner utility styling.
  * Adjusted the heading and feature rows for more consistent spacing, wrapping, and icon presentation.

* **Bug Fixes**
  * Improved the display of enabled, disabled, and highlighted features with clearer icons and text emphasis.
  * Tooltips continue to appear alongside feature labels where available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->