### PR TITLE
fix(auth,organizations): guard soft-refresh navigation and the signout race

### DIFF
--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -340,6 +340,13 @@ export const useAuthStore = defineStore('auth', {
         this.pendingRequests = res.data.pendingRequests || [];
         coreStore.refreshNav(this.isLoggedIn);
       } catch (err) {
+        // A concurrent signout() may have already invalidated this generation
+        // while the request was in flight — the failure (e.g. a 401 once the
+        // session is gone) is then just a side effect of that deliberate
+        // signout, not a real refresh failure. Swallow it silently instead of
+        // signing out again and rethrowing a stale "session expired" error
+        // right after the user chose to leave.
+        if (generation !== _authGeneration) return;
         // If token refresh fails, sign out and propagate to caller
         await this.signout();
         throw err;

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -43,11 +43,15 @@ function deduceNamesFromEmail(email) {
  * refreshAbilities() and signout() (module scope, mirrors the
  * isRefreshingAbilities dedup flag in lib/services/axios.js). token() and
  * refreshAbilities() capture the generation before their network await;
- * signout() bumps it synchronously before doing anything else. If either
- * soft-refresh resolves after a concurrent signout() already bumped the
- * generation, the captured value no longer matches and the continuation
- * drops its state writes instead of resurrecting auth=true/user/
- * localStorage right after the user signed out.
+ * signout() bumps it synchronously before doing anything else. This drops
+ * a soft-refresh continuation that was already in flight when signout()
+ * ran — its captured generation no longer matches once signout() bumps it,
+ * so it skips resurrecting auth=true/user/localStorage right after the
+ * user signed out. Scope: a soft-refresh call that starts DURING signout()'s
+ * own async window (e.g. a concurrent 401/403 interceptor retry firing
+ * while the /signout request is still pending) captures the already-bumped
+ * generation and is not guarded against resolving after signout() completes
+ * — a known narrow follow-up, not covered here.
  */
 let _authGeneration = 0;
 

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -39,6 +39,19 @@ function deduceNamesFromEmail(email) {
 }
 
 /**
+ * Monotonically-increasing generation counter shared by token()/
+ * refreshAbilities() and signout() (module scope, mirrors the
+ * isRefreshingAbilities dedup flag in lib/services/axios.js). token() and
+ * refreshAbilities() capture the generation before their network await;
+ * signout() bumps it synchronously before doing anything else. If either
+ * soft-refresh resolves after a concurrent signout() already bumped the
+ * generation, the captured value no longer matches and the continuation
+ * drops its state writes instead of resurrecting auth=true/user/
+ * localStorage right after the user signed out.
+ */
+let _authGeneration = 0;
+
+/**
  * Store definition.
  */
 export const useAuthStore = defineStore('auth', {
@@ -267,6 +280,11 @@ export const useAuthStore = defineStore('auth', {
       const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
       const coreStore = useCoreStore();
 
+      // Bump the generation FIRST (synchronously, before any await) so any
+      // token()/refreshAbilities() already in flight is invalidated the
+      // moment signout begins, regardless of when its network call settles.
+      _authGeneration += 1;
+
       // Call backend first so the server can clear the httpOnly TOKEN cookie.
       // Swallow any error (older backends may not expose this endpoint, or the
       // server may be unreachable) — the local reset below must still run.
@@ -306,8 +324,13 @@ export const useAuthStore = defineStore('auth', {
     async refreshAbilities() {
       const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
       const coreStore = useCoreStore();
+      // Capture the generation BEFORE the network await — if a concurrent
+      // signout() bumps it while this request is in flight, the response
+      // below is a stale continuation and must not resurrect state.
+      const generation = _authGeneration;
       try {
         const res = await axios.get(`${api}/${config.api.endPoints.auth}/token`);
+        if (generation !== _authGeneration) return; // signout() won the race
         if (res.data.abilities) {
           updateAbilities(res.data.abilities);
         }
@@ -326,9 +349,14 @@ export const useAuthStore = defineStore('auth', {
     async token() {
       const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
       const coreStore = useCoreStore();
+      // Capture the generation BEFORE the network await — see refreshAbilities()
+      // for the shared rationale (a soft-refresh continuation resolving after
+      // signout() must not re-populate auth=true/user/localStorage).
+      const generation = _authGeneration;
 
       try {
         const res = await axios.get(`${api}/${config.api.endPoints.auth}/token`);
+        if (generation !== _authGeneration) return; // signout() won the race
         localStorage.setItem(`${config.cookie.prefix}UserRoles`, res.data.user.roles);
         localStorage.setItem(`${config.cookie.prefix}CookieExpire`, res.data.tokenExpiresIn);
 

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -1176,6 +1176,86 @@ describe('Auth Store', () => {
       expect(mockReset).toHaveBeenCalledOnce();
     });
   });
+
+  // #4459 — token()/refreshAbilities() are soft-refreshes that can be in
+  // flight when the user signs out. Without a generation guard, a late
+  // resolution would write auth=true/user/localStorage right after
+  // signout() already cleared them ("un-logout"). signout() bumps a shared
+  // generation counter synchronously; token()/refreshAbilities() capture it
+  // before their network await and drop stale continuations.
+  describe('signout race guard (#4459)', () => {
+    it('does NOT resurrect auth/user/localStorage when token() resolves after a concurrent signout()', async () => {
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.cookieExpire = Date.now() + 1000;
+      authStore.user = { id: 'u1' };
+      localStorage.setItem(`${config.cookie.prefix}UserRoles`, 'user');
+      localStorage.setItem(`${config.cookie.prefix}CookieExpire`, '12345');
+
+      let resolveTokenGet;
+      axios.get.mockImplementationOnce(() => new Promise((resolve) => { resolveTokenGet = resolve; }));
+      axios.post.mockResolvedValueOnce({ data: {} }); // signout()'s backend call
+
+      const tokenPromise = authStore.token(); // in-flight, generation captured BEFORE signout()
+      await authStore.signout(); // bumps generation + clears state synchronously
+
+      // token()'s network call now settles AFTER signout() has already run.
+      resolveTokenGet({
+        data: {
+          user: { id: 'ghost' },
+          tokenExpiresIn: Date.now() + 7200000,
+          roles: ['user'],
+        },
+      });
+      await tokenPromise;
+
+      expect(authStore.auth).toBe(false);
+      expect(authStore.user).toBe(null);
+      expect(authStore.cookieExpire).toBe(0);
+      expect(localStorage.getItem(`${config.cookie.prefix}UserRoles`)).toBe(null);
+      expect(localStorage.getItem(`${config.cookie.prefix}CookieExpire`)).toBe(null);
+    });
+
+    it('does NOT resurrect the user when refreshAbilities() resolves after a concurrent signout()', async () => {
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.cookieExpire = Date.now() + 1000;
+      authStore.user = { id: 'u1' };
+
+      let resolveGet;
+      axios.get.mockImplementationOnce(() => new Promise((resolve) => { resolveGet = resolve; }));
+      axios.post.mockResolvedValueOnce({ data: {} }); // signout()'s backend call
+
+      const refreshPromise = authStore.refreshAbilities(); // generation captured BEFORE signout()
+      await authStore.signout();
+
+      resolveGet({
+        data: {
+          user: { id: 'ghost' },
+          abilities: [{ action: 'manage', subject: 'all' }],
+        },
+      });
+      await refreshPromise;
+
+      expect(authStore.user).toBe(null);
+      expect(authStore.auth).toBe(false);
+    });
+
+    it('a fresh token() call after signout() still succeeds normally (generation bump does not break later refreshes)', async () => {
+      const authStore = useAuthStore();
+
+      axios.post.mockResolvedValueOnce({ data: {} });
+      await authStore.signout();
+
+      axios.get.mockResolvedValueOnce({
+        data: { user: { id: 'u2', roles: ['user'] }, tokenExpiresIn: Date.now() + 3600000 },
+      });
+      await authStore.token();
+
+      expect(authStore.auth).toBe(true);
+      expect(authStore.user).toEqual({ id: 'u2', roles: ['user'] });
+    });
+  });
 });
 
 describe('auth store — beta seat getters', () => {

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -1255,6 +1255,53 @@ describe('Auth Store', () => {
       expect(authStore.auth).toBe(true);
       expect(authStore.user).toEqual({ id: 'u2', roles: ['user'] });
     });
+
+    // Phase-0 follow-up: refreshAbilities()'s catch path unconditionally called
+    // signout() + rethrew, even when the /token request only failed because a
+    // concurrent signout() already ran (e.g. the session cookie is now gone).
+    // That surfaced a stale "session expired" error to the caller right after a
+    // deliberate signout. The catch must respect the same generation guard as
+    // the success path: a stale rejection is swallowed silently instead.
+    it('does NOT re-signout-and-rethrow when refreshAbilities() rejects after a concurrent signout() already ran', async () => {
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.cookieExpire = Date.now() + 1000;
+      authStore.user = { id: 'u1' };
+
+      let rejectGet;
+      axios.get.mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectGet = reject; }));
+      axios.post.mockResolvedValueOnce({ data: {} }); // signout()'s backend call (in-flight refresh's own signout, guarded below, never fires)
+
+      const refreshPromise = authStore.refreshAbilities(); // generation captured BEFORE signout()
+      await authStore.signout(); // bumps generation + clears state synchronously
+
+      // The in-flight /token request now settles with a failure AFTER signout()
+      // already ran (e.g. 401 because the session cookie is gone).
+      rejectGet(new Error('Token refresh failed'));
+
+      // Must resolve silently — no rethrow, and no second signout() call.
+      await expect(refreshPromise).resolves.toBeUndefined();
+
+      // Only signout()'s own backend call happened — the stale catch did not
+      // fire a second /signout request.
+      expect(axios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('still signs out and rethrows when refreshAbilities() fails within the same (non-stale) generation', async () => {
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.cookieExpire = Date.now() + 1000;
+      authStore.user = { id: 'u1' };
+
+      axios.get.mockRejectedValueOnce(new Error('Token refresh failed'));
+      axios.post.mockResolvedValueOnce({ data: {} }); // the catch's own signout() backend call
+
+      await expect(authStore.refreshAbilities()).rejects.toThrow('Token refresh failed');
+
+      expect(authStore.auth).toBe(false);
+      expect(authStore.user).toBe(null);
+      expect(axios.post).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/src/modules/organizations/tests/organization.create.view.unit.tests.js
+++ b/src/modules/organizations/tests/organization.create.view.unit.tests.js
@@ -275,4 +275,79 @@ describe('organization.create.view — soft-refresh guard (#4459)', () => {
     expect(tokenMock).not.toHaveBeenCalled();
     expect(push).not.toHaveBeenCalled();
   });
+
+  // Regression: the alert's `closable`/@click:close only ever cleared `error`,
+  // never `pendingOrg`. Dismissing the banner instead of clicking its inline
+  // Retry left the still-enabled primary "Create Organization" button wired to
+  // create() — clicking it called createOrganization() a SECOND time with the
+  // same data, duplicating the org server-side (the exact outcome the guard
+  // was meant to prevent). The primary button must route to retryRefresh()
+  // whenever pendingOrg is set, independent of whether the alert was dismissed.
+  it('does not recreate the organization when the primary button is clicked after the alert is dismissed while pendingOrg is set', async () => {
+    tokenMock.mockReset().mockResolvedValue(); // stalls: never populates currentOrganization
+
+    const wrapper = mountView();
+    wrapper.vm.name = 'Acme';
+    await wrapper.vm.create();
+    await flushPromises();
+
+    expect(createOrganizationMock).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.pendingOrg).toEqual({ org: { id: 'org-9' }, isFirstOrg: true });
+
+    // Dismiss the banner exactly as @click:close does: clear `error` only.
+    wrapper.vm.error = null;
+    await wrapper.vm.$nextTick();
+
+    // The alert (and its inline Retry button) is now gone, but pendingOrg
+    // persists — the primary button must have flipped to "Retry" already.
+    const primaryButton = wrapper.find('[data-test="organization-create-primary-action"]');
+    expect(primaryButton.text()).toBe('Retry');
+
+    await primaryButton.trigger('click');
+    await flushPromises();
+
+    // Only the refresh retried — createOrganization was NOT called again.
+    expect(createOrganizationMock).toHaveBeenCalledTimes(1);
+    expect(tokenMock).toHaveBeenCalledTimes(2); // initial create() attempt + the retry
+  });
+
+  it('handlePrimaryAction routes to retryRefresh (not create) whenever pendingOrg is set', async () => {
+    tokenMock.mockReset().mockResolvedValue();
+    const wrapper = mountView();
+    wrapper.vm.pendingOrg = { org: { id: 'org-9' }, isFirstOrg: true };
+
+    await wrapper.vm.handlePrimaryAction();
+    await flushPromises();
+
+    expect(createOrganizationMock).not.toHaveBeenCalled();
+    expect(tokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('handlePrimaryAction falls through to create() when there is no pendingOrg', async () => {
+    tokenMock.mockReset().mockImplementation(async () => {
+      authStoreMock.user = { ...authStoreMock.user, currentOrganization: 'org-9' };
+    });
+    const wrapper = mountView();
+    wrapper.vm.name = 'Acme';
+
+    await wrapper.vm.handlePrimaryAction();
+    await flushPromises();
+
+    expect(createOrganizationMock).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith('/tasks');
+  });
+
+  it('renders the primary button as "Retry" (disabled/loading bound to retrying) while pendingOrg is set', async () => {
+    tokenMock.mockReset().mockResolvedValue();
+    const wrapper = mountView();
+    wrapper.vm.name = 'Acme';
+    await wrapper.vm.create();
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+
+    const primaryButton = wrapper.find('[data-test="organization-create-primary-action"]');
+    expect(primaryButton.exists()).toBe(true);
+    expect(primaryButton.text()).toBe('Retry');
+    expect(primaryButton.attributes('disabled')).toBeFalsy();
+  });
 });

--- a/src/modules/organizations/tests/organization.create.view.unit.tests.js
+++ b/src/modules/organizations/tests/organization.create.view.unit.tests.js
@@ -3,9 +3,30 @@ import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 
-const tokenMock = vi.hoisted(() => vi.fn().mockResolvedValue());
+// Default token() simulates a realistic successful /auth/token refresh: the
+// backend already reflects the just-created/joined org, so currentOrganization
+// gets populated if it wasn't already set. Individual #4459 guard tests
+// override this per-case to simulate a soft-refresh that does NOT (yet)
+// populate it.
+const tokenMock = vi.hoisted(() => vi.fn().mockImplementation(async () => {
+  if (authStoreMock.user && !authStoreMock.user.currentOrganization) {
+    authStoreMock.user = { ...authStoreMock.user, currentOrganization: 'org-9' };
+  }
+}));
 const createOrganizationMock = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'org-9' }));
 const authStoreMock = vi.hoisted(() => ({ user: null, token: tokenMock }));
+
+/**
+ * Reset tokenMock to the default "realistic successful refresh" implementation
+ * described above (used by beforeEach blocks across this file).
+ */
+const resetTokenMockToSuccess = () => {
+  tokenMock.mockReset().mockImplementation(async () => {
+    if (authStoreMock.user && !authStoreMock.user.currentOrganization) {
+      authStoreMock.user = { ...authStoreMock.user, currentOrganization: 'org-9' };
+    }
+  });
+};
 
 vi.mock('../../auth/stores/auth.store', () => ({
   useAuthStore: () => authStoreMock,
@@ -50,7 +71,7 @@ describe('organization.create.view — first-org redirect (#4422)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     push.mockReset();
-    tokenMock.mockReset().mockResolvedValue();
+    resetTokenMockToSuccess();
     createOrganizationMock.mockReset().mockResolvedValue({ id: 'org-9' });
     authStoreMock.user = null;
   });
@@ -98,7 +119,7 @@ describe('organization.create.view — error surfacing (#4447)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     push.mockReset();
-    tokenMock.mockReset().mockResolvedValue();
+    resetTokenMockToSuccess();
     createOrganizationMock.mockReset().mockResolvedValue({ id: 'org-9' });
     authStoreMock.user = { id: 'u1' };
   });
@@ -172,5 +193,86 @@ describe('organization.create.view — error surfacing (#4447)', () => {
 
     expect(wrapper.vm.error).toBeNull();
     expect(push).toHaveBeenCalled();
+  });
+});
+
+// #4459 — token() never throws, so a transient blip after create() must not
+// navigate on the assumption the refresh succeeded: the app-router org-guard
+// would bounce the just-created org straight back to /organization-required.
+// Mirrors organizations.required.view.vue's refresh()/acceptInvitation()
+// currentOrganization check.
+describe('organization.create.view — soft-refresh guard (#4459)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    push.mockReset();
+    createOrganizationMock.mockReset().mockResolvedValue({ id: 'org-9' });
+    authStoreMock.user = { id: 'u1' }; // no currentOrganization → first org
+  });
+
+  it('stays on the page (no router push) when token() resolves without populating currentOrganization', async () => {
+    // token() swallows failures internally — simulate that here: it resolves,
+    // but the store's user still has no currentOrganization.
+    tokenMock.mockReset().mockResolvedValue();
+
+    const wrapper = mountView();
+    wrapper.vm.name = 'Acme';
+    await wrapper.vm.create();
+    await flushPromises();
+
+    expect(push).not.toHaveBeenCalled();
+    expect(wrapper.vm.error).toBeTruthy();
+    expect(wrapper.vm.pendingOrg).toEqual({ org: { id: 'org-9' }, isFirstOrg: true });
+    expect(wrapper.vm.loading).toBe(false);
+  });
+
+  it('still navigates when the soft refresh populates currentOrganization', async () => {
+    tokenMock.mockReset().mockImplementation(async () => {
+      authStoreMock.user = { ...authStoreMock.user, currentOrganization: 'org-9' };
+    });
+
+    const wrapper = mountView();
+    wrapper.vm.name = 'Acme';
+    await wrapper.vm.create();
+    await flushPromises();
+
+    expect(push).toHaveBeenCalledWith('/tasks');
+    expect(wrapper.vm.error).toBeNull();
+    expect(wrapper.vm.pendingOrg).toBeNull();
+  });
+
+  it('retryRefresh re-attempts the soft refresh and navigates without recreating the organization', async () => {
+    // First attempt: token() resolves but does not populate currentOrganization.
+    tokenMock.mockReset().mockResolvedValueOnce();
+
+    const wrapper = mountView();
+    wrapper.vm.name = 'Acme';
+    await wrapper.vm.create();
+    await flushPromises();
+
+    expect(push).not.toHaveBeenCalled();
+    expect(createOrganizationMock).toHaveBeenCalledTimes(1);
+
+    // Retry: this time the refresh succeeds.
+    tokenMock.mockImplementation(async () => {
+      authStoreMock.user = { ...authStoreMock.user, currentOrganization: 'org-9' };
+    });
+    await wrapper.vm.retryRefresh();
+    await flushPromises();
+
+    expect(createOrganizationMock).toHaveBeenCalledTimes(1); // organization not recreated
+    expect(push).toHaveBeenCalledWith('/tasks');
+    expect(wrapper.vm.error).toBeNull();
+    expect(wrapper.vm.pendingOrg).toBeNull();
+  });
+
+  it('retryRefresh is a no-op with no pendingOrg', async () => {
+    tokenMock.mockReset().mockResolvedValue();
+    const wrapper = mountView();
+
+    await wrapper.vm.retryRefresh();
+    await flushPromises();
+
+    expect(tokenMock).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/organizations/views/organization.create.view.vue
+++ b/src/modules/organizations/views/organization.create.view.vue
@@ -56,15 +56,16 @@
               <v-spacer></v-spacer>
               <v-btn variant="text" class="text-none text-body-medium mr-2" to="/users">Cancel</v-btn>
               <v-btn
-                :disabled="!valid || loading"
-                :loading="loading"
+                :disabled="pendingOrg ? retrying : (!valid || loading)"
+                :loading="pendingOrg ? retrying : loading"
                 color="primary"
                 variant="flat"
                 :class="config.vuetify.theme.rounded"
                 class="text-none text-body-medium"
-                @click="create"
+                data-test="organization-create-primary-action"
+                @click="handlePrimaryAction"
               >
-                Create Organization
+                {{ pendingOrg ? 'Retry' : 'Create Organization' }}
               </v-btn>
             </v-row>
           </v-form>
@@ -98,6 +99,25 @@ export default {
     };
   },
   methods: {
+    /**
+     * @desc Route the primary button's click. While a post-create soft-refresh
+     *       is pending (pendingOrg set — the organization already exists
+     *       server-side), always retry the refresh instead of creating again,
+     *       regardless of whether the error alert was dismissed in the meantime:
+     *       dismissing the alert only clears `error` (`@click:close` above), it
+     *       must never re-enable a second createOrganization() call for the same
+     *       pending org. Without this, dismissing the banner left the primary
+     *       "Create Organization" button pointed at create(), producing a
+     *       duplicate org on click (#4459 follow-up).
+     * @returns {Promise<void>}
+     */
+    async handlePrimaryAction() {
+      if (this.pendingOrg) {
+        await this.retryRefresh();
+        return;
+      }
+      await this.create();
+    },
     /**
      * @desc Validate the form and create the organization, then route the user:
      *       a first org (no current org yet) lands in the app via sign.route; an

--- a/src/modules/organizations/views/organization.create.view.vue
+++ b/src/modules/organizations/views/organization.create.view.vue
@@ -16,7 +16,21 @@
             closable
             @click:close="error = null"
           >
-            {{ error }}
+            <div class="d-flex align-center flex-wrap ga-2">
+              <span class="flex-grow-1">{{ error }}</span>
+              <v-btn
+                v-if="pendingOrg"
+                variant="tonal"
+                color="error"
+                size="small"
+                :class="config.vuetify.theme.rounded"
+                class="text-none"
+                :loading="retrying"
+                @click="retryRefresh"
+              >
+                Retry
+              </v-btn>
+            </div>
           </v-alert>
 
           <v-form ref="form" v-model="valid">
@@ -72,9 +86,14 @@ export default {
     return {
       valid: false,
       loading: false,
+      retrying: false,
       error: null,
       name: '',
       description: '',
+      // { org, isFirstOrg } captured when a post-create soft-refresh does not
+      // (yet) populate currentOrganization — lets retryRefresh() re-attempt
+      // the refresh without recreating the organization.
+      pendingOrg: null,
       rules: { required: (v) => (!!v && !!v.trim()) || 'Required' },
     };
   },
@@ -91,6 +110,7 @@ export default {
       if (form.valid) {
         this.loading = true;
         this.error = null;
+        this.pendingOrg = null;
         const organizationsStore = useOrganizationsStore();
         const authStore = useAuthStore();
         // No current org (a first org, or a management user who just deleted their
@@ -105,19 +125,61 @@ export default {
             description: this.description,
           });
           if (org) {
-            // Soft-refresh (token(), never throws) to pick up the new org context.
-            // refreshAbilities() signs out + rethrows on failure, which would eject
-            // a user who just created their org.
-            await authStore.token();
-            this.$router.push(
-              isFirstOrg ? this.config.sign.route : `/users/organizations/${org.id || org._id}`,
-            );
+            await this.refreshAndNavigate(authStore, org, isFirstOrg);
           }
         } catch (err) {
           this.error = err?.response?.data?.message || err?.message || 'Could not create organization. Please try again.';
         } finally {
           this.loading = false;
         }
+      }
+    },
+    /**
+     * @desc Soft-refresh the session (token(), never throws) to pick up the new
+     *       org context, then navigate — but only if the refresh actually
+     *       populated authStore.user.currentOrganization. token() swallows
+     *       failures internally, so a transient blip leaves currentOrganization
+     *       falsy; navigating anyway would have the app-router org-guard bounce
+     *       the just-created org back to /organization-required. refreshAbilities()
+     *       signs out + rethrows on failure, which would eject a user who just
+     *       created their org, so token() stays the right primitive here — this
+     *       guard just mirrors organizations.required.view.vue's refresh()/
+     *       acceptInvitation() currentOrganization check on its result instead of
+     *       assuming success. On a stalled refresh the organization already
+     *       exists server-side, so it is kept in pendingOrg for a manual retry
+     *       instead of being lost behind a generic error.
+     * @param {Object} authStore - The auth store instance.
+     * @param {Object} org - The just-created organization.
+     * @param {boolean} isFirstOrg - Captured before create(); see create() above.
+     * @returns {Promise<void>}
+     */
+    async refreshAndNavigate(authStore, org, isFirstOrg) {
+      await authStore.token();
+      if (!authStore.user?.currentOrganization) {
+        this.pendingOrg = { org, isFirstOrg };
+        this.error = 'Organization created, but we could not refresh your session. Please retry.';
+        return;
+      }
+      this.pendingOrg = null;
+      this.$router.push(
+        isFirstOrg ? this.config.sign.route : `/users/organizations/${org.id || org._id}`,
+      );
+    },
+    /**
+     * @desc Re-attempt the post-create soft refresh without recreating the
+     *       organization (it already exists server-side from the original create()).
+     * @returns {Promise<void>}
+     */
+    async retryRefresh() {
+      if (!this.pendingOrg || this.retrying) return;
+      this.retrying = true;
+      this.error = null;
+      const authStore = useAuthStore();
+      const { org, isFirstOrg } = this.pendingOrg;
+      try {
+        await this.refreshAndNavigate(authStore, org, isFirstOrg);
+      } finally {
+        this.retrying = false;
       }
     },
   },


### PR DESCRIPTION
## Summary

- What changed:
  - `organization.create.view.vue`: the post-create soft-refresh (`authStore.token()`) navigated unconditionally even though `token()` swallows failures. A transient blip left `authStore.user.currentOrganization` falsy, and the app-router org-guard bounced the just-created org back to `/organization-required`. The refresh now checks `currentOrganization` on its result before navigating; on a stall the already-created org is kept in `pendingOrg` and the primary button becomes "Retry" (re-attempts the refresh, never re-creates the org — including when the error banner is dismissed first).
  - `auth.store.js`: added a module-scope generation counter shared by `token()`, `refreshAbilities()`, and `signout()`. Both soft-refresh actions capture the generation before their network await; `signout()` bumps it synchronously before doing anything else. A soft-refresh continuation whose captured generation no longer matches (because a concurrent `signout()` ran while it was in flight) drops its state writes instead of resurrecting `auth=true`/`user`/localStorage right after the user signed out — including on `refreshAbilities()`'s reject path, which previously called `signout()` + rethrew even when the failure was just a side effect of that earlier signout.
- Why: two related races off `#4459` — `token()` never throws, so its silent failure needs an explicit `currentOrganization` check instead of being treated as success; and a soft-refresh in flight when the user signs out has no way to know it should discard its result.
- Related issues: Closes #4459

## Scope

- Modules impacted: `organizations` (create view), `auth` (store)
- Cross-module impact: `none` — the generation guard is internal to `auth.store.js`; the org-create change is local to that view.
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

Tests are state-based (no fake timers): `createOrganization` is asserted to be
called exactly once across create → stall → dismiss → retry, and the
signout-wins-the-race path asserts `auth`/`user`/localStorage stay cleared
when a stale `token()`/`refreshAbilities()` resolves after `signout()`. Full
suite: 2481 tests green (145 files).

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — no new endpoints, no credential handling changes.
- Mergeability considerations: none, additive changes to an existing view/store.
- Follow-up tasks (optional): the generation guard covers soft-refresh calls that were already in flight when `signout()` ran. It does not cover a soft-refresh call that *starts* during `signout()`'s own async window (e.g. a concurrent 401/403 interceptor retry firing while the `/signout` request is still pending) — that call captures the already-bumped generation and isn't guarded against resolving after `signout()` completes. Known narrow follow-up, out of this PR's scope.

https://claude.ai/code/session_01WfNC8bt1TgL4AsiYgCEGup
