### PR TITLE
docs(ui): beauty pass — encodable craft rules + config re-skin levers

### DIFF
--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -15,7 +15,7 @@ Design system reference and visual quality guidelines for the Devkit Vue stack.
 
 Invoke `/ui` directly only for pure design tasks (restyle, theme change, layout fix) that don't need the full `/feature` workflow.
 
-This skill is an **enforcer**, not a creative brief. Its job is to keep visual work within the stack's design system (Vuetify 4 + MD3 + theme helpers). Creative direction for net-new identity work (landings, brand, bold aesthetic stances) belongs outside this skill.
+This skill is an **enforcer** of the design system (Vuetify 4 + MD3 + theme helpers) **and a craft baseline** — the "Beauty pass" below is teachable, encodable craft (not taste-by-vibes), the difference between *correct* and *beautiful*. Net-new brand identity (a bold landing aesthetic, a new visual language) still belongs to creative direction outside this skill; the Beauty pass makes the everyday output stop looking generic.
 
 ## References
 
@@ -36,6 +36,20 @@ This skill is an **enforcer**, not a creative brief. Its job is to keep visual w
 - **Reuse**: Check existing components before creating new ones
 - **Verify**: Screenshot desktop+mobile, light+dark after visual changes
 
+## Beauty pass (correct → beautiful)
+
+Consistency + accessibility make a UI *correct*; these seven rules make it *beautiful*. Each is a checkable rule with a named failure mode — the inverse of each is exactly what makes a layout read as generic. Apply on every visual surface; they need **no bespoke CSS** (Vuetify props, spacing classes, elevation, and theme tokens carry all seven). Deeper config levers to push past the generic Material look: `references/design-system.md` § "Beauty levers".
+
+1. **Whitespace first, then reduce.** Start generous, don't fill the viewport; cramped padding is the #1 generic tell. Lean on `pa-6`/`pa-8`, section `py-12`+. Context-calibrate: dense dashboards tighten, but never start cramped.
+2. **Hierarchy by weight + color, not size alone.** Cap ~3 type sizes per view; de-emphasize secondary/tertiary with a lighter `text-medium-emphasis` / muted color, not just smaller. Size-only hierarchy is a slop signature.
+3. **Spacing on the fixed scale only.** Use the spacing classes (steps `0`→`16` = 4→64px); never an arbitrary inline `margin: 13px`. Off-scale spacing reads ad-hoc.
+4. **Color reserved for emphasis.** Mostly-neutral base (tinted greys via `surface`/`background`, not pure grey); `primary` for the ONE action that matters, not spread across the screen. Even color spread = the default-Material generic look. Never grey text on a colored background.
+5. **Depth = soft, two-part elevation.** Prefer low `elevation-1`/`elevation-2` (Vuetify's shadows are already the layered contact+ambient pair) or `elevation-0` + a subtle `surface` border; overlap elements to layer. One harsh high-contrast shadow reads cheap.
+6. **Proximity groups related items** (Gestalt). A field label sits tight to its input; a card's title/body/action cluster with less gap inside than between cards. Uniform spacing everywhere destroys grouping.
+7. **Restraint over decoration.** Fewer weights, one accent, generous rhythm — boring-and-consistent beats clever-and-busy. Delete an element before adding one.
+
+> These seven rules are the canonical craft baseline: name the visual intent when planning a surface, apply the rules while building, and score the rendered result against them in QA. This skill is where they're authored.
+
 ## Anti-patterns
 
 - `text-h1`..`text-h6` → use MD3: `text-display-large`, `text-headline-medium`
@@ -44,3 +58,4 @@ This skill is an **enforcer**, not a creative brief. Its job is to keep visual w
 - Ignoring dark mode
 - Skipping visual verification
 - Custom CSS when a Vuetify prop/class/transition covers the need
+- **Generic-look tells** (Beauty pass inverses): cramped padding · hierarchy by size alone · color spread evenly instead of reserved for emphasis · one harsh shadow · arbitrary off-scale spacing · pure untinted greys · grey text on colored backgrounds

--- a/.claude/skills/ui/references/design-system.md
+++ b/.claude/skills/ui/references/design-system.md
@@ -170,6 +170,29 @@ Stack uses **FontAwesome** (`defaultSet: 'fa'`).
 <v-icon>fa-brands fa-github</v-icon>
 ```
 
+## Beauty levers (config-only re-skin — push past generic Material)
+
+Vuetify components are **white-label by default** — the Material look is a starting point, not a constraint. Four levers re-skin the whole app with **zero bespoke per-element CSS**; reach for them in order:
+
+1. **Theme palette (biggest lever).** `config.vuetify.theme.themes.{light,dark}.colors` — author a distinctive, mostly-neutral palette: tinted-grey `background`/`surface` (a few degrees of hue, never pure `#888`), one confident `primary` reserved for emphasis, restrained accents. Every token is exposed as `--v-theme-{name}` RGB-triples, so re-tinting is config, not CSS. Author colors in a perceptual space (OKLCH in 2025-26, or HSL — never hand-pick raw hex) so shades stay even.
+2. **Shape.** `config.vuetify.theme.rounded` (`rounded` sharp → `rounded-lg` → `rounded-xl`) sets the app's roundness personality in one value. Sharp reads editorial/serious; pill reads friendly/consumer.
+3. **Density + elevation strategy.** `density` on components (`comfortable`/`compact`) tunes the whitespace rhythm globally; pick a low, consistent elevation ceiling (mostly `elevation-1`/`2`, or `flat: true` + subtle borders) rather than mixing high shadows — consistency of depth is what reads premium.
+4. **Global SASS variables (deepest, still no per-element CSS).** Override Vuetify's own settings once in a `settings.scss` registered via `vite-plugin-vuetify`:
+   ```js
+   // vite.config — plugin registration
+   vuetify({ styles: { configFile: 'src/styles/settings.scss' } })
+   ```
+   ```scss
+   // src/styles/settings.scss — override globals before Vuetify builds
+   @use 'vuetify/settings' with (
+     $body-font-family: ('Inter', sans-serif),
+     $border-radius-root: 6px,       // default 4px — nudge the app's roundness
+   );
+   ```
+   This shifts font, base radius, and the spacing unit app-wide from one file. **Blueprints** (`createVuetify({ blueprint })`) go further for a full re-skin. Both are config, not scattered `<style>` blocks — keep the "CSS last resort" rule intact.
+
+Pick the aesthetic direction up front (the surface's stated visual intent), then reach for lever 1→4 to carry it. Most distinctiveness is won by levers 1-3 alone.
+
 ## Config-driven theming
 
 The stack's theme is fully config-driven. Key config paths:

--- a/.claude/skills/ui/references/design-system.md
+++ b/.claude/skills/ui/references/design-system.md
@@ -182,14 +182,18 @@ Vuetify components are **white-label by default** — the Material look is a sta
    // vite.config — plugin registration
    vuetify({ styles: { configFile: 'src/styles/settings.scss' } })
    ```
+
    ```scss
-   // src/styles/settings.scss — override globals before Vuetify builds
-   @use 'vuetify/settings' with (
+   // src/styles/settings.scss — override globals before Vuetify builds.
+   // Use @forward (not @use) in a configFile: it re-exports vuetify/settings
+   // WITH your overrides so the framework's own SASS picks them up.
+   @forward 'vuetify/settings' with (
      $body-font-family: ('Inter', sans-serif),
      $border-radius-root: 6px,       // default 4px — nudge the app's roundness
    );
    ```
-   This shifts font, base radius, and the spacing unit app-wide from one file. **Blueprints** (`createVuetify({ blueprint })`) go further for a full re-skin. Both are config, not scattered `<style>` blocks — keep the "CSS last resort" rule intact.
+
+   This shifts font and base radius app-wide from one file. **Blueprints** (`createVuetify({ blueprint })`) go further for a full re-skin. Both are config, not scattered `<style>` blocks — keep the "CSS last resort" rule intact.
 
 Pick the aesthetic direction up front (the surface's stated visual intent), then reach for lever 1→4 to carry it. Most distinctiveness is won by levers 1-3 alone.
 


### PR DESCRIPTION
## What

The `/ui` skill enforced consistency + accessibility (making output *correct*) but had no polish rules, so generated UIs read generic. This adds the missing craft layer.

- **SKILL.md** — a "Beauty pass": 7 checkable craft rules (whitespace-first, hierarchy by weight+color not size, fixed spacing scale, color-for-emphasis, soft two-part elevation, Gestalt proximity, restraint), each paired with its named generic-look failure mode. Zero bespoke CSS — Vuetify props/classes/tokens carry all seven.
- **references/design-system.md** — config-only re-skin levers (theme palette, shape, density + elevation, global SASS `settings.scss`) to push past the white-label Material default.

Doc-only, sourced from Refactoring UI + NN/g + Radix Colors.

Closes #4402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the UI design guidance with a clearer “beauty pass” standard, including practical checks for spacing, hierarchy, color use, depth, grouping, and restraint.
  * Added a set of global visual tuning options for adjusting theme colors, rounding, density, elevation, and overall styling consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->