### PR TITLE
refactor(core,organizations): drive org-required header visibility via route meta

### DIFF
--- a/src/modules/core/components/core.header.component.vue
+++ b/src/modules/core/components/core.header.component.vue
@@ -152,11 +152,15 @@ export default {
       return authStore.isLoggedIn;
     },
     /**
-     * @desc Whether to force-show the header on `/organization-required` for a
-     *       signed-in user who has no organization yet. The sidenav is hidden on
-     *       that page (it gates on `hasOrganization`), so by default the header is
-     *       shown there to keep some chrome. A sidenav-only consumer that hides the
-     *       header once signed in can opt out via
+     * @desc Whether to force-show the header on the organizations module's
+     *       org-required gate page, for a signed-in user who has no organization
+     *       yet. The sidenav is hidden on that page (it gates on
+     *       `hasOrganization`), so by default the header is shown there to keep
+     *       some chrome. Driven by `meta.orgGate` on the matched route (set by
+     *       `organizations.router.js`) rather than a hardcoded path literal —
+     *       core must not know module route URLs, or renaming the route would
+     *       silently break this. A sidenav-only consumer that hides the header
+     *       once signed in can opt out via
      *       `config.vuetify.theme.header.showOnOrgRequired: false`, so the page no
      *       longer falls back to the signed-out top-nav (the org-required view
      *       carries its own sign-out escape). Default (undefined) preserves the
@@ -165,7 +169,7 @@ export default {
      */
     showOnOrgRequired() {
       return (
-        this.$route.path === '/organization-required'
+        Boolean(this.$route.meta?.orgGate)
         && this.config.vuetify.theme.header?.showOnOrgRequired !== false
       );
     },

