### PR TITLE
docs(skills): add the minimal-code decision ladder to /feature Phase 0

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -116,7 +116,7 @@ For each user-facing flow this feature creates or modifies, identify:
 
 Challenge every **mechanism** this change would introduce — a store field, a persisted flag, a composable, a wrapper component, a new field in the API contract. Stop at the first rung that holds:
 
-0. **Does a product decision remove it?** — accept the cost, accept the failure, do nothing, or surface it to the user.
+0. **Does a product decision remove it?** — accept the cost, accept the failure, do nothing, or surface it to the user. This rung holds **only if the mechanism then disappears**; if the product still needs it (a message still has to be rendered, a state still has to be held), keep going down the ladder.
 1. **Already in this codebase?** — reuse the composable, store or component.
 2. **In the standard library?** — use it.
 3. **A native platform feature?** (HTML input validation, CSS, a framework or design-system built-in) — use it.
@@ -124,7 +124,7 @@ Challenge every **mechanism** this change would introduce — a store field, a p
 5. **One line, a constant, or config?** — make it that.
 6. Only then: build it, minimal.
 
-**Persisted state is the expensive rung.** State that outlives the session (a persisted store slice, a `localStorage` key, a new field in the API contract) encoding a *policy* — a preference, a cap, a memo of a past failure — is not a code choice: code is deleted, persisted state has to be migrated or read forever. Rung 0 is mandatory for it, and it needs **explicit user confirmation in §4** before it is built.
+**Persisted state is the expensive rung.** State that **outlives the session** — a persisted store slice, a `localStorage` key, an API field the backend retains and replays back — encoding a *policy* (a preference, a cap, a memo of a past failure) is not a code choice: code is deleted, persisted state has to be migrated or read forever. A transient request or response field is **not** this; only state that is retained or restored counts. Rung 0 is mandatory for it, and it needs an **explicit, blocking user confirmation in §4** before it is built — a yes on that specific state, never implied by the general plan validation.
 
 **Never traded away** (lazy ≠ negligent): understanding the problem before picking a rung, validation at trust boundaries, error handling that prevents data loss, security, accessibility, and anything the user explicitly asked for.
 
@@ -133,7 +133,8 @@ Challenge every **mechanism** this change would introduce — a store field, a p
 **STOP and present to the user:**
 - Flows identified (happy + error + edge cases)
 - UI elements needed
-- **Ladder outcome (§3b)** — one line per rejected mechanism (`<mechanism> — simpler option <X> rejected because <reason>`), plus any persisted state awaiting confirmation. A change that adds a mechanism and rejects nothing means nobody looked.
+- **Ladder outcome (§3b)** — the **selected rung** first (`<rung> — <what it resolves to>`, e.g. `1 reuse — existing composable`), then one line per rejected mechanism (`<mechanism> — simpler option <X> rejected because <reason>`). A change that adds a mechanism and rejects nothing means nobody looked.
+- **Persisted state, if any** — name it and **wait for an explicit yes on it**; a general "plan validated" does not cover it, and it is not built without that yes.
 - Open questions or scope decisions
 
 **Wait for user validation before coding.** (Non-interactive runs: Phase 0.0

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -112,11 +112,28 @@ For each user-facing flow this feature creates or modifies, identify:
 - Every UI action has visible feedback (success + error)
 - Feature works without mailer / without organizations enabled
 
+### 3b. Minimal-code ladder (run before presenting)
+
+Challenge every **mechanism** this change would introduce — a store field, a persisted flag, a composable, a wrapper component, a new field in the API contract. Stop at the first rung that holds:
+
+0. **Does a product decision remove it?** — accept the cost, accept the failure, do nothing, or surface it to the user.
+1. **Already in this codebase?** — reuse the composable, store or component.
+2. **In the standard library?** — use it.
+3. **A native platform feature?** (HTML input validation, CSS, a framework or design-system built-in) — use it.
+4. **An already-installed dependency?** — use it.
+5. **One line, a constant, or config?** — make it that.
+6. Only then: build it, minimal.
+
+**Persisted state is the expensive rung.** State that outlives the session (a persisted store slice, a `localStorage` key, a new field in the API contract) encoding a *policy* — a preference, a cap, a memo of a past failure — is not a code choice: code is deleted, persisted state has to be migrated or read forever. Rung 0 is mandatory for it, and it needs **explicit user confirmation in §4** before it is built.
+
+**Never traded away** (lazy ≠ negligent): understanding the problem before picking a rung, validation at trust boundaries, error handling that prevents data loss, security, accessibility, and anything the user explicitly asked for.
+
 ### 4. Present plan & ask questions
 
 **STOP and present to the user:**
 - Flows identified (happy + error + edge cases)
 - UI elements needed
+- **Ladder outcome (§3b)** — one line per rejected mechanism (`<mechanism> — simpler option <X> rejected because <reason>`), plus any persisted state awaiting confirmation. A change that adds a mechanism and rejects nothing means nobody looked.
 - Open questions or scope decisions
 
 **Wait for user validation before coding.** (Non-interactive runs: Phase 0.0


### PR DESCRIPTION
Closes #4401
Part of pierreb-devkit/Node#3943

Adds the minimal-code decision ladder to the `/feature` skill, run before an implementation is proposed.

## Placement — deliberate change vs the issue text

The issue asked for the ladder in **Phase 1** ("before writing new code"). It landed at the **end of Phase 0** instead, as `§3b`, immediately before `§4 Present plan & ask questions`.

Reason: the first rung is a *product* question ("does a decision remove this mechanism?"), and §4 is the one place the skill already stops and talks to the user. Running the ladder in Phase 1 would mean discovering the answer after the plan was already validated. The ladder outcome is now carried into §4 as an explicit bullet, so a rejected mechanism is visible at the moment the user validates.

## Rungs

Product decision → reuse → stdlib → native platform → installed dependency → one-liner → minimal code. Stop at the first rung that holds.

Two additions beyond the original 7-rung list:

- **Rung 0 — the product decision.** The other rungs all ask "what is the cheapest way to build this?". Rung 0 asks whether the requirement can be dropped: accept the cost, accept the failure, do nothing, or surface it to the user. It is the only rung that removes code rather than shrinking it.
- **Persisted state is the expensive rung.** State that outlives the session (a persisted store slice, a `localStorage` key, a new field in the API contract) encoding a *policy* is not a code choice — code is deleted, persisted state has to be migrated or read forever. Rung 0 is mandatory for it, and it needs explicit user confirmation in §4 before it is built.

## Guardrails unchanged

Understanding the problem before picking a rung, validation at trust boundaries, error handling that prevents data loss, security, and anything the user explicitly asked for are never traded away. The ladder prunes gratuitous mechanisms, never guardrails.

Docs-only: one file, no runtime code, no dependency change.

https://claude.ai/code/session_019Cow7oT71FcBKpD5brmwBs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature planning guidance with a “Minimal-code ladder” for evaluating simpler implementation alternatives.
  * Phase 0 planning presentations now include ladder outcomes and clearly identify decisions requiring explicit confirmation before policy state is persisted.
  * No changes were made to exported or public product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->