### PR TITLE
fix(billing): meter-mode upgrade prompt copy + single-entry route

### DIFF
--- a/src/modules/billing/components/billing.upgradePrompt.component.vue
+++ b/src/modules/billing/components/billing.upgradePrompt.component.vue
@@ -14,7 +14,7 @@
             variant="flat"
             size="small"
             class="text-none"
-            @click="$emit('buy-pack')"
+            to="/pricing#units"
           >
             Buy Boost pack — $9
           </v-btn>
@@ -36,6 +36,7 @@
   <v-alert v-else type="info" variant="tonal" prominent class="my-4">
     <template #text>
       <span v-if="hasUsageInfo">{{ `You've used ${current} of ${limit} ${displayLabel}.` }}</span>
+      <span v-else-if="mode === 'meter'">You're out of compute. Buy more units or upgrade for monthly compute.</span>
       <span v-else>{{ `This feature requires the ${requiredPlan} plan.` }}</span>
     </template>
     <template #append>
@@ -45,7 +46,7 @@
         variant="flat"
         size="small"
         class="text-none"
-        @click="$emit('buy-pack')"
+        to="/pricing#units"
       >
         Buy units
       </v-btn>
@@ -105,8 +106,8 @@ export default {
       default: '',
     },
     /**
-     * @desc Billing mode. Meter mode prompts users to buy unit packs instead of
-     * routing them to plan pricing.
+     * @desc Billing mode. Meter mode surfaces a "buy units" CTA that routes to the
+     * units section of the pricing page; subscription mode surfaces a plan-upgrade CTA.
      */
     mode: {
       type: String,
@@ -119,7 +120,6 @@ export default {
       validator: (value) => ['subscription', 'meter'].includes(value),
     },
   },
-  emits: ['buy-pack'],
   /**
    * @desc Wires useQuota composable and billing store for exhaustedAfterGrant detection.
    * @returns {{ usage: Object, limits: Object, billingStore: Object }}

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -140,6 +140,8 @@ describe('BillingUpgradePrompt', () => {
       const packBtn = wrapper.find('[data-test="cta-pack"]');
       expect(packBtn.exists()).toBe(true);
       expect(packBtn.text()).toMatch(/boost|pack/i);
+      // Post-grant Boost-pack CTA routes to the single billing entry point, not a modal event.
+      expect(wrapper.findComponent('[data-test="cta-pack"]').props('to')).toBe('/pricing#units');
     });
 
     it('renders secondary upgrade CTA in post-grant variant', () => {

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -75,15 +75,19 @@ describe('BillingUpgradePrompt', () => {
     expect(btn.props('to')).toBe('/pricing');
   });
 
-  it('emits buy-pack instead of linking to pricing in meter mode', async () => {
+  it('routes the Buy units CTA to /pricing#units in meter mode (single billing entry, no modal event)', () => {
     const wrapper = mountComponent({ requiredPlan: 'pro', mode: 'meter' });
     const btn = wrapper.findComponent({ name: 'v-btn' });
     expect(btn.exists()).toBe(true);
     expect(btn.text()).toContain('Buy units');
-    expect(btn.props('to')).toBeUndefined();
+    expect(btn.props('to')).toBe('/pricing#units');
+    expect(wrapper.emitted('buy-pack')).toBeUndefined();
+  });
 
-    await btn.trigger('click');
-    expect(wrapper.emitted('buy-pack')).toHaveLength(1);
+  it('shows out-of-compute copy in meter mode, never the plan-requirement text', () => {
+    const wrapper = mountComponent({ requiredPlan: 'Growth', mode: 'meter' });
+    expect(wrapper.text()).toContain('out of compute');
+    expect(wrapper.text()).not.toContain('requires the');
   });
 
   it('shows generic message when resource/action set but no quota data', () => {


### PR DESCRIPTION
## What
Fix `BillingUpgradePrompt` in meter mode.

## Changes
- Meter mode no longer falls back to the subscription-only "This feature requires the {plan} plan." copy when no usage info is passed (it showed plan-upsell text next to a meter "Buy units" button). Meter mode now shows a generic out-of-compute message; the plan-requirement text is reserved for subscription mode.
- The meter CTAs ("Buy units", "Buy Boost pack") routed nowhere — they emitted a bare `buy-pack` event, diverging from every sibling billing CTA. They now route to `/pricing#units` (the single billing entry point, matching `billing.subscriptions.component`). The undefined `buy-pack` emit is removed.
- Tests updated + added.

https://claude.ai/code/session_01S8zb8xNiyALVu366vzyi8x