### PR TITLE
fix(auth): stop signup auth-watcher from racing past email verification

### DIFF
--- a/src/modules/auth/tests/auth.signup.view.race.unit.tests.js
+++ b/src/modules/auth/tests/auth.signup.view.race.unit.tests.js
@@ -19,6 +19,10 @@ import axios from '../../../lib/services/axios';
  * Only network/analytics/ability are mocked here; the auth store, its real signup()
  * action, and the component's real Vue reactivity all run unmocked.
  */
+/**
+ * @desc Real API endpoint config consumed directly by auth.store.js (protocol/host/port + cookie prefix).
+ * @returns {{default: object}} minimal config shape needed by the real auth store
+ */
 vi.mock('../../../lib/services/config', () => ({
   default: {
     api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api', endPoints: { auth: 'auth' } },
@@ -26,21 +30,44 @@ vi.mock('../../../lib/services/config', () => ({
   },
 }));
 
+/**
+ * @desc Stub axios so signup()/fetchServerConfig() network calls are mock-controlled per test.
+ * @returns {{default: {post: Function, get: Function}}} axios module shape
+ */
 vi.mock('../../../lib/services/axios', () => ({
   default: { post: vi.fn(), get: vi.fn() },
 }));
 
+/**
+ * @desc Stub the CASL ability helper consumed by core.store.js's refreshNav() (called from signup()).
+ * @returns {{ability: {can: Function}, updateAbilities: Function}} ability module shape
+ */
 vi.mock('../../../lib/helpers/ability', () => ({
-  ability: { can: () => false },
+  ability: {
+    /**
+     * @desc Always deny — refreshNav()'s guarded-route branch is not exercised by this suite.
+     * @returns {boolean} false
+     */
+    can: () => false,
+  },
   updateAbilities: vi.fn(),
 }));
 
+/**
+ * @desc Stub the analytics helpers invoked by auth.store.js's signup() action.
+ * @returns {{capture: Function, identify: Function, reset: Function}} analytics module shape
+ */
 vi.mock('../../../lib/helpers/analytics', () => ({
   capture: vi.fn(),
   identify: vi.fn(),
   reset: vi.fn(),
 }));
 
+/**
+ * @desc Stub the organizations store. signup.view.vue only reaches it via the stubbed
+ * AuthOrganizationSetupComponent, which this suite never instantiates.
+ * @returns {{useOrganizationsStore: Function}} organizations store module shape
+ */
 vi.mock('../../organizations/stores/organizations.store', () => ({
   useOrganizationsStore: () => ({ createOrganization: vi.fn() }),
 }));

--- a/src/modules/auth/tests/auth.signup.view.race.unit.tests.js
+++ b/src/modules/auth/tests/auth.signup.view.race.unit.tests.js
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createVuetify } from 'vuetify';
+import axios from '../../../lib/services/axios';
+
+/**
+ * Race-condition regression suite for #4437.
+ *
+ * `auth.signup.view.unit.tests.js` mocks `useAuthStore` with a static `{ auth: false }`
+ * object — the component's `auth` computed never changes, so a `watch.auth` handler would
+ * never fire at all, masking the bug entirely. This suite instead runs the REAL Pinia auth
+ * store so `authStore.auth` flips via genuine reactivity, reproducing the actual defect:
+ * a `watch.auth` handler is a "pre"-flush job scheduled the instant `signup()` sets
+ * `this.auth = true`, which lands on an EARLIER microtask than `validate()`'s own
+ * `await authStore.signup()` continuation — so it could navigate away before `validate()`
+ * reaches the `emailVerificationRequired` branch and sets `signupStep = 'emailVerification'`.
+ *
+ * Only network/analytics/ability are mocked here; the auth store, its real signup()
+ * action, and the component's real Vue reactivity all run unmocked.
+ */
+vi.mock('../../../lib/services/config', () => ({
+  default: {
+    api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api', endPoints: { auth: 'auth' } },
+    cookie: { prefix: 'devkit' },
+  },
+}));
+
+vi.mock('../../../lib/services/axios', () => ({
+  default: { post: vi.fn(), get: vi.fn() },
+}));
+
+vi.mock('../../../lib/helpers/ability', () => ({
+  ability: { can: () => false },
+  updateAbilities: vi.fn(),
+}));
+
+vi.mock('../../../lib/helpers/analytics', () => ({
+  capture: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+}));
+
+vi.mock('../../organizations/stores/organizations.store', () => ({
+  useOrganizationsStore: () => ({ createOrganization: vi.fn() }),
+}));
+
+import AuthSignupView from '../views/signup.view.vue';
+
+const mockConfig = {
+  api: { protocol: 'http', host: 'localhost', port: '3000', base: 'api', endPoints: { auth: 'auth' } },
+  cookie: { prefix: 'devkit' },
+  sign: { route: '/tasks', in: true, up: true },
+  vuetify: { theme: { flat: true, rounded: 'rounded-lg' } },
+};
+
+/**
+ * Build a VForm stub whose validate() resolves with the given validity.
+ * @param {boolean} valid - Whether the form should pass validation.
+ * @returns {object} Vue component definition
+ */
+const makeFormStub = (valid = true) => ({
+  template: '<div><slot /></div>',
+  methods: {
+    validate: vi.fn().mockResolvedValue({ valid }),
+    reset: vi.fn(),
+  },
+});
+
+/**
+ * Mount the real signup view against the real (unmocked) auth store.
+ * @param {object} [routeQuery] - Optional $route.query override.
+ * @returns {import('@vue/test-utils').VueWrapper} mounted wrapper
+ */
+const mountView = (routeQuery = {}) =>
+  mount(AuthSignupView, {
+    global: {
+      plugins: [createVuetify()],
+      mocks: { config: mockConfig, $route: { query: routeQuery }, $router: { push: vi.fn() } },
+      stubs: { RouterLink: true, VForm: makeFormStub(), AuthOrganizationSetupComponent: true },
+    },
+  });
+
+describe('auth.signup.view — auth-watcher race (#4437, real store)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+    axios.get.mockReset();
+    axios.post.mockReset();
+  });
+
+  it('organizations disabled + emailVerificationRequired: shows the verification step and never navigates', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { data: { sign: { in: true, up: true }, organizations: { enabled: false } } },
+    });
+    axios.post.mockResolvedValueOnce({
+      data: { user: { email: 'race@example.com', roles: ['user'] }, tokenExpiresIn: 123, emailVerificationRequired: true },
+    });
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    wrapper.vm.email = 'race@example.com';
+    wrapper.vm.password = 'password123';
+
+    await wrapper.vm.validate();
+    await flushPromises();
+
+    expect(wrapper.vm.signupStep).toBe('emailVerification');
+    expect(wrapper.vm.$router.push).not.toHaveBeenCalled();
+  });
+
+  it('serverConfig null (failed config fetch) + emailVerificationRequired: shows the verification step and never navigates', async () => {
+    axios.get.mockRejectedValueOnce(new Error('config fetch failed'));
+    axios.post.mockResolvedValueOnce({
+      data: { user: { email: 'race2@example.com', roles: ['user'] }, tokenExpiresIn: 123, emailVerificationRequired: true },
+    });
+
+    const wrapper = mountView();
+    await flushPromises();
+    expect(wrapper.vm.serverConfig).toBeNull();
+
+    wrapper.vm.email = 'race2@example.com';
+    wrapper.vm.password = 'password123';
+
+    await wrapper.vm.validate();
+    await flushPromises();
+
+    expect(wrapper.vm.signupStep).toBe('emailVerification');
+    expect(wrapper.vm.$router.push).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/auth/views/signup.view.vue
+++ b/src/modules/auth/views/signup.view.vue
@@ -209,10 +209,6 @@ export default {
     };
   },
   computed: {
-    auth() {
-      const authStore = useAuthStore();
-      return authStore.auth;
-    },
     /**
      * @desc Compute the signup step title based on the current step.
      * @returns {string} Title for the current signup step.
@@ -255,16 +251,6 @@ export default {
     },
     themeName() {
       return this.theme.name;
-    },
-  },
-  watch: {
-    auth(auth) {
-      if (auth && this.signupStep === 'form') {
-        // Only auto-redirect if no org step is pending
-        if (!this.serverConfig?.organizations?.enabled) {
-          this.pushAfterAuth();
-        }
-      }
     },
   },
   /**


### PR DESCRIPTION
## Bug

On a signup that requires email verification, the user could be dropped straight into the app WITHOUT ever seeing the "check your inbox" step — when organizations are disabled, or when the server-config fetch returned null.

`signup.view.vue`'s `watch.auth` called `pushAfterAuth()` as soon as the store flipped `auth = true` (set synchronously inside `signup()`). That pre-flush watcher job lands on an **earlier microtask** than `validate()`'s own `await authStore.signup()` continuation, so on the `!serverConfig?.organizations?.enabled` path (also true when `serverConfig === null` after a failed config fetch) the watcher could navigate into the app *before* `validate()` reached the `emailVerificationRequired` branch and set `signupStep = 'emailVerification'` — silently skipping the verification gate. No router guard enforces email-verified downstream, so nothing caught it.

The existing unit suite mocked `useAuthStore` with a static `{ auth: false }` object — the component's `auth` computed never changed, so the watcher never fired in tests, masking the race entirely.

## Fix

`validate()` already calls `pushAfterAuth()` in every terminal branch where navigation should happen, so the watcher's fast-path push was redundant as well as unsafe. Removed the `watch.auth` handler (and the now-unused `auth` computed) entirely. OAuth's full-page href redirects (handled in `created()`) are unaffected.

## Test

Added `auth.signup.view.race.unit.tests.js`, which runs the **real** Pinia auth store (only network/analytics/ability are mocked) so `auth` flips via genuine reactivity, reproducing the actual microtask race. Both tests:
- fail against master's behavior (proves the race: `router.push('/tasks')` fires before the verification step is shown)
- pass with the fix

Covers: organizations disabled + `emailVerificationRequired`, and the `serverConfig === null` (failed config fetch) path.

Closes #4437


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signup behavior during email verification.
  * Prevented unintended navigation while authentication and configuration data are loading or unavailable.
  * Ensured signup reaches the email verification step reliably when organization features are disabled.

* **Tests**
  * Added regression coverage for successful and failed configuration-loading scenarios during signup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->