### PR TITLE
feat(ui): config-overridable loader, plan-badge set, and copy strings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,7 +105,10 @@ jobs:
           DEVKIT_NODE_cors_origin: '[http://localhost:8080]'
           DEVKIT_NODE_cors_credentials: "true"
       - name: Wait for Node backend
-        run: npx wait-on http://127.0.0.1:3000/api/home --timeout 60000 || (echo "--- Node backend logs ---"; cat /tmp/node-backend.log; exit 1)
+        # Poll /api/health (the real readiness route). /api/home was never a route —
+        # it only returned 2xx via the unmatched-route fallback; the content-negotiated
+        # 404 change made it return 404, so wait-on polled a permanent 404 until timeout.
+        run: npx wait-on http://127.0.0.1:3000/api/health --timeout 300000 || (echo "--- Node backend logs ---"; cat /tmp/node-backend.log; echo "--- curl /api/health ---"; curl -sv --max-time 10 http://127.0.0.1:3000/api/health 2>&1 | head -30; exit 1)
 
       # Install & start Vue dev server
       - name: Install Vue

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,23 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## config-ui-hooks: overridable loader, plan-badge set, and copy strings (2026-07-18, #4474)
+
+Three previously-hardcoded UI spots became config-overridable so a downstream project can rebrand/reconfigure them without editing the stack view (which caused byte-drift on every `/update-stack`). All three are no-ops for downstreams that don't opt in — every key is absent/null by default and every consumer falls back to the exact current behavior.
+
+### What changed (this repo)
+
+- **Loader** (new `config.ui.loader.component`, default `null`): new `CoreAppSpinner` component (`src/modules/core/components/core.appSpinner.component.vue`) renders the built-in `v-progress-circular` by default, or a project-provided loader SFC resolved via an `import.meta.glob` filename convention (`/src/modules/*/components/**/*.loader.component.vue`) when the config key is set — config values can only be strings, so the override is a Vite path, not a component reference. The 6 hardcoded `v-progress-circular` loading-state usages (auth token view, docs article/home/reference views, billing subscriptions + account view) now render `<AppSpinner>`, passing color/size/data-test through via Vue's automatic attribute fallthrough.
+- **Plan badge** (new `config.billing.planBadge.plans` / `config.billing.planBadge.fallbackColor`, both absent by default): `billing.planBadge.component.vue`'s hardcoded allowed-ids + color map (`free/starter/pro/enterprise`) is now the devkit default only, overridable by an ordered `{ id, color }[]` array (a downstream override fully replaces the set — `generateConfig`'s deepMerge replaces arrays wholesale, it does not union them).
+- **Copy** (new `config.billing.meterPeriodWord`, `config.billing.freePlanBlurb`, `config.app.itemNoun`, all absent by default): three hardcoded strings (the meter-period word in the upgrade-prompt copy, the free-plan upgrade blurb, and the "projects" noun in the workspace-setup helper text) now read `this.config?.X ?? currentDefault`. None of the three keys are seeded in any config fragment, so the generated `src/config/index.js` stays byte-identical.
+
+### Action required for downstream projects (`/update-stack`)
+
+1. All files are devkit-owned → arrive via `/update-stack`. No action required — every key defaults to today's exact behavior.
+2. To customize: add any of `ui.loader.component`, `billing.planBadge.{plans,fallbackColor}`, `billing.meterPeriodWord`, `billing.freePlanBlurb`, `app.itemNoun` to your `src/config/defaults/<project>.config.js` (or a per-module `<module>.<project>.config.js` fragment). A custom loader SFC ships inside your own project module (e.g. `src/modules/<project>/components/<project>.loader.component.vue`) and is referenced by its literal absolute-from-root Vite path.
+
+---
+
 ## docs: Redoc /api/docs reference UI decommissioned (2026-06-17, #4333)
 
 The docs module's in-theme OpenAPI reference (`/docs/api`) renders the merged spec at `GET /api/spec.json` natively — it is now the **only** reference surface. The dead "Open in Redoc" affordance (a header button + an empty-state fallback link, both pointing at the decommissioned backend `/api/docs` Redoc UI) has been removed.

--- a/src/config/defaults/development.config.js
+++ b/src/config/defaults/development.config.js
@@ -101,4 +101,16 @@ export default {
       capturePageleave: false, // opt-in: capture page-leave events
     },
   },
+  ui: {
+    loader: {
+      component: null, // Vite path of a custom loader SFC matching /src/modules/*/components/**/*.loader.component.vue; null = built-in v-progress-circular (see CoreAppSpinner)
+    },
+  },
+  // Config-driven copy — intentionally absent here (each consumer falls back to its
+  // current hardcoded default via `config.X ?? default`), so the generated config stays
+  // byte-identical until a downstream opts in via `src/config/defaults/<project>.config.js`:
+  //   app.itemNoun              — noun for the items a workspace groups, default 'projects'
+  //   billing.meterPeriodWord   — billing period word in meter-mode upgrade copy, default 'monthly'
+  //   billing.freePlanBlurb     — full free-plan upgrade paragraph (see billing.subscriptions.component.vue)
+  //   billing.planBadge.plans / billing.planBadge.fallbackColor — see billing.planBadge.component.vue
 };

