### PR TITLE
chore: audit polish — header key doc, pendingRequests consistency, verify-skill test rule

### DIFF
--- a/.claude/skills/ui/references/design-system.md
+++ b/.claude/skills/ui/references/design-system.md
@@ -206,7 +206,8 @@ config.vuetify.theme.dark        // 'auto', 'dark', 'light'
 config.vuetify.theme.flat        // true = flat design
 config.vuetify.theme.rounded     // 'rounded-lg', 'rounded-xl', etc.
 config.vuetify.theme.maxWidth    // '1200px' default
-config.vuetify.theme.header      // { background, color, colorMode, opacity, scrollBehavior }
+config.vuetify.theme.header      // { background, color, colorMode, opacity, scrollBehavior, showOnOrgRequired }
+                                  // showOnOrgRequired: false hides the header on /organization-required (sidenav-only apps)
 config.vuetify.theme.navigation  // { background, color, drawer: { floating, expand, rail } }
 config.vuetify.theme.themes.light.colors  // { primary, secondary, background, surface, ... }
 config.vuetify.theme.themes.dark.colors   // { primary, secondary, background, surface, ... }

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -26,6 +26,7 @@ description: >
      - Missing form validation or confirmation dialogs on destructive actions
      - Inconsistent selectors in E2E tests (prefer getByRole/getByPlaceholder)
      - Broken or nonexistent route references
+     - Store-contract tests that only assert a mock was called, not the resulting store state (interaction-only assertions let a dropped field slip through)
    - Fix all issues found before proceeding
 
 2. **Lint** — `npm run lint`

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -131,7 +131,7 @@ export const useAuthStore = defineStore('auth', {
         }
 
         if (res.data.abilities) updateAbilities(res.data.abilities);
-        if (res.data.pendingRequests) this.pendingRequests = res.data.pendingRequests;
+        this.pendingRequests = res.data.pendingRequests || [];
 
         coreStore.refreshNav(this.isLoggedIn);
 

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -262,6 +262,39 @@ describe('Auth Store', () => {
       expect(localStorage.getItem(`${config.cookie.prefix}LastLoginAt`)).toBe(lastLogin);
     });
 
+    it('should populate pendingRequests from the signin response', async () => {
+      const authStore = useAuthStore();
+      const pending = [{ id: 'req-1', organizationId: { name: 'Acme' } }];
+      const mockResponse = {
+        data: {
+          user: { id: '123', email: 'test@test.com', roles: ['user'] },
+          tokenExpiresIn: Date.now() + 3600000,
+          pendingRequests: pending,
+        },
+      };
+
+      axios.post.mockResolvedValueOnce(mockResponse);
+      await authStore.signin({ email: 'test@test.com', password: 'password' });
+
+      expect(authStore.pendingRequests).toEqual(pending);
+    });
+
+    it('should reset a stale pendingRequests to [] when the signin response omits them', async () => {
+      const authStore = useAuthStore();
+      authStore.pendingRequests = [{ id: 'stale' }];
+      const mockResponse = {
+        data: {
+          user: { id: '123', email: 'test@test.com', roles: ['user'] },
+          tokenExpiresIn: Date.now() + 3600000,
+        },
+      };
+
+      axios.post.mockResolvedValueOnce(mockResponse);
+      await authStore.signin({ email: 'test@test.com', password: 'password' });
+
+      expect(authStore.pendingRequests).toEqual([]);
+    });
+
     it('should handle 423 lockout response', async () => {
       const authStore = useAuthStore();
 


### PR DESCRIPTION
## Summary

- What changed:
  - `design-system.md` documents the existing `showOnOrgRequired` header config key (was implemented but undocumented — `false` hides the header on `/organization-required` for sidenav-only apps).
  - `auth.store.js` `signin()` harmonized to the `|| []` `pendingRequests` pattern already used by `refreshAbilities`/token flows, so a signin response omitting the field resets stale state instead of silently keeping it.
  - `verify` skill (`SKILL.md`) gains a diff-audit test rule flagging store-contract tests that only assert a mock was called, not the resulting store state — the exact gap that let the `pendingRequests` inconsistency ship undetected.
- Why: three small findings from an internal audit pass. The header key was documented nowhere, `signin()` was the only pendingRequests setter using stale-keep semantics while every other setter resets, and the verify skill had no rule to catch a state-not-asserted test gap like that one.
- Related issues: Closes #4449

## Scope

- Modules impacted: `auth` store, `.claude/skills/ui` reference docs, `.claude/skills/verify` skill
- Cross-module impact: none — `pendingRequests` is fully server-authoritative on signin; verified no consumer relies on stale-keep behavior across a signin response omitting the field.
- Risk level: low

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` — 2465 passed (2465), including 2 new red-green tests for the `signin()` `pendingRequests` fix (populate-from-response, reset-to-[]-when-omitted)
- [ ] `npm run build`
- [x] Manual checks done (if applicable) — traced all `pendingRequests` consumers (nav badge, org-request views) to confirm server-authoritative, no stale-keep dependency

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — doc + skill-rule + a data-freshness fix on an already-authoritative field.
- Mergeability considerations: none, additive/doc-only outside the one-line store fix.
- Follow-up tasks (optional): none.

https://claude.ai/code/session_01WfNC8bt1TgL4AsiYgCEGup