### PR TITLE
fix(billing): config-source the upgrade-prompt pricing copy

### DIFF
--- a/src/modules/billing/components/billing.upgradePrompt.component.vue
+++ b/src/modules/billing/components/billing.upgradePrompt.component.vue
@@ -4,7 +4,7 @@
     <v-alert type="info" variant="tonal" prominent>
       <template #text>
         <p class="font-weight-bold mb-1">Your signup grant is depleted</p>
-        <p>You used your 500 compute one-shot grant. Buy a Boost pack to keep going, or upgrade for monthly compute.</p>
+        <p>{{ grantDepletedMessage }}</p>
       </template>
       <template #append>
         <div class="d-flex flex-column ga-2">
@@ -16,7 +16,7 @@
             class="text-none"
             to="/pricing#units"
           >
-            Buy Boost pack — $9
+            {{ packCtaLabel }}
           </v-btn>
           <v-btn
             data-test="cta-upgrade"
@@ -25,7 +25,7 @@
             class="text-none"
             to="/pricing"
           >
-            Upgrade Growth / Pro
+            {{ upgradeCtaLabel }}
           </v-btn>
         </div>
       </template>
@@ -70,6 +70,12 @@
  */
 import { useQuota } from '../composables/billing.useQuota';
 import { useBillingStore } from '../stores/billing.store.js';
+import { resolveStaticContent } from '../lib/billing.resolveStaticContent.js';
+
+// Static-content resolver call — same module-scope pattern as billing.subscriptions.component.vue.
+// config.billing.staticContent (project override) wins per key, devkit default otherwise —
+// see billing.resolveStaticContent.js for the resolution contract.
+const { packs: packsConfig, plans: plansConfig, signupGrant: signupGrantConfig } = resolveStaticContent();
 
 /**
  * Component definition.
@@ -173,6 +179,46 @@ export default {
      */
     displayLabel() {
       return this.label || `${this.resource} ${this.action}`;
+    },
+    /**
+     * @desc First pack from the resolved static content — the pack featured by the
+     * post-grant prompt's primary CTA. `null` when a project configures no packs.
+     * @returns {Object|null}
+     */
+    primaryPack() {
+      return packsConfig[0] || null;
+    },
+    /**
+     * @desc Post-grant depletion message, config-sourced (grant label + featured pack name).
+     * Devkit default: generic, numberless placeholder copy — no downstream product vocabulary.
+     * @returns {string}
+     */
+    grantDepletedMessage() {
+      const packPhrase = this.primaryPack ? `a ${this.primaryPack.title}` : 'a compute pack';
+      return `You used your ${signupGrantConfig.label}. Buy ${packPhrase} to keep going, or upgrade for monthly compute.`;
+    },
+    /**
+     * @desc Primary pack CTA label, config-sourced from the resolved pack's own `cta` +
+     * price (e.g. "{pack.cta} — {pack.price.amount}"). Falls back to a generic label
+     * when a project configures no packs.
+     * @returns {string}
+     */
+    packCtaLabel() {
+      if (!this.primaryPack) return 'Buy a compute pack';
+      const amount = this.primaryPack.price?.amount;
+      return amount ? `${this.primaryPack.cta} — ${amount}` : this.primaryPack.cta;
+    },
+    /**
+     * @desc Secondary upgrade CTA label, config-sourced from the non-free plan titles
+     * in the resolved static content (e.g. "Upgrade Starter / Pro"). Falls back to a
+     * bare "Upgrade" when no paid plans are configured.
+     * @returns {string}
+     */
+    upgradeCtaLabel() {
+      const paidPlanTitles = plansConfig
+        .filter((plan) => plan.id !== 'free' && plan.title)
+        .map((plan) => plan.title);
+      return paidPlanTitles.length > 0 ? `Upgrade ${paidPlanTitles.join(' / ')}` : 'Upgrade';
     },
   },
 };