--- a/src/modules/auth/components/organizationSetup.component.vue
+++ b/src/modules/auth/components/organizationSetup.component.vue
@@ -6,7 +6,7 @@
           <v-icon icon="fa-solid fa-building" size="x-large" color="primary" class="mb-4"></v-icon>
           <h3 class="text-headline-small font-weight-bold mb-2">Set up your workspace</h3>
           <p class="text-body-medium text-medium-emphasis">
-            A workspace keeps your projects and teammates together — create one or join an existing organization to get started.
+            A workspace keeps your {{ itemNoun }} and teammates together — create one or join an existing organization to get started.
           </p>
         </div>
 
@@ -140,6 +140,16 @@ export default {
         required: (v) => (!!v && !!v.trim()) || 'Organization name is required',
       },
     };
+  },
+  computed: {
+    /**
+     * @desc Noun for the items a workspace groups (e.g. "projects"), config-overridable
+     * app-wide vocabulary.
+     * @returns {string}
+     */
+    itemNoun() {
+      return this.config?.app?.itemNoun ?? 'projects';
+    },
   },
   methods: {
     /**

--- a/src/modules/auth/tests/auth.organizationSetup.component.unit.tests.js
+++ b/src/modules/auth/tests/auth.organizationSetup.component.unit.tests.js
@@ -35,14 +35,15 @@ const makeFormStub = (valid = true) => ({
  * Mount the organization setup component with Vuetify and stubbed form.
  * @param {object} formStub - VForm component definition controlling validation outcome.
  * @param {object} props - Component props (e.g. suggestedOrganization).
+ * @param {object} [config] - `this.config` override (defaults to the shared mockConfig).
  * @returns {import('@vue/test-utils').VueWrapper} mounted wrapper
  */
-const mountComponent = (formStub = makeFormStub(), props = {}) =>
+const mountComponent = (formStub = makeFormStub(), props = {}, config = mockConfig) =>
   mount(AuthOrganizationSetupComponent, {
     props,
     global: {
       plugins: [createVuetify()],
-      mocks: { config: mockConfig },
+      mocks: { config },
       stubs: { VForm: formStub },
     },
   });
@@ -285,5 +286,23 @@ describe('auth.organizationSetup.component', () => {
     await wrapper.vm.requestJoin();
 
     expect(createJoinRequestMock).not.toHaveBeenCalled();
+  });
+
+  // --- config-driven item noun (#4474) ---
+
+  it('defaults the workspace helper text to "projects" when config.app.itemNoun is unset', async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('keeps your projects and teammates together');
+  });
+
+  it('uses the configured item noun in the workspace helper text', async () => {
+    const overrideConfig = { ...mockConfig, app: { itemNoun: 'boards' } };
+    const wrapper = mountComponent(makeFormStub(), {}, overrideConfig);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('keeps your boards and teammates together');
+    expect(wrapper.text()).not.toContain('keeps your projects and teammates together');
   });
 });

--- a/src/modules/auth/views/token.view.vue
+++ b/src/modules/auth/views/token.view.vue
@@ -4,7 +4,7 @@
       <v-card class="mt-8 pa-8" width="100%" :style="{ background: theme.current.colors.surface }" :flat="config.vuetify.theme.flat">
         <template v-if="loading">
           <v-col cols="12" class="text-center py-8">
-            <v-progress-circular indeterminate color="primary" size="48" />
+            <AppSpinner color="primary" size="48" />
             <p class="mt-4">Signing you in…</p>
           </v-col>
         </template>
@@ -44,6 +44,7 @@
 import { useTheme } from 'vuetify';
 import { useAuthStore } from '../stores/auth.store';
 import { createLogger } from '../../../lib/helpers/logger';
+import AppSpinner from '../../core/components/core.appSpinner.component.vue';
 
 const logger = createLogger('auth');
 
