### PR TITLE
fix(auth): token() soft-refresh also carries pendingRequests

### DIFF
--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -335,6 +335,10 @@ export const useAuthStore = defineStore('auth', {
         this.auth = true;
         this.cookieExpire = res.data.tokenExpiresIn;
         this.user = res.data.user;
+        // Soft-refresh must carry pendingRequests too, so the org-required wall's
+        // join banner + duplicate-request guard stay accurate after a token()
+        // soft-refresh (mirrors refreshAbilities()). /token already returns it.
+        this.pendingRequests = res.data.pendingRequests || [];
 
         if (res.data.abilities) updateAbilities(res.data.abilities);
         if (res.data.user.lastLoginAt) {

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -470,6 +470,28 @@ describe('Auth Store', () => {
       expect(localStorage.getItem(`${config.cookie.prefix}LastLoginAt`)).toBe(lastLogin);
     });
 
+    it('should populate pendingRequests from the token response (soft-refresh superset)', async () => {
+      const authStore = useAuthStore();
+      const pending = [{ id: 'req-1', organizationId: { name: 'Acme' } }];
+      axios.get.mockResolvedValueOnce({
+        data: { user: { id: '789', roles: ['user'] }, tokenExpiresIn: Date.now() + 7200000, pendingRequests: pending },
+      });
+
+      await authStore.token();
+
+      expect(authStore.pendingRequests).toEqual(pending);
+    });
+
+    it('should clear a stale pendingRequests when the token response omits them', async () => {
+      const authStore = useAuthStore();
+      authStore.pendingRequests = [{ id: 'stale' }];
+      axios.get.mockResolvedValueOnce({ data: { user: { id: '789', roles: ['user'] }, tokenExpiresIn: 1 } });
+
+      await authStore.token();
+
+      expect(authStore.pendingRequests).toEqual([]);
+    });
+
     it('should handle token refresh error without logging to the console', async () => {
       const authStore = useAuthStore();
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## What

`token()` (soft-refresh) refreshed user / abilities / nav but, unlike `refreshAbilities()`, never reassigned `pendingRequests`. After the recent `refreshAbilities()` → `token()` swap at the onboarding sites, the org-required wall's **"request pending" banner** and its **duplicate-request guard** (`Request to join` disabled while `pendingRequests.length > 0`) went stale in-session on the join path — a user clicks *Request to join*, sees nothing change, and a re-click fires a duplicate request.

`/token` already returns `pendingRequests`; `token()` just dropped it on the floor.

## Fix

One line in `token()`: `this.pendingRequests = res.data.pendingRequests || []` (mirrors `refreshAbilities()`). This makes `token()` a true soft-refresh superset — repairs `proceedToApp`, the wall's `refresh()` / `requestToJoin()`, and every other `token()` call site, and lets a soft-refresh clear a stale banner too.

## Tests

Added: `token()` populates `pendingRequests` from the response, and clears a stale one when omitted. Full unit suite green.

https://claude.ai/code/session_01XioM62H2iEMLsr686minjn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication token refresh behavior by keeping pending request information up to date.
  - Clears outdated pending request information when it is no longer included in the refresh response.

- **Tests**
  - Added coverage for updating and clearing pending requests during token refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->