--- a/src/modules/billing/components/billing.upgradePrompt.component.vue
+++ b/src/modules/billing/components/billing.upgradePrompt.component.vue
@@ -200,13 +200,14 @@ export default {
     /**
      * @desc Primary pack CTA label, config-sourced from the resolved pack's own `cta` +
      * price (e.g. "{pack.cta} — {pack.price.amount}"). Falls back to a generic label
-     * when a project configures no packs.
+     * when a project configures no packs, or when a configured pack omits `cta`.
      * @returns {string}
      */
     packCtaLabel() {
       if (!this.primaryPack) return 'Buy a compute pack';
+      const cta = this.primaryPack.cta || 'Buy a compute pack';
       const amount = this.primaryPack.price?.amount;
-      return amount ? `${this.primaryPack.cta} — ${amount}` : this.primaryPack.cta;
+      return amount ? `${cta} — ${amount}` : cta;
     },
     /**
      * @desc Secondary upgrade CTA label, config-sourced from the non-free plan titles

--- a/src/modules/billing/config/billing.static-content.js
+++ b/src/modules/billing/config/billing.static-content.js
@@ -20,6 +20,12 @@
  *   - plans        : Plan[]
  *   - packs        : Pack[]
  *   - faqs         : { title?: string, subtitle?: string, content: FAQ[] }
+ *   - signupGrant  : { label: string }
+ *                    Copy fragment for the meter-mode "signup grant depleted" prompt
+ *                    (billing.upgradePrompt.component.vue), e.g. used as
+ *                    `You used your ${signupGrant.label}.`. Structural key — an explicit
+ *                    `null` (or non-object) is coerced back to the devkit default, same as
+ *                    plans/packs/faqs, since the consumer reads `.label` unconditionally.
  *
  * Plan shape (V4 — unified with packs):
  *   {
@@ -245,6 +251,18 @@ export const faqs = {
 };
 
 /**
+ * @desc Copy fragment for the meter-mode signup-grant-depleted prompt
+ * (billing.upgradePrompt.component.vue). Downstream projects override via
+ * `config.billing.staticContent.signupGrant` to describe their own grant's size and
+ * unit, e.g. `{ label: '2,000-credit one-shot grant' }`. This devkit default stays
+ * generic — no specific quantity or product vocabulary.
+ * @type {{ label: string }}
+ */
+export const signupGrant = {
+  label: 'one-shot compute grant',
+};
+
+/**
  * @desc Configurable tab labels (used in 'both-tabs' mode).
  * This devkit default ships `plans: 'Plans'` / `units: 'Extras'`.
  * Downstream projects can override either or both labels per project.
@@ -283,6 +301,7 @@ export default {
     plans,
     packs,
     faqs,
+    signupGrant,
     tabs,
     header,
     halo,

--- a/src/modules/billing/lib/billing.resolveStaticContent.js
+++ b/src/modules/billing/lib/billing.resolveStaticContent.js
@@ -15,8 +15,8 @@
  *   - Structural collections (plans, packs): after presence resolution, coerce to devkit
  *     default when the resolved value is not an array. Prevents consumer .map()/.length
  *     crashes when a downstream explicitly sets the key to null or a non-array value.
- *   - Structural object (faqs): coerce to devkit default when the resolved value is not
- *     a non-null object. Prevents consumer property-access crashes on null.
+ *   - Structural object (faqs, signupGrant): coerce to devkit default when the resolved
+ *     value is not a non-null object. Prevents consumer property-access crashes on null.
  *   - Display-optional (pricingMode, tabs, header, halo): pure presence-check — explicit
  *     null is a legitimate suppression signal and consumers tolerate it gracefully.
  */
@@ -26,6 +26,7 @@ import {
   plans as dPlans,
   packs as dPacks,
   faqs as dFaqs,
+  signupGrant as dSignupGrant,
   tabs as dTabs,
   header as dHeader,
   halo as dHalo,
@@ -33,7 +34,7 @@ import {
 
 /**
  * @desc Resolve effective billing static content (project override or devkit default), per key.
- * @returns {{ pricingMode: string, plans: Array, packs: Array, faqs: object, tabs: object, header: object, halo: object|null }}
+ * @returns {{ pricingMode: string, plans: Array, packs: Array, faqs: object, signupGrant: {label: string}, tabs: object, header: object, halo: object|null }}
  */
 export function resolveStaticContent() {
   const o = config?.billing?.staticContent ?? {};
@@ -42,8 +43,9 @@ export function resolveStaticContent() {
   const rPlans = 'plans' in o ? o.plans : dPlans;
   const rPacks = 'packs' in o ? o.packs : dPacks;
 
-  // Structural object — coerce null/non-object to devkit default (crash-safe).
+  // Structural objects — coerce null/non-object to devkit default (crash-safe).
   const rFaqs = 'faqs' in o ? o.faqs : dFaqs;
+  const rSignupGrant = 'signupGrant' in o ? o.signupGrant : dSignupGrant;
 
   return {
     // Display-optional: pure presence-check — explicit null honored by consumers.
@@ -55,5 +57,6 @@ export function resolveStaticContent() {
     plans: Array.isArray(rPlans) ? rPlans : dPlans,
     packs: Array.isArray(rPacks) ? rPacks : dPacks,
     faqs: rFaqs && typeof rFaqs === 'object' ? rFaqs : dFaqs,
+    signupGrant: rSignupGrant && typeof rSignupGrant === 'object' ? rSignupGrant : dSignupGrant,
   };
 }

--- a/src/modules/billing/tests/billing.resolveStaticContent.unit.tests.js
+++ b/src/modules/billing/tests/billing.resolveStaticContent.unit.tests.js
@@ -27,6 +27,7 @@ describe('billing.resolveStaticContent', () => {
     expect(r.plans).toEqual(devkitDefaults.plans);
     expect(r.packs).toEqual(devkitDefaults.packs);
     expect(r.faqs).toEqual(devkitDefaults.faqs);
+    expect(r.signupGrant).toEqual(devkitDefaults.signupGrant);
     expect(r.tabs).toEqual(devkitDefaults.tabs);
     expect(r.header).toEqual(devkitDefaults.header);
     expect(r.halo).toEqual(devkitDefaults.halo);
@@ -39,6 +40,7 @@ describe('billing.resolveStaticContent', () => {
         plans: [{ id: 'x', title: 'X', features: [], meta: {} }],
         packs: [],
         faqs: { title: 'F', content: [] },
+        signupGrant: { label: 'custom grant label' },
         tabs: { plans: 'P', units: 'U' },
         header: { title: 'H', subtitle: 'S' },
         halo: null,
@@ -48,6 +50,7 @@ describe('billing.resolveStaticContent', () => {
     const r = resolveStaticContent();
     expect(r.pricingMode).toBe('subscription');
     expect(r.plans[0].id).toBe('x');
+    expect(r.signupGrant).toEqual({ label: 'custom grant label' });
     expect(r.header.title).toBe('H');
     expect(r.halo).toBeNull();
   });
@@ -74,5 +77,20 @@ describe('billing.resolveStaticContent', () => {
     const r = resolveStaticContent();
     expect(r.plans).toEqual(devkitDefaults.plans); // null → devkit default, not null
     expect(r.packs).toEqual(devkitDefaults.packs); // null → devkit default, not null
+  });
+
+  it('signupGrant set to null (or a non-object) falls back to devkit default (crash-safe)', async () => {
+    configMock.billing = { staticContent: { signupGrant: null } };
+    const { resolveStaticContent } = await load();
+    const r = resolveStaticContent();
+    expect(r.signupGrant).toEqual(devkitDefaults.signupGrant); // null → devkit default, not null
+  });
+
+  it('signupGrant override wins when present (per-key resolution, same as faqs)', async () => {
+    configMock.billing = { staticContent: { signupGrant: { label: 'downstream grant label' } } };
+    const { resolveStaticContent } = await load();
+    const r = resolveStaticContent();
+    expect(r.signupGrant).toEqual({ label: 'downstream grant label' });
+    expect(r.plans).toEqual(devkitDefaults.plans); // absent key still falls back
   });
 });

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
@@ -231,6 +231,13 @@ describe('BillingUpgradePrompt', () => {
   });
 
   describe('static-content resolution (issue #4460 — config-sourced pricing copy)', () => {
+    // Unmock unconditionally after every test in this block, pass or fail — a mock left
+    // active on assertion failure would leak into later tests' module-scope resolution.
+    afterEach(() => {
+      vi.doUnmock('../../../lib/services/config.js');
+      vi.resetModules();
+    });
+
     /**
      * Dynamically re-import the resolver + component after mocking the underlying
      * config service, so the module-scope `resolveStaticContent()` call picks up the
@@ -270,8 +277,6 @@ describe('BillingUpgradePrompt', () => {
       expect(text).toContain('Custom Test Pack');
       expect(text).toContain('$42.00');
       expect(text).toContain('Ultra');
-      vi.doUnmock('../../../lib/services/config.js');
-      vi.resetModules();
     });
   });
 });

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
@@ -131,7 +131,7 @@ describe('BillingUpgradePrompt', () => {
       expect(wrapper.text()).toMatch(/signup grant.*depleted|free compute.*used up/i);
     });
 
-    it('renders Boost pack CTA first (primary) in post-grant variant', () => {
+    it('renders the primary pack CTA first, config-sourced from the resolved static content', () => {
       const wrapper = mountWithStore({
         subscription: { plan: 'free' },
         extrasBalance: { balance: 0 },
@@ -139,8 +139,8 @@ describe('BillingUpgradePrompt', () => {
       });
       const packBtn = wrapper.find('[data-test="cta-pack"]');
       expect(packBtn.exists()).toBe(true);
-      expect(packBtn.text()).toMatch(/boost|pack/i);
-      // Post-grant Boost-pack CTA routes to the single billing entry point, not a modal event.
+      expect(packBtn.text()).toMatch(/pack/i);
+      // Post-grant pack CTA routes to the single billing entry point, not a modal event.
       expect(wrapper.findComponent('[data-test="cta-pack"]').props('to')).toBe('/pricing#units');
     });
 
@@ -209,6 +209,69 @@ describe('BillingUpgradePrompt', () => {
       expect(wrapper.text()).not.toMatch(/signup grant.*depleted/i);
       // Regular prompt still shows
       expect(wrapper.text()).toMatch(/requires the|Upgrade/i);
+    });
+
+    it('devkit default renders generic placeholder copy — no downstream-specific product literal', () => {
+      const wrapper = mountWithStore({
+        subscription: { plan: 'free' },
+        extrasBalance: { balance: 0 },
+        extrasLedger: { entries: [{ source: 'signup_grant', amount: 500 }], total: 1, page: 1, limit: 20 },
+      });
+      const text = wrapper.text();
+      // Devkit generic default — numberless grant label, generic pack/plan names sourced
+      // from billing.static-content.js, not any real consumer's economics. (The rendered
+      // "$9.00" is the devkit's OWN generic demo pack price — same placeholder used
+      // module-wide, e.g. billing.subscriptions.component.vue — not a leaked literal;
+      // the component source itself no longer hardcodes any price.)
+      expect(text).toMatch(/one-shot compute grant/i);
+      expect(text).not.toMatch(/\bboost\b/i);
+      expect(text).not.toMatch(/\bgrowth\b/i);
+      expect(text).not.toContain('500 compute');
+    });
+  });
+
+  describe('static-content resolution (issue #4460 — config-sourced pricing copy)', () => {
+    /**
+     * Dynamically re-import the resolver + component after mocking the underlying
+     * config service, so the module-scope `resolveStaticContent()` call picks up the
+     * per-test override. Mirrors the pattern in billing.resolveStaticContent.unit.tests.js.
+     * @param {Object} staticContent - Value to install at config.billing.staticContent.
+     * @returns {Promise<{Component: Object, useBillingStore: Function}>}
+     */
+    async function loadWithConfig(staticContent) {
+      vi.resetModules();
+      vi.doMock('../../../lib/services/config.js', () => ({
+        default: { billing: { staticContent } },
+      }));
+      const { default: Component } = await import('../components/billing.upgradePrompt.component.vue');
+      const storeModule = await import('../stores/billing.store.js');
+      return { Component, useBillingStore: storeModule.useBillingStore };
+    }
+
+    it('renders copy DRIVEN by the resolved static content — changing config changes the rendered copy', async () => {
+      const { Component, useBillingStore: useStore } = await loadWithConfig({
+        signupGrant: { label: 'custom test grant' },
+        packs: [{ id: 'x', title: 'Custom Test Pack', cta: 'Buy Custom Test Pack', price: { amount: '$42.00', period: null } }],
+        plans: [{ id: 'free', title: 'Free' }, { id: 'ultra', title: 'Ultra' }],
+      });
+      setActivePinia(createPinia());
+      const store = useStore();
+      Object.assign(store, {
+        subscription: { plan: 'free' },
+        extrasBalance: { balance: 0 },
+        extrasLedger: { entries: [{ source: 'signup_grant', amount: 500 }], total: 1, page: 1, limit: 20 },
+      });
+      const wrapper = mount(Component, {
+        props: { requiredPlan: 'ultra', mode: 'meter' },
+        global: { plugins: [vuetify], stubs: { RouterLink: true } },
+      });
+      const text = wrapper.text();
+      expect(text).toContain('custom test grant');
+      expect(text).toContain('Custom Test Pack');
+      expect(text).toContain('$42.00');
+      expect(text).toContain('Ultra');
+      vi.doUnmock('../../../lib/services/config.js');
+      vi.resetModules();
     });
   });
 });


### PR DESCRIPTION
## Summary

- What changed: `billing.upgradePrompt.component.vue` (post-grant, meter-mode variant) previously hardcoded downstream product economics directly in the public devkit component — grant size, pack price + CTA copy, and plan names. This PR config-sources every one of those literals from the static-content resolver instead: three new computed properties (`grantDepletedMessage`, `packCtaLabel`, `upgradeCtaLabel`) derive their copy from `resolveStaticContent()` (`config.billing.staticContent`), the same pattern already used by `billing.subscriptions.component.vue`. A new `signupGrant.label` schema field was added to `billing.static-content.js` / `billing.resolveStaticContent.js` (structural key, coerced to the devkit default on invalid override, consistent with `faqs`) to carry the grant-size copy fragment. The devkit default copy ships generic and numberless — no specific product vocabulary.
- Why: the shared component lived in the public open-source devkit repo but baked in one consumer's specific product numbers and plan names. Any other downstream mounting this component would show wrong pricing/marketing copy, and the public repo should never carry a specific consumer's product economics.
- Related issues: Closes #4460

## Scope

- Modules impacted: `billing` (component, static-content config, resolver)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

Tests are config-driven red/green (asserting the rendered copy actually changes when `config.billing.staticContent` is overridden, not just that it renders) plus a devkit-default-generic assertion (no downstream-specific product literal survives in the default copy). Full suite: 2491 tests / 145 files green. Build green.

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — pure copy/config sourcing change, no new data flow.
- Mergeability considerations: additive schema field (`signupGrant`) with a coercion-to-default fallback, so existing downstream `config.billing.staticContent` overrides that don't set it keep working unchanged.
- Follow-up tasks (optional): none.

https://claude.ai/code/session_01WfNC8bt1TgL4AsiYgCEGup