@@ -60,6 +61,9 @@ function asNonEmptyString(value) {
  * Component definition.
  */
 export default {
+  components: {
+    AppSpinner,
+  },
   data() {
     const theme = useTheme();
     return {

--- a/src/modules/billing/README.md
+++ b/src/modules/billing/README.md
@@ -50,6 +50,24 @@ Auto-colored progress bar (green/orange/red). Shows "Unlimited" for uncapped pla
 <BillingPlanBadgeComponent :plan="currentPlan" />
 ```
 
+Allowed plan ids + chip colors default to `free`/`starter`/`pro`/`enterprise`. A
+downstream project can replace the whole set via config — the array replaces
+(does not merge with) the devkit default, so a downstream fully owns its plan
+vocabulary:
+
+```js
+// src/config/defaults/<project>.config.js
+billing: {
+  planBadge: {
+    plans: [
+      { id: 'team', color: 'info' },
+      { id: 'scale', color: 'error' },
+    ],
+    fallbackColor: 'grey', // color for a `plan` prop value not in `plans` (optional, default 'grey')
+  },
+},
+```
+
 ### `<BillingNavComputeGaugeComponent>`
 
 Sidenav compute-usage indicator (meter mode). A color-coded ring + `X% used`

--- a/src/modules/billing/components/billing.planBadge.component.vue
+++ b/src/modules/billing/components/billing.planBadge.component.vue
@@ -11,11 +11,42 @@
 
 <script>
 /**
- * Validate supported billing plan identifiers.
+ * Module dependencies.
+ */
+import config from '../../../lib/services/config';
+
+/**
+ * Devkit default plan set — { id, color } pairs, ordered.
+ * MUST NEVER be declared in any config fragment/defaults file: it lives here so the
+ * generated config stays byte-identical, and so a downstream `billing.planBadge.plans`
+ * array fully replaces this set (generateConfig's deepMerge REPLACES arrays wholesale —
+ * it does not union them, so a devkit default landing in a config layer would let a
+ * downstream shrink but never fully own the allowed set).
+ */
+const DEFAULT_PLANS = [
+  { id: 'free', color: 'grey' },
+  { id: 'starter', color: 'primary' },
+  { id: 'pro', color: 'secondary' },
+  { id: 'enterprise', color: 'warning' },
+];
+
+/**
+ * Resolve the effective plan definitions — a project override (config.billing.planBadge.plans)
+ * when present and non-empty, otherwise the devkit default. A lazy accessor (not a module-eval
+ * snapshot) so config can be mocked/mutated per test.
+ * @returns {Array<{id: string, color: string}>}
+ */
+const planDefinitions = () => {
+  const plans = config?.billing?.planBadge?.plans;
+  return Array.isArray(plans) && plans.length ? plans : DEFAULT_PLANS;
+};
+
+/**
+ * Validate supported billing plan identifiers against the resolved (config-aware) plan set.
  * @param {string} value Plan identifier.
  * @returns {boolean} True when the identifier is allowed.
  */
-const isAllowedPlan = (value) => ['free', 'starter', 'pro', 'enterprise'].includes(value);
+const isAllowedPlan = (value) => planDefinitions().some((definition) => definition && definition.id === value);
 
 /**
  * Component definition.
@@ -31,17 +62,14 @@ export default {
   },
   computed: {
     /**
-     * @desc Map plan name to Vuetify theme color.
+     * @desc Map plan name to Vuetify theme color, from the resolved (config-aware) plan set.
+     * Falls back to config.billing.planBadge.fallbackColor, then 'grey', for a plan id
+     * that isn't in the resolved set.
      * @returns {string} Vuetify color name
      */
     color() {
-      const colors = {
-        free: 'grey',
-        starter: 'primary',
-        pro: 'secondary',
-        enterprise: 'warning',
-      };
-      return colors[this.plan] || 'grey';
+      const definition = planDefinitions().find((d) => d && d.id === this.plan);
+      return (definition && definition.color) || config?.billing?.planBadge?.fallbackColor || 'grey';
     },
   },
 };

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -59,7 +59,7 @@
 
     <!-- ── Loading ──────────────────────────────────────────────────────── -->
     <v-row v-if="fetchLoading" justify="center" class="py-10">
-      <v-progress-circular indeterminate color="primary" />
+      <AppSpinner color="primary" />
     </v-row>
 
     <!-- ── P1-1: Subscription fetch error ─────────────────────────────── -->
@@ -111,7 +111,7 @@
               </div>
             </div>
             <p class="text-body-medium text-medium-emphasis mb-6">
-              You're on the free plan. Upgrade to unlock more projects, team members, and advanced features.
+              {{ freePlanBlurb }}
             </p>
             <v-btn
               color="primary"
@@ -302,6 +302,7 @@ import BillingMeterProgressComponent from './billing.meterProgress.component.vue
 import BillingMeterBreakdownChartComponent from './billing.meterBreakdownChart.component.vue';
 import BillingExtrasLedgerComponent from './billing.extrasLedger.component.vue';
 import BillingExtrasCheckoutModalComponent from './billing.extrasCheckoutModal.component.vue';
+import AppSpinner from '../../core/components/core.appSpinner.component.vue';
 
 const { plans: plansConfig, packs: packsConfig } = resolveStaticContent();
 
@@ -316,6 +317,7 @@ export default {
     BillingMeterBreakdownChartComponent,
     BillingExtrasLedgerComponent,
     BillingExtrasCheckoutModalComponent,
+    AppSpinner,
   },
   /**
    * @desc Wires billingStore + authStore + reactive meterMode + useMeter derived refs.
@@ -403,6 +405,18 @@ export default {
     },
     fetchLoading() {
       return this.billingStore.loading;
+    },
+    /**
+     * @desc Free-plan upgrade blurb, config-overridable. Devkit default: exact current
+     * copy (full paragraph, not just the second sentence) so a downstream missing a
+     * feature (e.g. no team members) can rewrite the whole thing.
+     * @returns {string}
+     */
+    freePlanBlurb() {
+      return (
+        this.config?.billing?.freePlanBlurb ??
+        "You're on the free plan. Upgrade to unlock more projects, team members, and advanced features."
+      );
     },
     subscription() {
       return this.billingStore.subscription;

--- a/src/modules/billing/components/billing.upgradePrompt.component.vue
+++ b/src/modules/billing/components/billing.upgradePrompt.component.vue
@@ -36,7 +36,7 @@
   <v-alert v-else type="info" variant="tonal" prominent class="my-4">
     <template #text>
       <span v-if="hasUsageInfo">{{ `You've used ${current} of ${limit} ${displayLabel}.` }}</span>
-      <span v-else-if="mode === 'meter'">You're out of compute. Buy more units or upgrade for monthly compute.</span>
+      <span v-else-if="mode === 'meter'">{{ `You're out of compute. Buy more units or upgrade for ${meterPeriodWord} compute.` }}</span>
       <span v-else>{{ `This feature requires the ${requiredPlan} plan.` }}</span>
     </template>
     <template #append>
@@ -195,7 +195,16 @@ export default {
      */
     grantDepletedMessage() {
       const packPhrase = this.primaryPack ? `a ${this.primaryPack.title}` : 'a compute pack';
-      return `You used your ${signupGrantConfig.label}. Buy ${packPhrase} to keep going, or upgrade for monthly compute.`;
+      return `You used your ${signupGrantConfig.label}. Buy ${packPhrase} to keep going, or upgrade for ${this.meterPeriodWord} compute.`;
+    },
+    /**
+     * @desc Billing period word used in the meter-mode upgrade copy (e.g. "monthly").
+     * Config-overridable so a downstream on a different billing period can rebrand this
+     * without editing the view.
+     * @returns {string}
+     */
+    meterPeriodWord() {
+      return this.config?.billing?.meterPeriodWord ?? 'monthly';
     },
     /**
      * @desc Primary pack CTA label, config-sourced from the resolved pack's own `cta` +

--- a/src/modules/billing/tests/billing.planBadge.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.planBadge.component.unit.tests.js
@@ -1,6 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createVuetify } from 'vuetify';
+
+// config is the generated runtime config; mock it per-test (same pattern as
+// billing.resolveStaticContent.unit.tests.js).
+vi.mock('../../../lib/services/config.js', () => ({ default: {} }));
+import configMock from '../../../lib/services/config.js';
 import BillingPlanBadgeComponent from '../components/billing.planBadge.component.vue';
 
 const vuetify = createVuetify();
@@ -17,6 +22,8 @@ const mountComponent = (props) =>
   });
 
 describe('BillingPlanBadgeComponent', () => {
+  // These 5 tests run against an empty mocked config (no override) — they prove the
+  // unset-config default is byte-identical to the pre-hook behavior.
   it('renders free plan with grey color', () => {
     const wrapper = mountComponent({ plan: 'free' });
     expect(wrapper.text()).toContain('free');
@@ -44,6 +51,60 @@ describe('BillingPlanBadgeComponent', () => {
   it('falls back to grey for unknown plan', () => {
     // Validator will warn, but computed still returns grey fallback
     const wrapper = mountComponent({ plan: 'unknown' });
+    expect(wrapper.vm.color).toBe('grey');
+  });
+});
+
+describe('BillingPlanBadgeComponent — config-driven plan set', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(configMock)) delete configMock[k];
+  });
+
+  it('renders an overridden plan set and validates against it (devkit ids excluded)', () => {
+    configMock.billing = {
+      planBadge: {
+        plans: [
+          { id: 'team', color: 'info' },
+          { id: 'scale', color: 'error' },
+        ],
+      },
+    };
+
+    const wrapper = mountComponent({ plan: 'team' });
+    expect(wrapper.text()).toContain('team');
+    expect(wrapper.vm.color).toBe('info');
+
+    const validator = BillingPlanBadgeComponent.props.plan.validator;
+    expect(validator('team')).toBe(true);
+    expect(validator('scale')).toBe(true);
+    expect(validator('free')).toBe(false);
+    expect(validator('nope')).toBe(false);
+  });
+
+  it('uses fallbackColor for a plan id outside the overridden set, else grey', () => {
+    configMock.billing = {
+      planBadge: {
+        plans: [{ id: 'team', color: 'info' }],
+        fallbackColor: 'surface',
+      },
+    };
+    let wrapper = mountComponent({ plan: 'ghost' });
+    expect(wrapper.vm.color).toBe('surface');
+
+    configMock.billing = {
+      planBadge: {
+        plans: [{ id: 'team', color: 'info' }],
+      },
+    };
+    wrapper = mountComponent({ plan: 'ghost' });
+    expect(wrapper.vm.color).toBe('grey');
+  });
+
+  it('pins the devkit default set + colors when config is unset', () => {
+    const validator = BillingPlanBadgeComponent.props.plan.validator;
+    expect(validator('enterprise')).toBe(true);
+
+    const wrapper = mountComponent({ plan: 'free' });
     expect(wrapper.vm.color).toBe('grey');
   });
 });

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -105,6 +105,7 @@ function mountSubscriptions({
   isLoggedIn = true,
   routeQuery = {},
   router = { replace: vi.fn(), push: vi.fn() },
+  config = mockConfig,
 } = {}) {
   authState.serverConfig = serverConfig;
   authState.isLoggedIn = isLoggedIn;
@@ -112,7 +113,7 @@ function mountSubscriptions({
     global: {
       plugins: [vuetify],
       mocks: {
-        config: mockConfig,
+        config,
         $route: { path: '/users', query: routeQuery },
         $router: router,
       },
@@ -1540,5 +1541,41 @@ describe('BillingSubscriptionsComponent — extras modal packs (real static-cont
     expect(packsProp.map((p) => p.packId)).toEqual(realPacks.map((p) => p.id));
     expect(packsProp.map((p) => p.priceUsd)).toEqual(realPacks.map((p) => p.meta.priceUsd));
     expect(packsProp.map((p) => p.meterUnits)).toEqual(realPacks.map((p) => p.meta.meterUnits));
+  });
+});
+
+// ─── Suite: config-driven free-plan blurb (#4474) ────────────────────────────
+
+describe('BillingSubscriptionsComponent — config-driven free-plan blurb (#4474)', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    store = useBillingStore();
+    seedMeterStore(store);
+    store.subscription = null; // free plan card
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+  });
+
+  it('renders the exact devkit default blurb when config.billing.freePlanBlurb is unset', async () => {
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+    expect(wrapper.text()).toContain(
+      "You're on the free plan. Upgrade to unlock more projects, team members, and advanced features.",
+    );
+  });
+
+  it('renders the overridden blurb and hides the default text', async () => {
+    const overrideConfig = { ...mockConfig, billing: { freePlanBlurb: 'Free tier active. Upgrade for extra capacity.' } };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } }, config: overrideConfig });
+    await flushPromises();
+    expect(wrapper.text()).toContain('Free tier active. Upgrade for extra capacity.');
+    expect(wrapper.text()).not.toContain("You're on the free plan");
   });
 });

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -100,6 +100,16 @@ const componentStubs = {
  * @param {Object} [opts]
  * @returns {import('@vue/test-utils').VueWrapper}
  */
+/**
+ * Mount BillingSubscriptionsComponent with test-controlled auth state, router, and config.
+ * @param {object} [options] Mount options.
+ * @param {object|null} [options.serverConfig] Server config injected into auth state.
+ * @param {boolean} [options.isLoggedIn] Logged-in auth state.
+ * @param {object} [options.routeQuery] Mocked route query.
+ * @param {object} [options.router] Mocked router with replace/push.
+ * @param {object} [options.config] Config object exposed to the component.
+ * @returns {import('@vue/test-utils').VueWrapper} The mounted component wrapper.
+ */
 function mountSubscriptions({
   serverConfig = null,
   isLoggedIn = true,

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -279,4 +279,53 @@ describe('BillingUpgradePrompt', () => {
       expect(text).toContain('Ultra');
     });
   });
+
+  describe('config-driven meter period word (#4474)', () => {
+    /**
+     * Mount the meter-mode prompt with an optional `this.config` override installed
+     * via global.mocks (the component reads `this.config`, not the imported config
+     * service — same pattern as home.notfound.view.vue).
+     * @param {Object} [config] - Value to install as `this.config` on the instance.
+     * @returns {import('@vue/test-utils').VueWrapper}
+     */
+    const mountMeterPrompt = (config) =>
+      mount(BillingUpgradePrompt, {
+        props: { requiredPlan: 'pro', mode: 'meter' },
+        global: {
+          plugins: [vuetify],
+          mocks: config ? { config } : {},
+          stubs: { RouterLink: true },
+        },
+      });
+
+    it('defaults to "monthly" when config.billing.meterPeriodWord is unset', () => {
+      const wrapper = mountMeterPrompt();
+      expect(wrapper.text()).toContain('upgrade for monthly compute');
+    });
+
+    it('uses the configured period word in the meter-mode prompt', () => {
+      const wrapper = mountMeterPrompt({ billing: { meterPeriodWord: 'quarterly' } });
+      expect(wrapper.text()).toContain('upgrade for quarterly compute');
+      expect(wrapper.text()).not.toContain('monthly compute');
+    });
+
+    it('applies the configured period word to BOTH occurrences (meter prompt + post-grant depletion message)', () => {
+      const store = useBillingStore();
+      Object.assign(store, {
+        subscription: { plan: 'free' },
+        extrasBalance: { balance: 0 },
+        extrasLedger: { entries: [{ source: 'signup_grant', amount: 500 }], total: 1, page: 1, limit: 20 },
+      });
+      const wrapper = mount(BillingUpgradePrompt, {
+        props: { requiredPlan: 'pro', mode: 'meter' },
+        global: {
+          plugins: [vuetify],
+          mocks: { config: { billing: { meterPeriodWord: 'quarterly' } } },
+          stubs: { RouterLink: true },
+        },
+      });
+      expect(wrapper.text()).toContain('upgrade for quarterly compute');
+      expect(wrapper.text()).not.toContain('monthly compute');
+    });
+  });
 });

--- a/src/modules/billing/views/billing.account.view.vue
+++ b/src/modules/billing/views/billing.account.view.vue
@@ -4,7 +4,7 @@
 
     <!-- Redirect in progress (single manageable org) -->
     <div v-if="redirecting" class="d-flex justify-center align-center pa-12">
-      <v-progress-circular indeterminate color="primary" />
+      <AppSpinner color="primary" />
     </div>
 
     <!-- Multiple manageable orgs → org selector -->
@@ -57,11 +57,13 @@
 <script>
 import { useOrganizationsStore } from '../../organizations/stores/organizations.store';
 import PageHeader from '../../core/components/core.pageHeader.component.vue';
+import AppSpinner from '../../core/components/core.appSpinner.component.vue';
 
 export default {
   name: 'BillingAccountView',
   components: {
     PageHeader,
+    AppSpinner,
   },
   /**
    * @desc Wire the organizations store so computed properties stay reactive.

--- a/src/modules/core/components/core.appSpinner.component.vue
+++ b/src/modules/core/components/core.appSpinner.component.vue
@@ -12,9 +12,9 @@ import config from '../../../lib/services/config';
 
 /**
  * Glob of module-provided loader components, matched by filename convention.
- * Non-eager: each entry only becomes a build chunk when a config value actually
- * resolves to it, so an upstream repo that ships no `*.loader.component.vue`
- * pays zero bundle cost. Test fixtures are excluded.
+ * Non-eager: each entry is turned into a build chunk only when a config value
+ * actually resolves to it, so an upstream repo that ships no
+ * `*.loader.component.vue` pays zero bundle cost. Test fixtures are excluded.
  */
 const loaderModules = import.meta.glob(['/src/modules/*/components/**/*.loader.component.vue', '!**/tests/**']);
 

--- a/src/modules/core/components/core.appSpinner.component.vue
+++ b/src/modules/core/components/core.appSpinner.component.vue
@@ -1,0 +1,84 @@
+<template>
+  <component :is="activeLoader" v-if="activeLoader" />
+  <v-progress-circular v-else indeterminate />
+</template>
+
+<script>
+/**
+ * Module dependencies.
+ */
+import { defineAsyncComponent } from 'vue';
+import config from '../../../lib/services/config';
+
+/**
+ * Glob of module-provided loader components, matched by filename convention.
+ * Non-eager: each entry only becomes a build chunk when a config value actually
+ * resolves to it, so an upstream repo that ships no `*.loader.component.vue`
+ * pays zero bundle cost. Test fixtures are excluded.
+ */
+const loaderModules = import.meta.glob(['/src/modules/*/components/**/*.loader.component.vue', '!**/tests/**']);
+
+/**
+ * Resolve a configured loader path against a glob map of loader components.
+ * Pure function — exported so it can be unit tested with a fake glob map,
+ * independent of the real `import.meta.glob` result.
+ * @param {Object<string, Function>} globMap - Map of Vite module path -> dynamic import loader.
+ * @param {string|null|undefined} path - Configured loader path (config.ui.loader.component).
+ * @returns {Function|null} The matched glob loader function, or null when unset/unmatched (fail-soft).
+ */
+export function resolveLoaderComponent(globMap, path) {
+  if (!path) return null;
+  const loader = globMap?.[path];
+  if (!loader) {
+    console.warn(
+      `[CoreAppSpinner] config.ui.loader.component "${path}" did not match any loader component ` +
+        '(expected a path like /src/modules/<module>/components/<name>.loader.component.vue). ' +
+        'Falling back to the built-in spinner.',
+    );
+    return null;
+  }
+  return loader;
+}
+
+const configuredLoaderPath = config?.ui?.loader?.component || null;
+const matchedLoader = resolveLoaderComponent(loaderModules, configuredLoaderPath);
+const resolvedLoader = matchedLoader ? defineAsyncComponent(matchedLoader) : null;
+
+/**
+ * CoreAppSpinner — config-overridable loading indicator.
+ *
+ * Renders the built-in Vuetify `v-progress-circular` by default (byte-identical to every
+ * existing call site). A downstream project can point `config.ui.loader.component` at its
+ * own SFC (matched by the `*.loader.component.vue` filename convention under
+ * `src/modules/*\/components/`) to replace the loader stack-wide with zero view edits —
+ * config values can only be strings (generateConfig.js JSON.stringify's the merged config),
+ * so the override is a Vite glob path resolved to a component at module load time.
+ *
+ * No visual props are declared: each template branch has a single root element, so Vue's
+ * automatic attribute fallthrough passes color/size/data-test/etc. straight through to
+ * whichever branch renders. The only declared prop is a programmatic escape hatch for tests.
+ */
+export default {
+  name: 'CoreAppSpinner',
+  props: {
+    /**
+     * @desc Test/programmatic escape hatch — a component definition to render instead of
+     * the config-resolved loader. Views never pass this; it exists so unit tests can assert
+     * the override path without needing a real `config.ui.loader.component` + glob match.
+     */
+    loader: {
+      type: [Object, Function],
+      default: null,
+    },
+  },
+  computed: {
+    /**
+     * @desc The component to render, or null to fall back to the built-in spinner.
+     * @returns {Object|Function|null}
+     */
+    activeLoader() {
+      return this.loader || resolvedLoader;
+    },
+  },
+};
+</script>

--- a/src/modules/core/components/tests/core.appSpinner.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.appSpinner.component.unit.tests.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import CoreAppSpinner, { resolveLoaderComponent } from '../core.appSpinner.component.vue';
+
+/**
+ * Vuetify instance with all components registered for component mount.
+ * @returns {import('vuetify').Vuetify}
+ */
+const makeVuetify = () => createVuetify({ components, directives });
+
+/**
+ * Mount CoreAppSpinner with sensible defaults; callers override via opts.
+ * @param {object} [opts]
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+const mountIt = (opts = {}) =>
+  mount(CoreAppSpinner, {
+    props: opts.props,
+    attrs: opts.attrs,
+    global: {
+      plugins: [makeVuetify()],
+    },
+  });
+
+describe('CoreAppSpinner — default rendering (config unset)', () => {
+  it('renders the built-in v-progress-circular with indeterminate=true', () => {
+    const wrapper = mountIt();
+    const spinner = wrapper.findComponent({ name: 'VProgressCircular' });
+    expect(spinner.exists()).toBe(true);
+    expect(spinner.props('indeterminate')).toBe(true);
+  });
+});
+
+describe('CoreAppSpinner — attribute fallthrough', () => {
+  it('forwards color/size/data-test to the rendered root (single-root branches, no declared visual props)', () => {
+    const wrapper = mountIt({ attrs: { color: 'primary', size: '48', 'data-test': 'x' } });
+    const spinner = wrapper.findComponent({ name: 'VProgressCircular' });
+    expect(spinner.props('color')).toBe('primary');
+    expect(spinner.props('size')).toBe('48');
+    expect(wrapper.attributes('data-test')).toBe('x');
+  });
+});
+
+describe('CoreAppSpinner — override via loader prop', () => {
+  it('renders the provided loader component instead of the built-in spinner', () => {
+    const wrapper = mountIt({
+      props: { loader: { template: '<div class="custom-loader" />' } },
+    });
+    expect(wrapper.find('.custom-loader').exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'VProgressCircular' }).exists()).toBe(false);
+  });
+});
+
+describe('resolveLoaderComponent — pure resolver', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when the configured path is unset', () => {
+    expect(resolveLoaderComponent({}, null)).toBeNull();
+    expect(resolveLoaderComponent({}, undefined)).toBeNull();
+    expect(resolveLoaderComponent({}, '')).toBeNull();
+  });
+
+  it('warns and returns null when the path has no glob match (fail-soft)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = resolveLoaderComponent({}, '/src/modules/x/components/x.loader.component.vue');
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the matched glob loader for a known key', () => {
+    const key = '/src/modules/x/components/x.loader.component.vue';
+    const globMap = { [key]: () => Promise.resolve({ default: { template: '<div class="x" />' } }) };
+    const result = resolveLoaderComponent(globMap, key);
+    expect(result).toBe(globMap[key]);
+    expect(typeof result).toBe('function');
+  });
+});

--- a/src/modules/docs/views/docs.article.view.vue
+++ b/src/modules/docs/views/docs.article.view.vue
@@ -17,7 +17,7 @@
 
         <!-- Loading -->
         <v-row v-if="loading" justify="center" class="py-12">
-          <v-progress-circular indeterminate color="primary" size="48" data-test="docs-article-loading" />
+          <AppSpinner color="primary" size="48" data-test="docs-article-loading" />
         </v-row>
 
         <!-- Not found -->
@@ -97,6 +97,7 @@ import { useDocsPage, EXAMPLE_MARKER_SOURCE } from '../composables/useDocsPage';
 import DocsNav from '../components/docs.nav.component.vue';
 import DocsToc from '../components/docs.toc.component.vue';
 import DocsCodeblock from '../components/docs.codeblock.component.vue';
+import AppSpinner from '../../core/components/core.appSpinner.component.vue';
 
 const route = useRoute();
 const store = useDocsStore();

--- a/src/modules/docs/views/docs.home.view.vue
+++ b/src/modules/docs/views/docs.home.view.vue
@@ -18,7 +18,7 @@
 
     <!-- Loading -->
     <v-row v-if="loading" justify="center" class="py-12">
-      <v-progress-circular indeterminate color="primary" size="48" data-test="docs-home-loading" />
+      <AppSpinner color="primary" size="48" data-test="docs-home-loading" />
     </v-row>
 
     <!-- Error -->
@@ -174,6 +174,7 @@ import { useDocsStore } from '../stores/docs.store';
 import { resolveDocsTarget } from '../composables/useDocsNav';
 import DocsSearch from '../components/docs.search.component.vue';
 import PageHeader from '../../core/components/core.pageHeader.component.vue';
+import AppSpinner from '../../core/components/core.appSpinner.component.vue';
 import config from '@/config';
 
 const home = config?.docs?.home || { icon: 'fa-solid fa-book', title: 'Documentation', subtitle: '' };

--- a/src/modules/docs/views/docs.reference.view.vue
+++ b/src/modules/docs/views/docs.reference.view.vue
@@ -17,8 +17,7 @@
 
         <!-- Loading -->
         <v-row v-if="loading" justify="center" class="py-12">
-          <v-progress-circular
-            indeterminate
+          <AppSpinner
             color="primary"
             size="48"
             data-test="docs-reference-loading"
@@ -217,6 +216,7 @@ import { parseSpec } from '../composables/useDocsReference';
 import { resolveDocsTarget } from '../composables/useDocsNav';
 import DocsNav from '../components/docs.nav.component.vue';
 import PageHeader from '../../core/components/core.pageHeader.component.vue';
+import AppSpinner from '../../core/components/core.appSpinner.component.vue';
 import config from '@/config';
 
 /**


### PR DESCRIPTION
Closes #4474

## What

Three previously-hardcoded UI spots become config-overridable so a downstream project can rebrand/reconfigure them without editing the stack view — which currently re-conflicts on every `/update-stack`. Every new key defaults to today's exact behavior; default output is byte-identical.

## Why

Downstream projects fork these views today to swap the loading indicator, use a different plan set, or change billing-period copy. Config hooks remove that fork/drift class entirely.

## Per-hook summary

### 1. Overridable loader (`ui.loader.component`)

- New `CoreAppSpinner` component (`src/modules/core/components/core.appSpinner.component.vue`) renders the built-in `v-progress-circular` by default.
- When `config.ui.loader.component` is set to a Vite path (config values can only be strings — `generateConfig.js` `JSON.stringify`'s the merged config), it's resolved to a component via an `import.meta.glob` filename convention (`/src/modules/*/components/**/*.loader.component.vue`), mirroring the existing `useLegalPage.js` precedent. Unmatched/unset paths fail soft (console.warn + fallback).
- No visual props declared — each template branch has a single root, so Vue's automatic attribute fallthrough passes color/size/data-test straight through.
- Wired into all 6 hardcoded `v-progress-circular` loading-state usages: auth token view, docs article/home/reference views, billing subscriptions + account view.
- Exported pure resolver `resolveLoaderComponent(globMap, path)` for unit testing without a live glob.
- Upstream ships no `*.loader.component.vue` → glob is empty → zero extra build chunks.

### 2. Config-driven plan badge (`billing.planBadge.plans`, `billing.planBadge.fallbackColor`)

- `billing.planBadge.component.vue`'s hardcoded `free/starter/pro/enterprise` ids + Vuetify colors become the devkit default only (module-scope `DEFAULT_PLANS`, documented as never-to-be-declared-in-config).
- A downstream sets `billing.planBadge.plans` (an ordered `{ id, color }[]`) to fully replace the allowed set — `generateConfig`'s `deepMerge` replaces arrays wholesale rather than merging them (same hazard documented for `admin.tabs`), so this can't accidentally union with the devkit default.
- `fallbackColor` (default `'grey'`) covers a `plan` prop value outside the resolved set.
- Lazy accessors (functions, not module-eval snapshots) so config can be read fresh per render/test.

### 3. Config-driven copy (`billing.meterPeriodWord`, `billing.freePlanBlurb`, `app.itemNoun`)

- Three hardcoded strings now read `this.config?.X ?? currentDefault`, following the canonical `home.notfound.view.vue` config-copy pattern (`this.config` via `app.config.globalProperties`, no import needed):
  - `billing.meterPeriodWord` (default `'monthly'`) — used in **both** occurrences of "upgrade for monthly compute" in `billing.upgradePrompt.component.vue` (meter-mode prompt + post-grant depletion message) so the component never contradicts itself.
  - `billing.freePlanBlurb` (default = exact current full paragraph) — free-plan upgrade blurb in `billing.subscriptions.component.vue`.
  - `app.itemNoun` (default `'projects'`) — workspace-setup helper text in `auth/components/organizationSetup.component.vue`.
- None of the three keys are seeded in any config fragment/defaults file, so the generated `src/config/index.js` stays byte-identical — downstreams override via their own `src/config/defaults/<project>.config.js`.

## Verify evidence

- `npm run lint` → `ESLint: No issues found`
- `npm run generateConfig` → confirmed `config.ui.loader.component === null` (new), and `billing.planBadge`, `billing.meterPeriodWord`, `billing.freePlanBlurb`, `app.itemNoun` all `undefined` (absent, as designed) — proves default output is byte-identical.
- `vitest run` → **149 test files / 2529 tests passed** (0 failures), including all pre-existing tests for every touched view/component unchanged (regression proof of byte-identity).
- `vitest run --coverage` → thresholds unchanged, no drop (99.1% stmts / 92.67% branches / 98.76% funcs / 99.66% lines on the covered `lib/*` + store surface).
- `vite build` → production build succeeds; no new build chunk emitted for the (empty, upstream) loader glob.
- Leak-guard: verified the diff contains no downstream-specific names or hosts (empty match).

## Tests added

- `src/modules/core/components/tests/core.appSpinner.component.unit.tests.js` (new): default render, attribute fallthrough, `loader` prop override, and 3 resolver unit tests.
- `src/modules/billing/tests/billing.planBadge.component.unit.tests.js`: existing 5 tests now run against a mocked empty config (byte-identity proof) + 3 new tests for overridden plan set / fallbackColor / default pin.
- `src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js`: 3 new tests for the config-driven period word (default, override, both occurrences in sync).
- `src/modules/billing/tests/billing.subscriptions.component.unit.tests.js`: 2 new tests for the free-plan blurb (default, override).
- `src/modules/auth/tests/auth.organizationSetup.component.unit.tests.js`: 2 new tests for the item noun (default, override) — the pre-existing default-guard test (`keeps your projects and teammates together`) is preserved unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable loading indicators across authentication, billing, and documentation screens.
  * Added configurable workspace terminology and billing copy.
  * Added support for custom billing plan sets, colors, fallback colors, and billing-period wording.
* **Improvements**
  * Standardized loading states with the shared application spinner.
  * Existing defaults remain unchanged unless custom settings are provided.
* **Documentation**
  * Added migration guidance and configuration details for the new options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->