### PR TITLE
chore(invitations): remove stale referral-rewards placeholder

### DIFF
--- a/src/modules/invitations/tests/invitations.account.view.unit.tests.js
+++ b/src/modules/invitations/tests/invitations.account.view.unit.tests.js
@@ -179,13 +179,9 @@ describe('invitations.account.view', () => {
     expect(wrapper.find('[data-test="referrals-summary"]').text()).toContain('1 expired');
   });
 
-  it('renders the referral-rewards placeholder — honest, no numbers', () => {
+  it('no longer renders the referral-rewards placeholder (#4504 — reward path shipped)', () => {
     const wrapper = mountView();
-    const placeholder = wrapper.find('[data-test="referral-rewards-placeholder"]');
-    expect(placeholder.exists()).toBe(true);
-    expect(placeholder.text()).toContain('Referral rewards — coming soon');
-    // Scaffold contract (#5 not built): the placeholder must never show numbers/fake math
-    expect(placeholder.text()).not.toMatch(/\d/);
+    expect(wrapper.find('[data-test="referral-rewards-placeholder"]').exists()).toBe(false);
   });
 
   it('signup open: replaces the invite form with the informational alert', () => {

--- a/src/modules/invitations/views/invitations.account.view.vue
+++ b/src/modules/invitations/views/invitations.account.view.vue
@@ -203,7 +203,7 @@ export default {
      * @desc Referrals summary counts, derived from the invitations list through
      * the SAME per-row derivation as the table's status chips (`inviteStatus`)
      * so the header and the list can never disagree. Pure derivation — no
-     * endpoint, no credit math (rewards are a later phase, #5).
+     * endpoint, no credit math (reward grants live server-side, #4504).
      * @returns {{ total: number, joined: number, pending: number, expired: number, revoked: number }}
      */
     referralSummary() {

--- a/src/modules/invitations/views/invitations.account.view.vue
+++ b/src/modules/invitations/views/invitations.account.view.vue
@@ -130,13 +130,6 @@
               <v-chip :color="inviteStatus(item).color" size="small" variant="tonal">{{ inviteStatus(item).label }}</v-chip>
             </template>
           </coreDataTableComponent>
-          <!-- Referral rewards placeholder — credits land here in a later phase (#5). No numbers, no math. -->
-          <div class="d-flex align-center mt-4" data-test="referral-rewards-placeholder">
-            <v-chip size="small" variant="tonal" class="text-medium-emphasis">
-              <v-icon start icon="fa-solid fa-coins" size="x-small"></v-icon>
-              Referral rewards — coming soon
-            </v-chip>
-          </div>
         </v-card>
       </v-col>
     </v-row>
@@ -162,9 +155,9 @@ import coreDataTableComponent from '../../core/components/core.datatable.compone
  * entry, both gated by `isModuleActive('invitations')`.
  *
  * P8b frames this as the referrals experience: a summary header (counts by
- * status, derived from the same list the table shows) + a "Referral rewards —
- * coming soon" placeholder marking where the credit grant (#5) will land.
- * Scaffold only — ZERO credit math/logic lives here.
+ * status, derived from the same list the table shows). The credit grant path
+ * lives server-side (billing referral service, #4504 removed the stale
+ * "coming soon" placeholder once it shipped) — ZERO credit math/logic here.
  */
 export default {
   name: 'InvitationsAccount',


### PR DESCRIPTION
Closes #4504

The reward-grant phase this placeholder marked has shipped server-side (billing referral service + referrer notification), so the 'coming soon' chip contradicts live behavior on deployments enabling rewards. Removed the block, updated the doc comment, placeholder unit test now asserts absence (29/29 view tests green).

Audit origin: plan-level cross-PR lens — the view is the CTA destination of live reward promises while stating 'coming soon'.

https://claude.ai/code/session_017qRhTzJxKUKoWory6mifBB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the “Referral rewards — coming soon” placeholder from the invitations account view.
  * Updated the referrals card to display only available referral information without placeholder content or misleading reward values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->