### PR TITLE
fix(core,organizations): config-gate org-required header + unify first-org redirect

### DIFF
--- a/src/modules/app/config/app.development.config.js
+++ b/src/modules/app/config/app.development.config.js
@@ -18,6 +18,7 @@ export default {
         opacity: 0.5, // header background opacity (0–1)
         scrollBehavior: 'float', // 'float' = shrink to pill on scroll, 'hide' = hide on scroll
         scrollThreshold: 50, // scroll distance (px) before scroll behavior triggers
+        showOnOrgRequired: true, // false to hide the header on /organization-required for sidenav-only apps (that page hides the sidenav, so the header keeps some chrome by default)
       },
       navigation: {
         background: '#2c3e50', // navigation drawer background color (fallback when glass is false)

--- a/src/modules/core/components/core.header.component.vue
+++ b/src/modules/core/components/core.header.component.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app-bar
-    v-if="!isLoggedIn || $route.path === '/organization-required'"
+    v-if="!isLoggedIn || showOnOrgRequired"
     :style="headerStyle"
     :flat="config.vuetify.theme.flat"
     :scroll-behavior="isFloatMode ? undefined : config.vuetify.theme.header?.scrollBehavior"
@@ -150,6 +150,24 @@ export default {
     isLoggedIn() {
       const authStore = useAuthStore();
       return authStore.isLoggedIn;
+    },
+    /**
+     * @desc Whether to force-show the header on `/organization-required` for a
+     *       signed-in user who has no organization yet. The sidenav is hidden on
+     *       that page (it gates on `hasOrganization`), so by default the header is
+     *       shown there to keep some chrome. A sidenav-only consumer that hides the
+     *       header once signed in can opt out via
+     *       `config.vuetify.theme.header.showOnOrgRequired: false`, so the page no
+     *       longer falls back to the signed-out top-nav (the org-required view
+     *       carries its own sign-out escape). Default (undefined) preserves the
+     *       existing behavior.
+     * @returns {Boolean}
+     */
+    showOnOrgRequired() {
+      return (
+        this.$route.path === '/organization-required'
+        && this.config.vuetify.theme.header?.showOnOrgRequired !== false
+      );
     },
     /**
      * @desc Whether the header uses the 'float' scroll behavior mode.

--- a/src/modules/core/tests/core.header.component.unit.tests.js
+++ b/src/modules/core/tests/core.header.component.unit.tests.js
@@ -47,16 +47,20 @@ const makeConfig = () => ({
  * @desc Mount the header component with router + config globals.
  * @returns {import('@vue/test-utils').VueWrapper}
  */
-const mountHeader = () => {
+const mountHeader = (routePath = '/', headerExtra = {}) => {
   const vuetify = createVuetify({ components, directives });
   const push = vi.fn();
+  const config = makeConfig();
+  Object.assign(config.vuetify.theme.header, headerExtra);
   return mount(CoreHeaderComponent, {
     global: {
       plugins: [vuetify],
-      mocks: { $router: { push }, $route: { path: '/' } },
-      config: { globalProperties: { config: makeConfig() } },
+      mocks: { $router: { push }, $route: { path: routePath } },
+      config: { globalProperties: { config } },
       // VAppBar needs an injected layout (v-app); stub it so we can exercise the
-      // navigate() method in isolation without a full layout wrapper.
+      // navigate() method in isolation without a full layout wrapper. The stub
+      // still honours the element's v-if, so `find('header')` doubles as a
+      // "is the header shown?" probe.
       stubs: { 'v-app-bar': { template: '<header><slot /></header>' } },
     },
   });
@@ -65,10 +69,38 @@ const mountHeader = () => {
 describe('CoreHeaderComponent', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    authStoreState.isLoggedIn = false; // default logged-out; org-required tests opt in
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  // #4421 — the header force-shows on /organization-required (the sidenav is
+  // hidden there) unless a sidenav-only consumer opts out via config.
+  describe('org-required header visibility (#4421)', () => {
+    it('shows the header on /organization-required by default (signed-in, no org)', () => {
+      authStoreState.isLoggedIn = true;
+      const wrapper = mountHeader('/organization-required');
+      expect(wrapper.find('header').exists()).toBe(true);
+    });
+
+    it('hides it there when the consumer opts out (showOnOrgRequired: false)', () => {
+      authStoreState.isLoggedIn = true;
+      const wrapper = mountHeader('/organization-required', { showOnOrgRequired: false });
+      expect(wrapper.find('header').exists()).toBe(false);
+    });
+
+    it('keeps the header hidden on ordinary signed-in routes', () => {
+      authStoreState.isLoggedIn = true;
+      const wrapper = mountHeader('/tasks');
+      expect(wrapper.find('header').exists()).toBe(false);
+    });
+
+    it('still shows the public header when signed out', () => {
+      const wrapper = mountHeader('/tasks');
+      expect(wrapper.find('header').exists()).toBe(true);
+    });
   });
 
   describe('navigate', () => {

--- a/src/modules/organizations/tests/organization.create.view.unit.tests.js
+++ b/src/modules/organizations/tests/organization.create.view.unit.tests.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+
+const refreshAbilitiesMock = vi.hoisted(() => vi.fn().mockResolvedValue());
+const createOrganizationMock = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'org-9' }));
+const authStoreMock = vi.hoisted(() => ({ user: null, refreshAbilities: refreshAbilitiesMock }));
+
+vi.mock('../../auth/stores/auth.store', () => ({
+  useAuthStore: () => authStoreMock,
+}));
+vi.mock('../stores/organizations.store', () => ({
+  useOrganizationsStore: () => ({ createOrganization: createOrganizationMock }),
+}));
+
+import OrganizationCreateView from '../views/organization.create.view.vue';
+
+const mockConfig = {
+  sign: { route: '/tasks' },
+  vuetify: { theme: { flat: true, rounded: 'rounded-lg' } },
+};
+
+const push = vi.fn();
+
+/**
+ * Mount the create view. VForm is stubbed so `$refs.form.validate()` resolves
+ * valid without wiring the full Vuetify validation lifecycle.
+ * @returns {import('@vue/test-utils').VueWrapper} mounted wrapper
+ */
+const mountView = () =>
+  mount(OrganizationCreateView, {
+    global: {
+      plugins: [createVuetify()],
+      mocks: { config: mockConfig, $router: { push } },
+      stubs: {
+        PageHeader: true,
+        VForm: {
+          template: '<form><slot /></form>',
+          methods: { validate: () => Promise.resolve({ valid: true }) },
+        },
+      },
+    },
+  });
+
+// #4422 — the standalone create view is reached both from the org-required wall
+// (first org) and from management (additional org). A first-org creator should
+// land in the app (sign.route) like signup; an additional org keeps -> detail.
+describe('organization.create.view — first-org redirect (#4422)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    push.mockReset();
+    refreshAbilitiesMock.mockReset().mockResolvedValue();
+    createOrganizationMock.mockReset().mockResolvedValue({ id: 'org-9' });
+    authStoreMock.user = null;
+  });
+
+  it('sends a first-org creator into the app via sign.route', async () => {
+    authStoreMock.user = { id: 'u1' }; // no currentOrganization → first org
+    const wrapper = mountView();
+    wrapper.vm.name = 'Acme';
+    await wrapper.vm.create();
+    await flushPromises();
+    expect(createOrganizationMock).toHaveBeenCalledWith({ name: 'Acme', description: '' });
+    expect(refreshAbilitiesMock).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith('/tasks');
+  });
+
+  it('sends an additional-org creator to the new org detail page', async () => {
+    authStoreMock.user = { id: 'u1', currentOrganization: 'org-1' }; // already has an org
+    const wrapper = mountView();
+    wrapper.vm.name = 'Beta';
+    await wrapper.vm.create();
+    await flushPromises();
+    expect(push).toHaveBeenCalledWith('/users/organizations/org-9');
+  });
+
+  it('captures first-org state BEFORE create, so the backend setting it does not flip the redirect', async () => {
+    // Simulate the backend attaching currentOrganization as a side effect of the
+    // first create — the redirect must still use the pre-create (first-org) state.
+    authStoreMock.user = { id: 'u1' };
+    createOrganizationMock.mockImplementation(async () => {
+      authStoreMock.user.currentOrganization = 'org-9';
+      return { id: 'org-9' };
+    });
+    const wrapper = mountView();
+    wrapper.vm.name = 'Acme';
+    await wrapper.vm.create();
+    await flushPromises();
+    expect(push).toHaveBeenCalledWith('/tasks');
+  });
+});

--- a/src/modules/organizations/views/organization.create.view.vue
+++ b/src/modules/organizations/views/organization.create.view.vue
@@ -70,15 +70,23 @@ export default {
       if (form.valid) {
         this.loading = true;
         const organizationsStore = useOrganizationsStore();
+        const authStore = useAuthStore();
+        // No current org (a first org, or a management user who just deleted their
+        // active one) is an onboarding-like step: land in the app via sign.route.
+        // An additional org created while one is already active keeps the
+        // -> org-detail destination. Captured BEFORE create, since the backend sets
+        // currentOrganization when the user had none.
+        const isFirstOrg = !authStore.user?.currentOrganization;
         try {
           const org = await organizationsStore.createOrganization({
             name: this.name,
             description: this.description,
           });
           if (org) {
-            const authStore = useAuthStore();
             await authStore.refreshAbilities();
-            this.$router.push(`/users/organizations/${org.id || org._id}`);
+            this.$router.push(
+              isFirstOrg ? this.config.sign.route : `/users/organizations/${org.id || org._id}`,
+            );
           }
         } catch (err) {
           console.error(err);


### PR DESCRIPTION
## What

Two stack fixes surfaced while a downstream consumer validated its onboarding flow.

### #4421 — config-gate the header on `/organization-required`

`core.header` force-showed the top-nav app-bar on `/organization-required` even for a signed-in user (the sidenav is hidden there, so the page had no chrome otherwise). Consumers using a sidenav-only layout once signed in got an off-layout public top-nav on the exact page a brand-new user lands on before creating an org.

The org-required header is now governed by `config.vuetify.theme.header.showOnOrgRequired` (via a new `showOnOrgRequired` computed). **The default preserves existing behavior** (unset → shown). A sidenav-only consumer sets `showOnOrgRequired: false` and the page no longer falls back to the signed-out header — the org-required view carries its own sign-out escape.

### #4422 — unify the first-org redirect

The standalone create view (`organization.create.view`) always redirected to `/users/organizations/:id` (org detail). But it is also reached from the org-required wall — a FIRST-org context, like signup — where the user should land in the app. So a first org created from the wall dead-ended on an org-management page instead of `config.sign.route`.

Now: `isFirstOrg ? config.sign.route : /users/organizations/:id`, where `isFirstOrg = !authStore.user?.currentOrganization` captured BEFORE create (the backend sets `currentOrganization` on the first org, so capturing after would flip it). Additional orgs created from management keep the → detail destination.

## Tests

- `core.header`: shows on org-required by default, hides when `showOnOrgRequired: false`, stays hidden on ordinary signed-in routes, still shows the public header when signed out.
- `organization.create.view` (new file): first-org → `sign.route`, additional-org → detail, and the pre-create capture holds when the backend attaches `currentOrganization` as a side effect.

Full unit suite (145 files / 2454 tests) + build green.

Closes #4421
Closes #4422

https://claude.ai/code/session_01XioM62H2iEMLsr686minjn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app header now remains visible on the organization-required page for signed-in users without an organization.
  * Header visibility can be disabled through configuration.

* **Bug Fixes**
  * Creating a first organization now redirects to the main tasks area.
  * Creating additional organizations continues to redirect to the new organization’s details page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->