### PR TITLE
fix(auth,organizations): soft-refresh (token) at onboarding sites to prevent silent sign-out

### DIFF
--- a/src/modules/auth/tests/auth.signup.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.signup.view.unit.tests.js
@@ -5,11 +5,11 @@ import { createVuetify } from 'vuetify';
 
 const signupMock = vi.hoisted(() => vi.fn());
 const fetchServerConfigMock = vi.hoisted(() => vi.fn().mockResolvedValue(null));
-const refreshAbilitiesMock = vi.hoisted(() => vi.fn().mockResolvedValue());
+const tokenMock = vi.hoisted(() => vi.fn().mockResolvedValue());
 const resendVerificationMock = vi.hoisted(() => vi.fn().mockResolvedValue());
 const verifyInviteMock = vi.hoisted(() => vi.fn().mockResolvedValue({ valid: false, email: null }));
 vi.mock('../stores/auth.store', () => ({
-  useAuthStore: () => ({ auth: false, signup: signupMock, serverConfig: null, fetchServerConfig: fetchServerConfigMock, refreshAbilities: refreshAbilitiesMock, resendVerification: resendVerificationMock, verifyInvite: verifyInviteMock }),
+  useAuthStore: () => ({ auth: false, signup: signupMock, serverConfig: null, fetchServerConfig: fetchServerConfigMock, token: tokenMock, resendVerification: resendVerificationMock, verifyInvite: verifyInviteMock }),
   deduceNamesFromEmail: (email) => {
     const local = email ? email.split('@')[0] : '';
     const parts = local.split(/[._-]/);
@@ -66,7 +66,7 @@ describe('auth.signup.view', () => {
     setActivePinia(createPinia());
     signupMock.mockReset();
     fetchServerConfigMock.mockReset().mockResolvedValue(null);
-    refreshAbilitiesMock.mockReset().mockResolvedValue();
+    tokenMock.mockReset().mockResolvedValue();
     resendVerificationMock.mockReset().mockResolvedValue();
     verifyInviteMock.mockReset().mockResolvedValue({ valid: false, email: null });
     createOrganizationMock.mockReset();
@@ -343,7 +343,7 @@ describe('auth.signup.view', () => {
 
       await wrapper.vm.proceedToApp();
 
-      expect(refreshAbilitiesMock).toHaveBeenCalled();
+      expect(tokenMock).toHaveBeenCalled();
       expect(wrapper.vm.$router.push).toHaveBeenCalledWith('/tasks');
     });
 
@@ -423,7 +423,7 @@ describe('auth.signup.view', () => {
       await wrapper.vm.proceedToApp();
       await flushPromises();
 
-      expect(refreshAbilitiesMock).toHaveBeenCalled();
+      expect(tokenMock).toHaveBeenCalled();
       // useAuthStore mock has currentOrganization undefined → proceedToApp checks authStore.user.currentOrganization;
       // since orgs.enabled is true AND user has no currentOrganization, it goes to /organization-required, NOT redirect.
       // For this test, we assert the redirect-honor branch fires when user DOES have an org.

--- a/src/modules/auth/tests/auth.verifyEmail.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.verifyEmail.view.unit.tests.js
@@ -4,11 +4,11 @@ import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 
 const verifyEmailMock = vi.hoisted(() => vi.fn());
-const refreshAbilitiesMock = vi.hoisted(() => vi.fn().mockResolvedValue());
+const tokenMock = vi.hoisted(() => vi.fn().mockResolvedValue());
 const fetchServerConfigMock = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 const storeMock = vi.hoisted(() => ({
   verifyEmail: verifyEmailMock,
-  refreshAbilities: refreshAbilitiesMock,
+  token: tokenMock,
   fetchServerConfig: fetchServerConfigMock,
   isLoggedIn: false,
   user: null,
@@ -48,7 +48,7 @@ describe('auth.verifyEmail.view', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     verifyEmailMock.mockReset();
-    refreshAbilitiesMock.mockReset().mockResolvedValue();
+    tokenMock.mockReset().mockResolvedValue();
     fetchServerConfigMock.mockReset().mockResolvedValue(null);
     storeMock.isLoggedIn = false;
     storeMock.user = null;

--- a/src/modules/auth/views/signup.view.vue
+++ b/src/modules/auth/views/signup.view.vue
@@ -395,7 +395,7 @@ export default {
     },
     /**
      * @desc Navigate to the main application after signup and org setup.
-     * @returns {void}
+     * @returns {Promise<void>}
      */
     async proceedToApp() {
       // Soft-refresh (token(), never throws) to pick up the new org context.

--- a/src/modules/auth/views/signup.view.vue
+++ b/src/modules/auth/views/signup.view.vue
@@ -398,9 +398,11 @@ export default {
      * @returns {void}
      */
     async proceedToApp() {
-      // Refresh token/abilities after org setup to pick up new org context
+      // Soft-refresh (token(), never throws) to pick up the new org context.
+      // refreshAbilities() signs out + rethrows on any failure — at this final
+      // onboarding click a transient error would silently eject a brand-new user.
       const authStore = useAuthStore();
-      await authStore.refreshAbilities();
+      await authStore.token();
       // If user has no org yet (pending join), go to organization-required page
       if (!authStore.user?.currentOrganization && this.serverConfig?.organizations?.enabled) {
         this.$router.push('/organization-required');

--- a/src/modules/auth/views/verifyEmail.view.vue
+++ b/src/modules/auth/views/verifyEmail.view.vue
@@ -103,13 +103,10 @@ export default {
      */
     async handlePostVerificationRedirect(authStore) {
       if (authStore.isLoggedIn) {
-        // Refresh user data to pick up emailVerified = true
-        try {
-          await authStore.refreshAbilities();
-        } catch {
-          // If refresh fails (e.g. expired token), stay on page
-          return;
-        }
+        // Soft-refresh (token(), never throws) to pick up emailVerified = true.
+        // refreshAbilities() signs out + rethrows on failure, which would eject
+        // the user who just verified their email.
+        await authStore.token();
         this.redirecting = true;
         const serverConfig = authStore.serverConfig || (await authStore.fetchServerConfig());
         if (!authStore.user?.currentOrganization && serverConfig?.organizations?.enabled) {

--- a/src/modules/organizations/tests/organization.create.view.unit.tests.js
+++ b/src/modules/organizations/tests/organization.create.view.unit.tests.js
@@ -3,9 +3,9 @@ import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 
-const refreshAbilitiesMock = vi.hoisted(() => vi.fn().mockResolvedValue());
+const tokenMock = vi.hoisted(() => vi.fn().mockResolvedValue());
 const createOrganizationMock = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'org-9' }));
-const authStoreMock = vi.hoisted(() => ({ user: null, refreshAbilities: refreshAbilitiesMock }));
+const authStoreMock = vi.hoisted(() => ({ user: null, token: tokenMock }));
 
 vi.mock('../../auth/stores/auth.store', () => ({
   useAuthStore: () => authStoreMock,
@@ -50,7 +50,7 @@ describe('organization.create.view — first-org redirect (#4422)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     push.mockReset();
-    refreshAbilitiesMock.mockReset().mockResolvedValue();
+    tokenMock.mockReset().mockResolvedValue();
     createOrganizationMock.mockReset().mockResolvedValue({ id: 'org-9' });
     authStoreMock.user = null;
   });
@@ -62,7 +62,7 @@ describe('organization.create.view — first-org redirect (#4422)', () => {
     await wrapper.vm.create();
     await flushPromises();
     expect(createOrganizationMock).toHaveBeenCalledWith({ name: 'Acme', description: '' });
-    expect(refreshAbilitiesMock).toHaveBeenCalled();
+    expect(tokenMock).toHaveBeenCalled();
     expect(push).toHaveBeenCalledWith('/tasks');
   });
 

--- a/src/modules/organizations/views/organization.create.view.vue
+++ b/src/modules/organizations/views/organization.create.view.vue
@@ -83,7 +83,10 @@ export default {
             description: this.description,
           });
           if (org) {
-            await authStore.refreshAbilities();
+            // Soft-refresh (token(), never throws) to pick up the new org context.
+            // refreshAbilities() signs out + rethrows on failure, which would eject
+            // a user who just created their org.
+            await authStore.token();
             this.$router.push(
               isFirstOrg ? this.config.sign.route : `/users/organizations/${org.id || org._id}`,
             );

--- a/src/modules/organizations/views/organization.create.view.vue
+++ b/src/modules/organizations/views/organization.create.view.vue
@@ -64,6 +64,12 @@ export default {
     };
   },
   methods: {
+    /**
+     * @desc Validate the form and create the organization, then route the user:
+     *       a first org (no current org yet) lands in the app via sign.route; an
+     *       additional org created while one is active goes to its detail page.
+     * @returns {Promise<void>}
+     */
     async create() {
       if (this.loading) return;
       const form = await this.$refs.form.validate();

--- a/src/modules/organizations/views/organizations.required.view.vue
+++ b/src/modules/organizations/views/organizations.required.view.vue
@@ -251,7 +251,9 @@ export default {
     },
     async refresh() {
       const authStore = useAuthStore();
-      await authStore.refreshAbilities();
+      // Soft-refresh (token(), never throws) — refreshAbilities() signs out +
+      // rethrows on failure, so a hiccup on "Check status" would eject the user.
+      await authStore.token();
       if (authStore.user?.currentOrganization) {
         this.$router.push(this.config.sign.route);
       }
@@ -263,7 +265,9 @@ export default {
       try {
         await organizationsStore.createJoinRequest(orgId);
         const authStore = useAuthStore();
-        await authStore.refreshAbilities();
+        // Soft-refresh (token(), never throws). refreshAbilities() would sign the
+        // user out before this try/catch could swallow the throw.
+        await authStore.token();
       } catch {
         // interceptor handles snackbar
       } finally {

--- a/src/modules/organizations/views/organizations.required.view.vue
+++ b/src/modules/organizations/views/organizations.required.view.vue
@@ -249,6 +249,11 @@ export default {
         this.acceptingId = null;
       }
     },
+    /**
+     * @desc Soft-refresh the session ("Check status") and, if the user now has an
+     *       organization, forward them into the app.
+     * @returns {Promise<void>}
+     */
     async refresh() {
       const authStore = useAuthStore();
       // Soft-refresh (token(), never throws) — refreshAbilities() signs out +
@@ -258,6 +263,12 @@ export default {
         this.$router.push(this.config.sign.route);
       }
     },
+    /**
+     * @desc Send a join request for the given organization, then soft-refresh the
+     *       session so any resulting membership/pending state is reflected.
+     * @param {Object} org - The organization to request to join.
+     * @returns {Promise<void>}
+     */
     async requestToJoin(org) {
       const orgId = org.id || org._id;
       this.requestingOrgId = orgId;


### PR DESCRIPTION
## What

`refreshAbilities()` signs the user out **and rethrows** on any failure. That is correct for the axios 401 interceptor and the router guard (session expiry → sign out), but it's a footgun at **onboarding touchpoints**: a transient network blip or 5xx at the wrong moment silently ejects a brand-new user — worst of all at the final "Get Started" click of signup.

The `acceptInvitation` flow already switched to the safe `token()` soft-refresh for exactly this reason. This PR applies the same pattern to the remaining onboarding sites.

## Changes

Replace `refreshAbilities()` with `token()` at the onboarding sites:

- **signup** `proceedToApp()` — the final "Get Started" click after org setup
- **verifyEmail** post-verification redirect
- **organization.create** — first / additional org creation
- **organizations.required** — `refresh()` ("Check status") and `requestToJoin()` (its signout fired *before* the surrounding `try/catch` could swallow the throw)

`token()` refreshes abilities + user + nav via the same `/token` endpoint, but never signs out and never throws (it swallows the error; the axios interceptor still surfaces a 401 to the user). Left untouched on purpose: the axios interceptor and router guard, where signout-on-failure is the intended behavior.

## Tests

Updated the four affected view tests to mock/assert `token()`. Full unit suite (145 files / 2454 tests) + build green.

https://claude.ai/code/session_01XioM62H2iEMLsr686minjn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication refresh handling during onboarding, email verification, organization creation, and membership join flows.
  * Uses a safer “soft refresh” approach to avoid prematurely signing users out or interrupting navigation.
  * Maintains the existing organization-aware redirects after authentication updates.
* **Tests**
  * Updated unit tests and mocks for the authentication refresh behavior across signup, email verification, organization creation, and required-organization flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->