### PR TITLE
fix(prerender): strip local server origin from captured HTML + fail-hard leak assert

### DIFF
--- a/src/lib/plugins/prerender.js
+++ b/src/lib/plugins/prerender.js
@@ -67,10 +67,11 @@ export function prerenderPlugin(config, mode) {
 
       let browser;
       let server;
+      let distDir;
 
       try {
         const puppeteer = await import('puppeteer');
-        const distDir = join(process.cwd(), 'dist');
+        distDir = join(process.cwd(), 'dist');
 
         // Spin up a lightweight static file server for the dist/ folder
         server = await startStaticServer(distDir);
@@ -100,6 +101,32 @@ export function prerenderPlugin(config, mode) {
       } finally {
         if (browser) await browser.close().catch(() => {});
         if (server) await closeServer(server);
+      }
+
+      // Fail-hard build-time assert (#4502): re-read each written prerendered file and
+      // refuse to ship a build that still references the local prerender-server origin.
+      // Deliberately OUTSIDE the try/catch above — that block is fail-soft by design
+      // (a puppeteer/render hiccup must never break unrelated builds), so a leak thrown
+      // in there would be silently swallowed. Mirrors the docs fail-hard gate pattern:
+      // fail-soft render step, then a separate check afterward that always propagates.
+      if (distDir) {
+        const leakPattern = /https?:\/\/(?:127\.0\.0\.1|localhost):\d+/;
+        for (const route of routes) {
+          const outputPath = routeToOutputPath(distDir, route);
+          let written;
+          try {
+            written = readFileSync(outputPath, 'utf-8');
+          } catch {
+            continue; // route was never (re)written this run — nothing to assert on
+          }
+          if (leakPattern.test(written)) {
+            throw new Error(
+              `[prerender] FAIL-HARD: pre-rendered route "${route}" (${outputPath}) still contains ` +
+                'a reference to the local prerender-server origin (127.0.0.1/localhost) — see #4502. ' +
+                'Refusing to ship a build with a leaked internal URL.',
+            );
+          }
+        }
       }
     },
   };
@@ -173,10 +200,15 @@ async function renderRoute(browser, port, route, distDir) {
     await page.goto(url, { waitUntil: 'networkidle0', timeout: 30_000 });
     const html = await page.content();
 
+    // Vite's __vitePreload absolutizes lazy-chunk deps via import.meta.resolve against
+    // the local prerender server origin (#4502); static chunks stay relative, so
+    // stripping the origin yields the same root-relative form.
+    const sanitized = html.replace(new RegExp('https?://(?:127\\.0\\.0\\.1|localhost):' + port, 'g'), '');
+
     const outputPath = routeToOutputPath(distDir, route);
 
     mkdirSync(dirname(outputPath), { recursive: true });
-    writeFileSync(outputPath, html, 'utf-8');
+    writeFileSync(outputPath, sanitized, 'utf-8');
     console.log(`[prerender] Rendered: ${route} → ${outputPath}`);
   } finally {
     await page.close();

--- a/src/lib/plugins/tests/prerender.unit.tests.js
+++ b/src/lib/plugins/tests/prerender.unit.tests.js
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // vi.hoisted runs before vi.mock hoisting — safe to reference in factories
-const { mockPage, mockBrowser, mockCreateServer } = vi.hoisted(() => {
+const { mockPage, mockBrowser, mockCreateServer, mockFsFns } = vi.hoisted(() => {
   const mockPage = {
     goto: vi.fn().mockResolvedValue(undefined),
     content: vi.fn().mockResolvedValue('<html><body>rendered</body></html>'),
@@ -18,32 +18,34 @@ const { mockPage, mockBrowser, mockCreateServer } = vi.hoisted(() => {
     close: vi.fn((cb) => cb()),
     on: vi.fn(),
   }));
-  return { mockPage, mockBrowser, mockCreateServer };
-});
-
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    default: { ...actual, writeFileSync: vi.fn(), mkdirSync: vi.fn(), readFileSync: vi.fn(() => '<html></html>') },
-    ...actual,
+  const mockFsFns = {
     writeFileSync: vi.fn(),
     mkdirSync: vi.fn(),
     readFileSync: vi.fn(() => '<html></html>'),
   };
+  return { mockPage, mockBrowser, mockCreateServer, mockFsFns };
 });
+
+// NOTE: deliberately NOT using the `async (importOriginal) => { const actual = await
+// importOriginal(); ... }` factory shape here. For these two Node builtins that pattern
+// fails to intercept the *transitive* import inside prerender.js (readFileSync/
+// writeFileSync/createServer silently fall through to the REAL implementations —
+// verified by writing real files under dist/ during a plain unit test run). A
+// synchronous factory that doesn't call importOriginal() intercepts correctly; since
+// prerender.js only ever touches these explicitly-mocked functions, nothing is lost.
+vi.mock('node:fs', () => ({
+  ...mockFsFns,
+  default: { ...mockFsFns },
+}));
 
 vi.mock('puppeteer', () => ({
   default: { launch: vi.fn().mockResolvedValue(mockBrowser) },
 }));
 
-vi.mock('node:http', async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    default: { ...actual, createServer: mockCreateServer },
-    ...actual,
-    createServer: mockCreateServer,
-  };
-});
+vi.mock('node:http', () => ({
+  createServer: mockCreateServer,
+  default: { createServer: mockCreateServer },
+}));
 
 import { prerenderPlugin, sanitizePath, routeToOutputPath } from '../prerender.js';
 
@@ -152,6 +154,40 @@ describe('prerenderPlugin', () => {
       'No chromium',
     );
     warnSpy.mockRestore();
+  });
+
+  it('strips the local prerender-server origin from captured HTML before writing (#4502)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockPage.content.mockResolvedValue(
+      '<html><head><link rel="modulepreload" href="http://127.0.0.1:54321/assets/x.js"></head><body>rendered</body></html>',
+    );
+
+    const plugin = prerenderPlugin(
+      { app: { seo: { prerender: { enabled: true, routes: ['/'] } } } },
+      'production',
+    );
+
+    await plugin.closeBundle();
+
+    const [, writtenHtml] = mockFsFns.writeFileSync.mock.calls[0];
+    expect(writtenHtml).not.toContain('127.0.0.1');
+    expect(writtenHtml).toContain('/assets/x.js');
+    logSpy.mockRestore();
+  });
+
+  it('fails hard (#4502) when a written prerendered file still leaks the local prerender origin', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockFsFns.readFileSync.mockReturnValueOnce(
+      '<html><body><link rel="modulepreload" href="http://127.0.0.1:54321/assets/x.js"></body></html>',
+    );
+
+    const plugin = prerenderPlugin(
+      { app: { seo: { prerender: { enabled: true, routes: ['/'] } } } },
+      'production',
+    );
+
+    await expect(plugin.closeBundle()).rejects.toThrow(/4502/);
+    logSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Closes #4502

- renderRoute(): strip `https?://(127.0.0.1|localhost):<port>` from captured HTML (static chunks stay relative; stripping yields the same root-relative form for lazy chunks)
- Fail-hard build assert after the fail-soft render try/catch: re-read written prerendered files, throw on any remaining local-origin reference — a render hiccup stays fail-soft, a leaked internal URL never ships
- 23 unit tests incl. both new behaviors

First observed on a downstream consumer's release build; promoted to the stack so the fix is generic.

https://claude.ai/code/session_017qRhTzJxKUKoWory6mifBB