### PR TITLE
fix(core): wire the computed theme into Vuetify so auto dark-mode works

### DIFF
--- a/src/lib/plugins/vuetify.js
+++ b/src/lib/plugins/vuetify.js
@@ -6,12 +6,20 @@ import '@fortawesome/fontawesome-free/css/all.css';
 import { createVuetify } from 'vuetify';
 import { aliases, fa } from 'vuetify/lib/iconsets/fa';
 import config from '../../config/index.js';
+import { isDark } from '../helpers/theme.js';
 
 /**
  * Vuetify configuration.
+ * `defaultTheme` seeds the initial paint from the resolved config/OS
+ * preference so there is no light-theme flash before `app.vue`'s
+ * `coreStore.theme` watch fires (#4462). `coreStore.theme` stays the single
+ * source of truth once the app mounts — this only covers the pre-mount paint.
  */
 export default createVuetify({
-  theme: config.vuetify.theme,
+  theme: {
+    ...config.vuetify.theme,
+    defaultTheme: isDark(config.vuetify.theme.dark) ? 'dark' : 'light',
+  },
   icons: {
     defaultSet: config.vuetify.icons.defaultSet,
     aliases,

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app id="app" :theme="themeName">
+  <v-app id="app">
     <v-snackbar
       v-if="config.vuetify.theme.snackbar.status"
       v-model="snackbar.status"
@@ -57,6 +57,7 @@ import { useTheme } from 'vuetify';
 import { buildCanonicalUrl } from '@/lib/helpers/canonical.js';
 import { useAuthStore } from '../auth/stores/auth.store';
 import { useBillingStore } from '../billing/stores/billing.store';
+import { useCoreStore } from '../core/stores/core.store';
 import { setupInterceptors } from '../../lib/services/axios';
 import devkitHeader from '../core/components/core.header.component.vue';
 import devkitNav from '../core/components/core.navigation.component.vue';
@@ -90,14 +91,15 @@ export default {
   },
   /**
    * @desc Initialise Pinia stores once so computed properties reference them
-   * via `this.authStore` / `this.billingStore` instead of calling the store
-   * factory on every evaluation.
-   * @returns {{ authStore: Object, billingStore: Object }}
+   * via `this.authStore` / `this.billingStore` / `this.coreStore` instead of
+   * calling the store factory on every evaluation.
+   * @returns {{ authStore: Object, billingStore: Object, coreStore: Object }}
    */
   setup() {
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
-    return { authStore, billingStore };
+    const coreStore = useCoreStore();
+    return { authStore, billingStore, coreStore };
   },
   data() {
     const theme = useTheme();
@@ -130,9 +132,6 @@ export default {
     };
   },
   computed: {
-    themeName() {
-      return this.theme.name;
-    },
     isLoggedIn() {
       return this.authStore.isLoggedIn;
     },
@@ -186,6 +185,23 @@ export default {
     },
   },
   watch: {
+    /**
+     * @desc Push the Pinia-computed theme (config `vuetify.theme.dark` value,
+     * re-derived on OS `prefers-color-scheme` change via `coreStore.syncOsTheme()`
+     * — see `main.js`) into Vuetify's global theme instance. `coreStore.theme`
+     * is the single source of truth; Vuetify itself has no independent notion
+     * of "current theme" beyond what this sets. `immediate: true` applies it
+     * on initial mount (covers hydration + prerender correction); the watch
+     * covers subsequent OS preference changes.
+     * @param {String} v - 'light' or 'dark'
+     * @returns {void}
+     */
+    'coreStore.theme': {
+      immediate: true,
+      handler(v) {
+        this.theme.global.name.value = v;
+      },
+    },
     /**
      * @desc Fire a warning toast once per week cycle when meter crosses 80 % / 100 %.
      * Uses `meterAlertedKeys` set to dedup — key format: `"{weekKey}:{level}"`.

--- a/src/modules/app/app.vue
+++ b/src/modules/app/app.vue
@@ -192,14 +192,17 @@ export default {
      * is the single source of truth; Vuetify itself has no independent notion
      * of "current theme" beyond what this sets. `immediate: true` applies it
      * on initial mount (covers hydration + prerender correction); the watch
-     * covers subsequent OS preference changes.
+     * covers subsequent OS preference changes. Uses `theme.change()` (the
+     * sanctioned Vuetify 4 API) rather than assigning `theme.global.name.value`
+     * directly — the latter trips a deprecation warning via Vuetify's Proxy
+     * set trap on 4.1.5+.
      * @param {String} v - 'light' or 'dark'
      * @returns {void}
      */
     'coreStore.theme': {
       immediate: true,
       handler(v) {
-        this.theme.global.name.value = v;
+        this.theme.change(v);
       },
     },
     /**

--- a/src/modules/app/tests/app.vue.unit.tests.js
+++ b/src/modules/app/tests/app.vue.unit.tests.js
@@ -10,13 +10,18 @@ const useHeadMock = vi.hoisted(() => vi.fn());
 vi.mock('@unhead/vue', () => ({ useHead: useHeadMock }));
 
 // Mock vuetify composables. `global.name` mirrors real Vuetify's useTheme()
-// shape (a mutable ref-like holder) so the app.vue theme watch can assign
-// `.value` on it — see the "theme wiring" describe block below (#4462).
+// shape (a mutable ref-like holder); `change()` mirrors the sanctioned
+// Vuetify 4 API the app.vue theme watch calls, updating `global.name.value`
+// as its real counterpart does — see the "theme wiring" describe block below
+// (#4462).
 vi.mock('vuetify', () => ({
   useTheme: () => ({
     name: 'light',
     current: { colors: { background: '#ffffff' } },
     global: { name: { value: 'light' } },
+    change(v) {
+      this.global.name.value = v;
+    },
   }),
 }));
 

--- a/src/modules/app/tests/app.vue.unit.tests.js
+++ b/src/modules/app/tests/app.vue.unit.tests.js
@@ -1,17 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
 import testConfig from '../../../config/defaults/test.config.js';
+import { useCoreStore } from '../../core/stores/core.store';
 
 // Mock @unhead/vue to capture useHead calls
 const useHeadMock = vi.hoisted(() => vi.fn());
 vi.mock('@unhead/vue', () => ({ useHead: useHeadMock }));
 
-// Mock vuetify composables
+// Mock vuetify composables. `global.name` mirrors real Vuetify's useTheme()
+// shape (a mutable ref-like holder) so the app.vue theme watch can assign
+// `.value` on it — see the "theme wiring" describe block below (#4462).
 vi.mock('vuetify', () => ({
   useTheme: () => ({
     name: 'light',
     current: { colors: { background: '#ffffff' } },
+    global: { name: { value: 'light' } },
   }),
 }));
 
@@ -236,5 +241,68 @@ describe('App.vue — SEO (useHead)', () => {
       mountApp(config);
       expect(resolveHead().script).toBeUndefined();
     });
+  });
+});
+
+describe('App.vue — theme wiring (#4462)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useHeadMock.mockClear();
+  });
+
+  /**
+   * @desc Mount App with a minimal config. Uses the real (un-mocked)
+   * `useCoreStore` so `coreStore.theme` is genuinely reactive — assigning
+   * `coreStore.theme` directly exercises the same reactivity path
+   * `syncOsTheme()` / `init()` use at runtime, without pulling in the config
+   * plumbing those actions depend on (already covered by
+   * `core.store.unit.tests.js`). This suite only proves the wiring: does
+   * app.vue's watch push `coreStore.theme` into Vuetify's global theme.
+   * @returns {import('@vue/test-utils').VueWrapper} Mounted wrapper
+   */
+  const mountApp = () => {
+    const config = {
+      ...makeConfig(),
+      vuetify: { theme: { snackbar: { status: false }, navigation: {} } },
+      header: { display: false },
+      footer: { links: [], variant: 'default' },
+    };
+    return mount(App, {
+      global: {
+        mocks: { config, $route: { path: '/' } },
+        stubs: { RouterView: true, 'v-app': true, 'v-snackbar': true, 'v-main': true },
+      },
+    });
+  };
+
+  it('applies coreStore.theme to the Vuetify global theme on mount (immediate)', () => {
+    const coreStore = useCoreStore();
+    coreStore.theme = 'dark';
+
+    const wrapper = mountApp();
+
+    expect(wrapper.vm.theme.global.name.value).toBe('dark');
+  });
+
+  it('defaults to the light Vuetify theme on mount when coreStore.theme is light', () => {
+    const coreStore = useCoreStore();
+    coreStore.theme = 'light';
+
+    const wrapper = mountApp();
+
+    expect(wrapper.vm.theme.global.name.value).toBe('light');
+  });
+
+  it('flips the Vuetify theme when coreStore.theme changes after mount', async () => {
+    const coreStore = useCoreStore();
+    coreStore.theme = 'light';
+
+    const wrapper = mountApp();
+    expect(wrapper.vm.theme.global.name.value).toBe('light');
+
+    coreStore.theme = 'dark';
+    await nextTick();
+
+    expect(wrapper.vm.theme.global.name.value).toBe('dark');
   });
 });


### PR DESCRIPTION
## Summary

- What changed: `app.vue` now drives Vuetify's theme by calling `theme.change(coreStore.theme)` inside an `{ immediate: true }` watch, replacing the old self-referential `themeName` computed that echoed Vuetify's own `useTheme().name` back into `<v-app :theme>` (a no-op). `vuetify.js` now seeds `defaultTheme` from the resolved config/OS preference so there's no light-theme flash before the watch fires on mount. The redundant `:theme="themeName"` prop is dropped from `<v-app>`.
- Why: `config.vuetify.theme.dark: 'auto'` was dead-wired. `core.store.js`'s `syncOsTheme()` correctly computed `coreStore.theme` from `isDark(config.vuetify.theme.dark)` and `main.js` wired a real `matchMedia` listener to keep it live — but nothing read `coreStore.theme` back into Vuetify. The app stayed light regardless of config or OS setting.
- Related issues: Closes #4462

## Scope

- Modules impacted: `app` (`app.vue`), `lib/plugins` (`vuetify.js`)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable)

**Tests note** — `app.vue.unit.tests.js` adds a "theme wiring (#4462)" suite using the real (un-mocked) Pinia `coreStore` so `coreStore.theme` is genuinely reactive; assertions are state-based (`wrapper.vm.theme.global.name.value`) rather than mechanism-based, covering initial mount (`immediate`) and post-mount flips. Also updated the theme watch to call `theme.change(v)` instead of assigning `theme.global.name.value` directly — Vuetify 4.1.5's Proxy set trap deprecates the latter in favor of `theme.change()` (same synchronous effect, adds theme-name validation, no console noise); the test mock's `change()` mirrors the real API's effect on `global.name.value` so the existing state-based assertions still hold. Full suite: 2494 tests green, build green.

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: none
- Follow-up tasks (optional): none

https://claude.ai/code/session_01WfNC8bt1TgL4AsiYgCEGup