--- a/src/modules/core/tests/core.header.component.unit.tests.js
+++ b/src/modules/core/tests/core.header.component.unit.tests.js
@@ -45,9 +45,12 @@ const makeConfig = () => ({
 
 /**
  * @desc Mount the header component with router + config globals.
+ * @param {String} routePath - `$route.path` mock.
+ * @param {Object} headerExtra - merged into `config.vuetify.theme.header`.
+ * @param {Object} routeMeta - `$route.meta` mock (e.g. `{ orgGate: true }`).
  * @returns {import('@vue/test-utils').VueWrapper}
  */
-const mountHeader = (routePath = '/', headerExtra = {}) => {
+const mountHeader = (routePath = '/', headerExtra = {}, routeMeta = {}) => {
   const vuetify = createVuetify({ components, directives });
   const push = vi.fn();
   const config = makeConfig();
@@ -55,7 +58,7 @@ const mountHeader = (routePath = '/', headerExtra = {}) => {
   return mount(CoreHeaderComponent, {
     global: {
       plugins: [vuetify],
-      mocks: { $router: { push }, $route: { path: routePath } },
+      mocks: { $router: { push }, $route: { path: routePath, meta: routeMeta } },
       config: { globalProperties: { config } },
       // VAppBar needs an injected layout (v-app); stub it so we can exercise the
       // navigate() method in isolation without a full layout wrapper. The stub
@@ -76,18 +79,21 @@ describe('CoreHeaderComponent', () => {
     vi.restoreAllMocks();
   });
 
-  // #4421 — the header force-shows on /organization-required (the sidenav is
-  // hidden there) unless a sidenav-only consumer opts out via config.
-  describe('org-required header visibility (#4421)', () => {
-    it('shows the header on /organization-required by default (signed-in, no org)', () => {
+  // #4421 — the header force-shows on the org-required gate page (the sidenav
+  // is hidden there) unless a sidenav-only consumer opts out via config.
+  // #4448 — driven by `meta.orgGate` (set by organizations.router.js), not a
+  // hardcoded '/organization-required' path literal — core must not know
+  // module route URLs.
+  describe('org-required header visibility (#4421, #4448)', () => {
+    it('shows the header on the org-gate route by default (signed-in, no org)', () => {
       authStoreState.isLoggedIn = true;
-      const wrapper = mountHeader('/organization-required');
+      const wrapper = mountHeader('/organization-required', {}, { orgGate: true });
       expect(wrapper.find('header').exists()).toBe(true);
     });
 
     it('hides it there when the consumer opts out (showOnOrgRequired: false)', () => {
       authStoreState.isLoggedIn = true;
-      const wrapper = mountHeader('/organization-required', { showOnOrgRequired: false });
+      const wrapper = mountHeader('/organization-required', { showOnOrgRequired: false }, { orgGate: true });
       expect(wrapper.find('header').exists()).toBe(false);
     });
 
@@ -99,6 +105,20 @@ describe('CoreHeaderComponent', () => {
 
     it('still shows the public header when signed out', () => {
       const wrapper = mountHeader('/tasks');
+      expect(wrapper.find('header').exists()).toBe(true);
+    });
+
+    // #4448 — proves the decoupling: the path literal alone no longer drives
+    // visibility (meta flag is what matters), and vice versa.
+    it('does NOT show the header on /organization-required without meta.orgGate (path literal alone no longer drives it)', () => {
+      authStoreState.isLoggedIn = true;
+      const wrapper = mountHeader('/organization-required');
+      expect(wrapper.find('header').exists()).toBe(false);
+    });
+
+    it('shows the header on any route carrying meta.orgGate, regardless of path', () => {
+      authStoreState.isLoggedIn = true;
+      const wrapper = mountHeader('/some-other-gate-path', {}, { orgGate: true });
       expect(wrapper.find('header').exists()).toBe(true);
     });
   });

--- a/src/modules/organizations/router/organizations.router.js
+++ b/src/modules/organizations/router/organizations.router.js
@@ -25,6 +25,10 @@ export default [
     meta: {
       display: false,
       requiresAuth: true,
+      // Consumed by core.header.component.vue's showOnOrgRequired computed —
+      // lets core force-show the header on this page without hardcoding the
+      // route path (core must not know module route literals).
+      orgGate: true,
     },
   },
   {

--- a/src/modules/organizations/tests/organizations.router.unit.tests.js
+++ b/src/modules/organizations/tests/organizations.router.unit.tests.js
@@ -16,4 +16,12 @@ describe('organizations router', () => {
     expect(redirect).toBeTruthy();
     expect(redirect.redirect).toEqual({ name: 'Account Organization General' });
   });
+
+  // #4448 — core.header.component.vue reads this flag instead of hardcoding
+  // the '/organization-required' path literal.
+  test('Organization Required route carries meta.orgGate for core.header.component.vue', () => {
+    const route = routes.find((r) => r.path === '/organization-required');
+    expect(route).toBeTruthy();
+    expect(route.meta.orgGate).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- What changed: `core.header.component.vue` no longer hardcodes the `/organization-required` path literal. `organizations.router.js` now sets `meta.orgGate: true` on that route, and the header's `showOnOrgRequired` computed reads `route.meta.orgGate` instead of comparing `route.path`.
- Why: the header (core) was reaching into a URL owned by the organizations module. Renaming that route would silently break header visibility with no compile-time or test signal. Route meta decouples the two — the organizations module now declares the gate itself.
- Related issues: Closes #4448

## Scope

- Modules impacted: `core` (header component), `organizations` (router)
- Cross-module impact: `yes` — core now depends on a route-meta contract (`meta.orgGate`) instead of a path string; the config opt-out (`config.vuetify.theme.header.showOnOrgRequired`) semantics are unchanged.
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

Test suite: 2466 tests green. New/updated tests assert the decoupling directly: a route with the old path literal but no `meta.orgGate` no longer shows the header, and a route carrying `meta.orgGate: true` (regardless of path) does. Also verified the initial-navigation edge case: Vue Router's `START_LOCATION` has `meta: {}`, so pre-resolution behavior (header hidden) is identical to before this change.

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — visibility-only UI gate, not an auth/access-control gate. The route itself remains protected by its own guard; this only affects whether the header renders.
- Mergeability considerations: downstream projects that override `organizations.router.js` should retain `meta.orgGate: true` on their org-required route (or set `config.vuetify.theme.header.showOnOrgRequired: false` to opt out) to preserve current header behavior.
- Follow-up tasks (optional): none

https://claude.ai/code/session_01WfNC8bt1TgL4AsiYgCEGup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header visibility on the organization-required page.
  * Header behavior now follows route configuration, ensuring consistent display even when page URLs change.

* **Tests**
  * Added coverage verifying header visibility across organization-gated routes.
  * Added validation that the organization-required route is correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->