### PR TITLE
feat(invitations): show invite form when user-facing invitations enabled with open signup

### DIFF
--- a/src/modules/invitations/tests/invitations.account.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.account.view.unit.tests.js
@@ -217,6 +217,41 @@ describe('invitations.account.view', () => {
     expect(wrapper.text()).toContain('My referrals');
     expect(wrapper.find('[data-test="referrals-summary"]').exists()).toBe(true);
   });
+
+  // #4500: user-facing invitations opt-in — the invite form stays available
+  // even with public signup open, when the deployment exposes the flag.
+  it('signup closed: userFacingInvitations is false by default, form renders (unchanged)', () => {
+    authStoreMock.serverConfig = { sign: { in: true, up: false } };
+    const wrapper = mountView();
+    expect(wrapper.vm.userFacingInvitations).toBe(false);
+    expect(wrapper.find('[data-test="referrals-open-signup-alert"]').exists()).toBe(false);
+    expect(wrapper.find('form').exists()).toBe(true);
+  });
+
+  it('signup open + userFacing true: renders the form, alert absent', () => {
+    authStoreMock.serverConfig = { sign: { in: true, up: true }, invitations: { userFacing: true } };
+    const wrapper = mountView();
+    expect(wrapper.vm.userFacingInvitations).toBe(true);
+    expect(wrapper.find('[data-test="referrals-open-signup-alert"]').exists()).toBe(false);
+    expect(wrapper.find('form').exists()).toBe(true);
+  });
+
+  it('signup open + userFacing undefined (old backend, no exposure): renders the alert, form absent', () => {
+    authStoreMock.serverConfig = { sign: { in: true, up: true } };
+    const wrapper = mountView();
+    expect(wrapper.vm.userFacingInvitations).toBe(false);
+    const alert = wrapper.find('[data-test="referrals-open-signup-alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(wrapper.find('form').exists()).toBe(false);
+  });
+
+  it('signup open + userFacing false: renders the alert, form absent', () => {
+    authStoreMock.serverConfig = { sign: { in: true, up: true }, invitations: { userFacing: false } };
+    const wrapper = mountView();
+    expect(wrapper.vm.userFacingInvitations).toBe(false);
+    expect(wrapper.find('[data-test="referrals-open-signup-alert"]').exists()).toBe(true);
+    expect(wrapper.find('form').exists()).toBe(false);
+  });
 });
 
 describe('invitations.account.view — one-time copy-link (#3834)', () => {

--- a/src/modules/invitations/views/invitations.account.view.vue
+++ b/src/modules/invitations/views/invitations.account.view.vue
@@ -23,12 +23,15 @@
             <v-icon icon="fa-solid fa-gift" color="primary" class="mr-3"></v-icon>
             <span class="text-title-large">Invite a contact</span>
           </div>
-          <!-- #3833 open-signup state: the server never claims/finalizes an invite
-               token while public signup is open (invitation.accepted never fires),
-               so soliciting invites here would promise a referral that can never
-               convert. Informational state instead of the form; list stays below. -->
+          <!-- #3833/#4500 open-signup state: with signup open, the server never
+               claims/finalizes an invite token (invitation.accepted never fires),
+               so soliciting invites here would normally promise a referral that
+               can never convert — UNLESS the deployment explicitly opts in via
+               user-facing invitations (userFacingInvitations), in which case the
+               form is shown regardless of the signup state. Informational state
+               only when open signup AND that opt-in is off; list stays below. -->
           <v-alert
-            v-if="signupOpen"
+            v-if="signupOpen && !userFacingInvitations"
             type="info"
             variant="tonal"
             density="compact"
@@ -235,6 +238,17 @@ export default {
      */
     signupOpen() {
       return useAuthStore().serverConfig?.sign?.up === true;
+    },
+    /**
+     * @desc Whether this deployment opts in to user-facing invitations (the
+     * invite form stays available even with public signup open) from the
+     * server auth config. Defaults to false — an unknown/missing exposure
+     * (older backend, config not loaded yet) keeps today's behavior: the
+     * form is gated behind `signupOpen` alone.
+     * @returns {boolean}
+     */
+    userFacingInvitations() {
+      return useAuthStore().serverConfig?.invitations?.userFacing === true;
     },
   },
   methods: {


### PR DESCRIPTION
## Summary

- Adds a `userFacingInvitations` computed on the account invitations view, reading `serverConfig.invitations.userFacing` from the auth store (undefined-safe, defaults to `false`).
- The invite form now renders when signup is closed (unchanged behavior) OR the `userFacing` flag is `true`. The informational "signup is open" alert is shown only when signup is open AND the flag is falsy.
- Updates the adjacent rationale comment to describe the new rule.

## Dependency

Runtime requires a companion backend exposure (`GET /api/auth/config` returning `invitations.userFacing`) that is being added in a parallel backend PR. This PR **degrades safely without it**: an absent/undefined field reads as `false`, so the form stays gated behind `signupOpen` alone — today's behavior, unchanged. Tests mock the flag directly (no live backend dependency for this PR).

## Test plan

- [x] Unit tests for all 4 state combinations: signup-closed (form, unchanged default), signup-open + flag `true` (form, alert absent), signup-open + flag `undefined` (alert, form absent — old-backend compatibility), signup-open + flag `false` (alert, form absent)
- [x] `npm run lint` — clean
- [x] `npm run test:coverage` — 149 test files / 2533 tests passing, coverage gate held (99.1% stmts / 92.67% branch / 98.76% funcs / 99.66% lines)
- [x] `npm run build` — green

Closes #4500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments can now opt in to displaying user-facing invitations while public signup is open.
  * When enabled, the invitation form remains available instead of showing the inactive-invitations notice.

* **Bug Fixes**
  * Preserved existing behavior for deployments that have not enabled the invitation setting, including legacy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->