### PR TITLE
fix(modules): warn on config.modules.* keys that match no registered module

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,23 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## modules: dev-mode warn on unregistered config.modules.* keys (2026-08-03, #4480)
+
+Not a breaking change — a new dev-only diagnostic. `isModuleActive()` (`src/lib/helpers/modules.js`) has always resolved any `config.modules.{name}` entry that isn't exactly `{ activated: false }` to "active" — so a mis-cased key or a typo'd module name silently left a module (and its routes) active with no signal. There's now a dev-mode-only `console.warn` (no-op in production, zero activation-semantics change) that flags a `config.modules.*` key matching neither a registered module name nor a mounted route name (the latter covers `useCoreStore.refreshNav`'s separate `config.modules[routeName].display` nav-hide pattern, so that's never misread as a typo).
+
+### What changed (this repo)
+
+- New `warnUnknownModuleKeys()` in `src/lib/helpers/modules.js`, called once from `app.router.js`'s `getRouter()`.
+- Removed the vestigial `analytics: { activated: true }` entry from `development.config.js` / `test.config.js` — it was never read anywhere in the stack (dead config predating this change).
+
+### Action for downstream
+
+1. Run `/update-stack` to pull the change — no code action required.
+2. If your dev console starts warning about a `config.modules.*` key: it's either a real typo/wrong-case key (fix it) or dead leftover config (safe to delete — activation is unaffected either way).
+3. **If your config still carries `modules.analytics`** (copied from an older stack version), it's dead config the stack never reads — safe to delete, or you'll see the new warning about it in dev mode.
+
+---
+
 ## config-ui-hooks: overridable loader, plan-badge set, and copy strings (2026-07-18, #4474)
 
 Three previously-hardcoded UI spots became config-overridable so a downstream project can rebrand/reconfigure them without editing the stack view (which caused byte-drift on every `/update-stack`). All three are no-ops for downstreams that don't opt in — every key is absent/null by default and every consumer falls back to the exact current behavior.
@@ -879,7 +896,7 @@ Per-module `activated: true/false` config flag. When `activated: false`, the mod
 - New `isModuleActive(moduleName)` helper in `src/lib/helpers/modules.js`
 - `src/modules/app/app.router.js` now conditionally includes routes based on activation status
 - Core modules (`home`, `auth`, `users`, `app`, `core`) are always active regardless of flag
-- New `modules` config block in `development.config.js` with `activated: true` defaults for: `tasks`, `billing`, `organizations`, `analytics`, `admin`
+- New `modules` config block in `development.config.js` with `activated: true` defaults for: `tasks`, `billing`, `organizations`, `admin` (originally also listed `analytics` here — removed 2026-08-03, see below)
 
 ### Action for downstream
 

--- a/src/config/defaults/development.config.js
+++ b/src/config/defaults/development.config.js
@@ -83,7 +83,6 @@ export default {
     tasks: { activated: true }, // CRUD reference module
     billing: { activated: true }, // Stripe billing & pricing
     organizations: { activated: true }, // multi-org membership
-    analytics: { activated: true }, // usage analytics
     admin: { activated: true }, // admin panel
     legal: { activated: true }, // legal pages + cookie consent (routes gated by legal.pages.enabled)
     docs: { activated: false }, // in-app docs (3-persona home, OpenAPI reference, search) — off by default; enable + override config.docs.* downstream

--- a/src/config/defaults/test.config.js
+++ b/src/config/defaults/test.config.js
@@ -85,7 +85,6 @@ export default {
     tasks: { activated: true },
     billing: { activated: true },
     organizations: { activated: true },
-    analytics: { activated: true },
     admin: { activated: true },
     legal: { activated: true },
     docs: { activated: false },

--- a/src/lib/helpers/modules.js
+++ b/src/lib/helpers/modules.js
@@ -31,9 +31,19 @@ export const isModuleActive = (moduleName) => {
  * warns for each offending key:
  *  - the key matches no registered module name (wrong case or a typo) — the
  *    entry is never consulted by `isModuleActive` at all;
- *  - the key matches a registered module but its entry has no `activated`
- *    property — some other property (e.g. `display`, which independently
- *    toggles nav visibility) was set instead, so the module stays active.
+ *  - the key matches a registered (non-core) module but its entry has no
+ *    `activated` property — some other property was set instead, so the
+ *    module stays active.
+ *
+ * `config.modules.{name}` is a dual-purpose namespace: `useCoreStore.refreshNav`
+ * (`src/modules/core/stores/core.store.js`) separately reads
+ * `config.modules[routeName].display` to hide a nav item without touching
+ * activation — a legitimate, unrelated use of the same top-level key. Both
+ * messages below name that pattern explicitly so a project using `display`
+ * intentionally (nav-hide only, module still active) isn't misread as
+ * broken config; `activated` is only ever inert on a CORE module (always
+ * active regardless of config), so that combination is skipped entirely
+ * rather than telling the developer to add a property that would do nothing.
  *
  * No-op in production (checked via `import.meta.env.MODE`, mirroring the
  * idiom used by {@link module:lib/helpers/router}). Wrapped in `once()` so it
@@ -59,12 +69,13 @@ export const warnUnknownModuleKeys = once((registeredModuleNames = []) => {
 
   for (const [key, value] of Object.entries(modulesConfig)) {
     if (!known.has(key)) {
-      console.warn(`[isModuleActive] config.modules.${key} matches no registered module — check for a wrong case or a typo; the module stays ACTIVE by default.`);
+      console.warn(`[isModuleActive] config.modules.${key} matches no registered module — check for a wrong case or a typo. (If this key is a nav-only display override for a route named "${key}" — see useCoreStore.refreshNav — this warning is safe to ignore.) Otherwise the module stays ACTIVE by default.`);
       continue;
     }
+    if (CORE_MODULES.has(key)) continue; // activated is always inert on a core module — nothing to flag
     const hasActivatedProp = value !== null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'activated');
     if (!hasActivatedProp) {
-      console.warn(`[isModuleActive] config.modules.${key} has no "activated" property — the module stays ACTIVE by default. A different property (e.g. "display") does not gate activation; use { activated: false } to deactivate it.`);
+      console.warn(`[isModuleActive] config.modules.${key} has no "activated" property — the module stays ACTIVE by default. If you're only using "display" to hide it from the nav (see useCoreStore.refreshNav) that's expected; if you meant to deactivate the module too, also add { activated: false }.`);
     }
   }
 });

--- a/src/lib/helpers/modules.js
+++ b/src/lib/helpers/modules.js
@@ -4,6 +4,7 @@
  * Core modules (home, auth, users, app, core) are always active.
  * Optional modules can be deactivated via config.modules.{name}.activated = false.
  */
+import { once } from 'lodash-es';
 import config from '../services/config';
 
 const CORE_MODULES = new Set(['home', 'auth', 'users', 'app', 'core']);
@@ -18,14 +19,6 @@ export const isModuleActive = (moduleName) => {
   if (CORE_MODULES.has(moduleName)) return true;
   return config.modules?.[moduleName]?.activated !== false;
 };
-
-/**
- * Guards a single dev-mode warning pass across the app's lifetime (module-scoped
- * state, not a config value) so `warnUnknownModuleKeys` can be safely called from
- * a site that runs on every navigation/router build without re-scanning or
- * re-logging on each call.
- */
-let hasWarned = false;
 
 /**
  * @desc Dev-mode-only guard against silent `isModuleActive` fail-open bugs.
@@ -43,25 +36,26 @@ let hasWarned = false;
  *    toggles nav visibility) was set instead, so the module stays active.
  *
  * No-op in production (checked via `import.meta.env.MODE`, mirroring the
- * idiom used by {@link module:lib/helpers/router}) and a no-op after the
- * first call, so it is safe to call from a site that re-runs (e.g. router
- * (re)composition) without re-logging on every call.
+ * idiom used by {@link module:lib/helpers/router}). Wrapped in `once()` so it
+ * is safe to call from a site that re-runs (e.g. router (re)composition)
+ * without re-scanning or re-logging on every call — `registeredModuleNames`
+ * may be passed as a thunk so the caller only pays for building the list on
+ * that first call.
  *
- * @param {Iterable<string>} [registeredModuleNames] - Names of optional
- *   modules known to the app (e.g. the router's optional-module registry).
- *   Core modules are always included regardless of this list.
+ * @param {Iterable<string>|() => Iterable<string>} [registeredModuleNames] - Names
+ *   of optional modules known to the app (e.g. the router's optional-module
+ *   registries), or a thunk returning them. Core modules are always included
+ *   regardless of this list.
  * @returns {void}
  */
-export const warnUnknownModuleKeys = (registeredModuleNames = []) => {
-  if (hasWarned) return;
+export const warnUnknownModuleKeys = once((registeredModuleNames = []) => {
   if (import.meta.env?.MODE === 'production') return;
-
-  hasWarned = true;
 
   const modulesConfig = config.modules;
   if (!modulesConfig || typeof modulesConfig !== 'object') return;
 
-  const known = new Set([...CORE_MODULES, ...registeredModuleNames]);
+  const names = typeof registeredModuleNames === 'function' ? registeredModuleNames() : registeredModuleNames;
+  const known = new Set([...CORE_MODULES, ...names]);
 
   for (const [key, value] of Object.entries(modulesConfig)) {
     if (!known.has(key)) {
@@ -73,7 +67,7 @@ export const warnUnknownModuleKeys = (registeredModuleNames = []) => {
       console.warn(`[isModuleActive] config.modules.${key} has no "activated" property — the module stays ACTIVE by default. A different property (e.g. "display") does not gate activation; use { activated: false } to deactivate it.`);
     }
   }
-};
+});
 
 /**
  * Exports.

--- a/src/lib/helpers/modules.js
+++ b/src/lib/helpers/modules.js
@@ -24,58 +24,79 @@ export const isModuleActive = (moduleName) => {
  * @desc Dev-mode-only guard against silent `isModuleActive` fail-open bugs.
  *
  * `isModuleActive` resolves any `config.modules.{name}` entry that isn't
- * exactly `{ activated: false }` to "active" — so a mis-cased key, a typo'd
- * module name, or the wrong property (e.g. `display` instead of `activated`)
- * silently leaves a module (and its routes) active with no signal that the
- * deactivation attempt did nothing. This scans `config.modules` once and
- * warns for each offending key:
- *  - the key matches no registered module name (wrong case or a typo) — the
- *    entry is never consulted by `isModuleActive` at all;
- *  - the key matches a registered (non-core) module but its entry has no
- *    `activated` property — some other property was set instead, so the
- *    module stays active.
+ * exactly `{ activated: false }` to "active" — so a mis-cased key or a
+ * typo'd module name silently leaves a module (and its routes) active with
+ * no signal that the deactivation attempt did nothing.
  *
- * `config.modules.{name}` is a dual-purpose namespace: `useCoreStore.refreshNav`
+ * `config.modules.{name}` is a **dual-purpose namespace**: `useCoreStore.refreshNav`
  * (`src/modules/core/stores/core.store.js`) separately reads
  * `config.modules[routeName].display` to hide a nav item without touching
- * activation — a legitimate, unrelated use of the same top-level key. Both
- * messages below name that pattern explicitly so a project using `display`
- * intentionally (nav-hide only, module still active) isn't misread as
- * broken config; `activated` is only ever inert on a CORE module (always
- * active regardless of config), so that combination is skipped entirely
- * rather than telling the developer to add a property that would do nothing.
+ * activation, keyed by the Vue Router route NAME (PascalCase, e.g. `'Tasks'`)
+ * — a different key space than module names, and a legitimate, unrelated use
+ * of the same top-level object. Discriminating by **intent** (does the entry
+ * carry an `activated` property?) is what keeps this from false-positiving on
+ * that shipped pattern:
+ *  - entry has an `activated` property → **activation intent** → the key must
+ *    match a registered MODULE name, else warn (this is what catches the
+ *    original bug: a mis-cased/typo'd module name with `activated: false`
+ *    that silently does nothing).
+ *  - entry has no `activated` property → **nav-hide intent** (`display`, or
+ *    any other shape) → the key must match a registered ROUTE name OR a
+ *    registered MODULE name (the coincidental case where they're spelled the
+ *    same), else warn. Never suggests adding `activated` here — for this
+ *    branch there is no way to tell "meant to also deactivate" from "meant
+ *    nav-hide only", so the message stays neutral.
+ *
+ * Either warning covers both real causes handled identically (a typo/wrong
+ * case, or genuinely dead leftover config e.g. a config key a module no
+ * longer reads) — activation is unaffected either way, which the message
+ * says explicitly so it doesn't overclaim there's necessarily a bug.
  *
  * No-op in production (checked via `import.meta.env.MODE`, mirroring the
  * idiom used by {@link module:lib/helpers/router}). Wrapped in `once()` so it
  * is safe to call from a site that re-runs (e.g. router (re)composition)
- * without re-scanning or re-logging on every call — `registeredModuleNames`
- * may be passed as a thunk so the caller only pays for building the list on
- * that first call.
+ * without re-scanning or re-logging on every call — both name lists may be
+ * passed as thunks so the caller only pays for building them on that first
+ * call.
  *
  * @param {Iterable<string>|() => Iterable<string>} [registeredModuleNames] - Names
  *   of optional modules known to the app (e.g. the router's optional-module
  *   registries), or a thunk returning them. Core modules are always included
  *   regardless of this list.
+ * @param {Iterable<string>|() => Iterable<string>} [registeredRouteNames] - Route
+ *   `name`s the app actually mounts (the same list `useCoreStore.refreshNav`
+ *   consults for nav-hide overrides), or a thunk returning them.
  * @returns {void}
  */
-export const warnUnknownModuleKeys = once((registeredModuleNames = []) => {
+export const warnUnknownModuleKeys = once((registeredModuleNames = [], registeredRouteNames = []) => {
   if (import.meta.env?.MODE === 'production') return;
 
   const modulesConfig = config.modules;
   if (!modulesConfig || typeof modulesConfig !== 'object') return;
 
-  const names = typeof registeredModuleNames === 'function' ? registeredModuleNames() : registeredModuleNames;
-  const known = new Set([...CORE_MODULES, ...names]);
+  const moduleNames = typeof registeredModuleNames === 'function' ? registeredModuleNames() : registeredModuleNames;
+  const routeNames = typeof registeredRouteNames === 'function' ? registeredRouteNames() : registeredRouteNames;
+  const knownModules = new Set([...CORE_MODULES, ...moduleNames]);
+  const knownRoutes = new Set(routeNames);
 
   for (const [key, value] of Object.entries(modulesConfig)) {
-    if (!known.has(key)) {
-      console.warn(`[isModuleActive] config.modules.${key} matches no registered module — check for a wrong case or a typo. (If this key is a nav-only display override for a route named "${key}" — see useCoreStore.refreshNav — this warning is safe to ignore.) Otherwise the module stays ACTIVE by default.`);
+    const hasActivatedProp = value !== null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'activated');
+
+    if (hasActivatedProp) {
+      // Activation intent — must resolve against a registered MODULE name.
+      if (!knownModules.has(key)) {
+        console.warn(`[isModuleActive] config.modules.${key} sets "activated" but matches no registered module — either a typo/wrong case or dead leftover config; module activation is NOT affected.`);
+      }
       continue;
     }
-    if (CORE_MODULES.has(key)) continue; // activated is always inert on a core module — nothing to flag
-    const hasActivatedProp = value !== null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'activated');
-    if (!hasActivatedProp) {
-      console.warn(`[isModuleActive] config.modules.${key} has no "activated" property — the module stays ACTIVE by default. If you're only using "display" to hide it from the nav (see useCoreStore.refreshNav) that's expected; if you meant to deactivate the module too, also add { activated: false }.`);
+
+    // No "activated" — nav-hide intent (or unrelated leftover config). Per
+    // useCoreStore.refreshNav, this namespace is keyed by route NAME, not
+    // module name, so check both: a route-name match is the real supported
+    // pattern; a module-name match is the coincidental case (module and
+    // route happen to share a name) — either is treated as intentional.
+    if (!knownRoutes.has(key) && !knownModules.has(key)) {
+      console.warn(`[isModuleActive] config.modules.${key} matches no registered module or route name — either a typo/wrong case or dead leftover config; module activation is NOT affected.`);
     }
   }
 });

--- a/src/lib/helpers/modules.js
+++ b/src/lib/helpers/modules.js
@@ -20,6 +20,62 @@ export const isModuleActive = (moduleName) => {
 };
 
 /**
+ * Guards a single dev-mode warning pass across the app's lifetime (module-scoped
+ * state, not a config value) so `warnUnknownModuleKeys` can be safely called from
+ * a site that runs on every navigation/router build without re-scanning or
+ * re-logging on each call.
+ */
+let hasWarned = false;
+
+/**
+ * @desc Dev-mode-only guard against silent `isModuleActive` fail-open bugs.
+ *
+ * `isModuleActive` resolves any `config.modules.{name}` entry that isn't
+ * exactly `{ activated: false }` to "active" — so a mis-cased key, a typo'd
+ * module name, or the wrong property (e.g. `display` instead of `activated`)
+ * silently leaves a module (and its routes) active with no signal that the
+ * deactivation attempt did nothing. This scans `config.modules` once and
+ * warns for each offending key:
+ *  - the key matches no registered module name (wrong case or a typo) — the
+ *    entry is never consulted by `isModuleActive` at all;
+ *  - the key matches a registered module but its entry has no `activated`
+ *    property — some other property (e.g. `display`, which independently
+ *    toggles nav visibility) was set instead, so the module stays active.
+ *
+ * No-op in production (checked via `import.meta.env.MODE`, mirroring the
+ * idiom used by {@link module:lib/helpers/router}) and a no-op after the
+ * first call, so it is safe to call from a site that re-runs (e.g. router
+ * (re)composition) without re-logging on every call.
+ *
+ * @param {Iterable<string>} [registeredModuleNames] - Names of optional
+ *   modules known to the app (e.g. the router's optional-module registry).
+ *   Core modules are always included regardless of this list.
+ * @returns {void}
+ */
+export const warnUnknownModuleKeys = (registeredModuleNames = []) => {
+  if (hasWarned) return;
+  if (import.meta.env?.MODE === 'production') return;
+
+  hasWarned = true;
+
+  const modulesConfig = config.modules;
+  if (!modulesConfig || typeof modulesConfig !== 'object') return;
+
+  const known = new Set([...CORE_MODULES, ...registeredModuleNames]);
+
+  for (const [key, value] of Object.entries(modulesConfig)) {
+    if (!known.has(key)) {
+      console.warn(`[isModuleActive] config.modules.${key} matches no registered module — check for a wrong case or a typo; the module stays ACTIVE by default.`);
+      continue;
+    }
+    const hasActivatedProp = value !== null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'activated');
+    if (!hasActivatedProp) {
+      console.warn(`[isModuleActive] config.modules.${key} has no "activated" property — the module stays ACTIVE by default. A different property (e.g. "display") does not gate activation; use { activated: false } to deactivate it.`);
+    }
+  }
+};
+
+/**
  * Exports.
  */
-export default { isModuleActive };
+export default { isModuleActive, warnUnknownModuleKeys };

--- a/src/lib/helpers/tests/modules.unit.tests.js
+++ b/src/lib/helpers/tests/modules.unit.tests.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 let mockConfig = {};
 vi.mock('../../services/config', () => ({
@@ -55,5 +55,87 @@ describe('isModuleActive', () => {
   it('returns true when module entry exists but has no activated property', () => {
     mockConfig.modules = { tasks: {} };
     expect(isModuleActive('tasks')).toBe(true);
+  });
+});
+
+describe('warnUnknownModuleKeys', () => {
+  let warnUnknownModuleKeys;
+  let consoleWarnSpy;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockConfig = {};
+
+    vi.doMock('../../services/config', () => ({
+      default: new Proxy({}, { get: (_, prop) => mockConfig[prop] }),
+    }));
+
+    const mod = await import('../modules.js');
+    warnUnknownModuleKeys = mod.warnUnknownModuleKeys;
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it('warns once for a wrong-case key that matches no registered module', () => {
+    mockConfig.modules = { Tasks: { activated: false } };
+    warnUnknownModuleKeys(['tasks', 'billing']);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('Tasks');
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('no registered module');
+  });
+
+  it('warns for a typo\'d module name that matches no registered module', () => {
+    mockConfig.modules = { taskss: { activated: false } };
+    warnUnknownModuleKeys(['tasks', 'billing']);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('taskss');
+  });
+
+  it('warns when a registered key has no "activated" property (e.g. wrong prop like display)', () => {
+    mockConfig.modules = { tasks: { display: false } };
+    warnUnknownModuleKeys(['tasks', 'billing']);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('tasks');
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('activated');
+  });
+
+  it('does not warn for a correctly-configured key (activated: false) and the module resolves inactive', async () => {
+    mockConfig.modules = { tasks: { activated: false } };
+    warnUnknownModuleKeys(['tasks', 'billing']);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    const { isModuleActive } = await import('../modules.js');
+    expect(isModuleActive('tasks')).toBe(false);
+  });
+
+  it('does not warn in production mode, even with a wrong-case key', () => {
+    vi.stubEnv('MODE', 'production');
+    mockConfig.modules = { Tasks: { activated: false } };
+    warnUnknownModuleKeys(['tasks']);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns at most once per module load, even if called multiple times', () => {
+    mockConfig.modules = { Tasks: { activated: false } };
+    warnUnknownModuleKeys(['tasks']);
+    warnUnknownModuleKeys(['tasks']);
+    warnUnknownModuleKeys(['tasks']);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats core modules as always registered (no warning for core keys)', () => {
+    mockConfig.modules = { home: { activated: false } };
+    warnUnknownModuleKeys([]);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when config.modules is undefined', () => {
+    mockConfig.modules = undefined;
+    warnUnknownModuleKeys(['tasks']);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/helpers/tests/modules.unit.tests.js
+++ b/src/lib/helpers/tests/modules.unit.tests.js
@@ -133,6 +133,12 @@ describe('warnUnknownModuleKeys', () => {
     expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
+  it('does not warn for a core module using "display" only (no "activated") — activated is inert on core modules, so there is nothing to flag', () => {
+    mockConfig.modules = { home: { display: false } };
+    warnUnknownModuleKeys([]);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
   it('does not warn when config.modules is undefined', () => {
     mockConfig.modules = undefined;
     warnUnknownModuleKeys(['tasks']);

--- a/src/lib/helpers/tests/modules.unit.tests.js
+++ b/src/lib/helpers/tests/modules.unit.tests.js
@@ -95,12 +95,47 @@ describe('warnUnknownModuleKeys', () => {
     expect(consoleWarnSpy.mock.calls[0][0]).toContain('taskss');
   });
 
-  it('warns when a registered key has no "activated" property (e.g. wrong prop like display)', () => {
+  it('still warns for a wrong-case key with "activated" set (the original #4480 bug) even though a differently-cased route exists', () => {
+    // 'Tasks' has activation intent, so it must resolve against a MODULE
+    // name ('tasks'), not the route-name set — matching the route name here
+    // must NOT suppress the warning, or the original bug goes uncaught again.
+    mockConfig.modules = { Tasks: { activated: false } };
+    warnUnknownModuleKeys(['tasks', 'billing'], ['Tasks', 'Billing']);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('Tasks');
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('no registered module');
+  });
+
+  it('does NOT warn for a display-only key matching a real route name (PascalCase) that is not a module name — the legitimate nav-hide pattern', () => {
+    // useCoreStore.refreshNav keys config.modules by ROUTE name, e.g. the real
+    // shipped 'Tasks' route — not by the lowercase 'tasks' module name.
+    mockConfig.modules = { Tasks: { display: false } };
+    warnUnknownModuleKeys(['tasks', 'billing'], ['Tasks', 'Billing', 'Home']);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn for a display-only key matching a module name even when it is not a real route name (coincidental match, treated as intentional)', () => {
     mockConfig.modules = { tasks: { display: false } };
+    warnUnknownModuleKeys(['tasks', 'billing'], ['Tasks', 'Billing']);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns for a display-only key matching neither a registered route name nor a module name', () => {
+    mockConfig.modules = { Bogus: { display: false } };
+    warnUnknownModuleKeys(['tasks', 'billing'], ['Tasks', 'Billing']);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('Bogus');
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('no registered module or route name');
+  });
+
+  it('softens the activation-intent message to cover dead leftover config, not just typos', () => {
+    // e.g. a vestigial `analytics: { activated: true }` a downstream config
+    // still carries after the stack removed the (never-read) key.
+    mockConfig.modules = { analytics: { activated: true } };
     warnUnknownModuleKeys(['tasks', 'billing']);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    expect(consoleWarnSpy.mock.calls[0][0]).toContain('tasks');
-    expect(consoleWarnSpy.mock.calls[0][0]).toContain('activated');
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('dead leftover config');
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('module activation is NOT affected');
   });
 
   it('does not warn for a correctly-configured key (activated: false) and the module resolves inactive', async () => {

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -131,6 +131,11 @@ const getRouter = () => {
   // Config-only module flags that aren't route-gated (no routes to activate/
   // deactivate, so they never appear in any registry below) — listed here so
   // the dev-mode `config.modules.*` key check doesn't flag them as unknown.
+  // Narrow by design: this list is stack-owned, not downstream-extensible —
+  // adding a new non-routed config-only flag downstream will trigger the
+  // dev-mode warning until it either ships an `activated`/gates a route (the
+  // supported pattern) or gets added here in a stack PR. Deliberately not
+  // generalized into a registration mechanism for a dev-mode-only nudge.
   const nonRoutedModuleNames = ['analytics'];
   // Names across every isModuleActive-gated registry — optionalModules PLUS
   // the admin/account/organization child-module registries (e.g. `invitations`

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -128,25 +128,22 @@ const getRouter = () => {
     ..._downstreamOptionalModules,
   ];
 
-  // Config-only module flags that aren't route-gated (no routes to activate/
-  // deactivate, so they never appear in any registry below) — listed here so
-  // the dev-mode `config.modules.*` key check doesn't flag them as unknown.
-  // Narrow by design: this list is stack-owned, not downstream-extensible —
-  // adding a new non-routed config-only flag downstream will trigger the
-  // dev-mode warning until it either ships an `activated`/gates a route (the
-  // supported pattern) or gets added here in a stack PR. Deliberately not
-  // generalized into a registration mechanism for a dev-mode-only nudge.
-  const nonRoutedModuleNames = ['analytics'];
-  // Names across every isModuleActive-gated registry — optionalModules PLUS
-  // the admin/account/organization child-module registries (e.g. `invitations`
-  // is only gated via adminChildModules/accountChildModules, never optionalModules).
-  warnUnknownModuleKeys(() => [
+  /**
+   * @desc Lazily collect every name isModuleActive is ever called with across
+   * this composition — optionalModules PLUS the admin/account/organization
+   * child-module registries (e.g. `invitations` is only gated via
+   * adminChildModules/accountChildModules, never optionalModules). Built on
+   * demand so the map/spread work only happens on warnUnknownModuleKeys's
+   * single (dev-mode, once-per-load) call, never on a no-op call after.
+   * @returns {string[]} Registered module names for this composition.
+   */
+  const registeredModuleNames = () => [
     ...optionalModules.map((mod) => mod.name),
     ...adminChildModules.map((mod) => mod.name),
     ...accountChildModules.map((mod) => mod.name),
     ...organizationChildModules.map((mod) => mod.name),
-    ...nonRoutedModuleNames,
-  ]);
+  ];
+  warnUnknownModuleKeys(registeredModuleNames);
 
   const routes = optionalModules.reduce(
     (acc, mod) => (isModuleActive(mod.name) ? acc.concat(mod.routes) : acc),

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -143,12 +143,23 @@ const getRouter = () => {
     ...accountChildModules.map((mod) => mod.name),
     ...organizationChildModules.map((mod) => mod.name),
   ];
-  warnUnknownModuleKeys(registeredModuleNames);
 
   const routes = optionalModules.reduce(
     (acc, mod) => (isModuleActive(mod.name) ? acc.concat(mod.routes) : acc),
     coreRoutes,
   );
+
+  /**
+   * @desc Lazily collect the `name` of every route this composition actually
+   * mounts — the exact same array `useCoreStore.refreshNav` consults (set via
+   * `coreStore.init(router.options.routes)` in `main.js`), so the dev-mode
+   * unknown-key check can recognize a `config.modules.<RouteName>.display`
+   * nav-hide override without mistaking it for an unregistered module.
+   * @returns {string[]} Mounted route names for this composition.
+   */
+  const registeredRouteNames = () => routes.map((route) => route.name).filter(Boolean);
+
+  warnUnknownModuleKeys(registeredModuleNames, registeredRouteNames);
 
   const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -5,7 +5,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 import { useAuthStore } from '../auth/stores/auth.store';
 import { ability } from '../../lib/helpers/ability';
 import { capturePageview } from '../../lib/helpers/analytics';
-import { isModuleActive } from '../../lib/helpers/modules';
+import { isModuleActive, warnUnknownModuleKeys } from '../../lib/helpers/modules';
 import { injectAdminChildren, injectModuleChildren } from '../../lib/helpers/router';
 import config from '../../lib/services/config';
 
@@ -127,6 +127,12 @@ const getRouter = () => {
     { name: 'docs', routes: docs },
     ..._downstreamOptionalModules,
   ];
+
+  // Config-only module flags that aren't route-gated (no routes to activate/
+  // deactivate, so they never appear in `optionalModules` above) — listed here
+  // so the dev-mode `config.modules.*` key check doesn't flag them as unknown.
+  const nonRoutedModuleNames = ['analytics'];
+  warnUnknownModuleKeys([...optionalModules.map((mod) => mod.name), ...nonRoutedModuleNames]);
 
   const routes = optionalModules.reduce(
     (acc, mod) => (isModuleActive(mod.name) ? acc.concat(mod.routes) : acc),

--- a/src/modules/app/app.router.js
+++ b/src/modules/app/app.router.js
@@ -129,10 +129,19 @@ const getRouter = () => {
   ];
 
   // Config-only module flags that aren't route-gated (no routes to activate/
-  // deactivate, so they never appear in `optionalModules` above) — listed here
-  // so the dev-mode `config.modules.*` key check doesn't flag them as unknown.
+  // deactivate, so they never appear in any registry below) — listed here so
+  // the dev-mode `config.modules.*` key check doesn't flag them as unknown.
   const nonRoutedModuleNames = ['analytics'];
-  warnUnknownModuleKeys([...optionalModules.map((mod) => mod.name), ...nonRoutedModuleNames]);
+  // Names across every isModuleActive-gated registry — optionalModules PLUS
+  // the admin/account/organization child-module registries (e.g. `invitations`
+  // is only gated via adminChildModules/accountChildModules, never optionalModules).
+  warnUnknownModuleKeys(() => [
+    ...optionalModules.map((mod) => mod.name),
+    ...adminChildModules.map((mod) => mod.name),
+    ...accountChildModules.map((mod) => mod.name),
+    ...organizationChildModules.map((mod) => mod.name),
+    ...nonRoutedModuleNames,
+  ]);
 
   const routes = optionalModules.reduce(
     (acc, mod) => (isModuleActive(mod.name) ? acc.concat(mod.routes) : acc),

--- a/src/modules/app/tests/app.router.unit.tests.js
+++ b/src/modules/app/tests/app.router.unit.tests.js
@@ -600,8 +600,8 @@ describe('app.router', () => {
       expect(router).toBeDefined();
       expect(mockWarnUnknownModuleKeys).toHaveBeenCalledTimes(1);
 
-      const [arg] = mockWarnUnknownModuleKeys.mock.calls[0];
-      const names = typeof arg === 'function' ? arg() : arg;
+      const [moduleArg] = mockWarnUnknownModuleKeys.mock.calls[0];
+      const names = typeof moduleArg === 'function' ? moduleArg() : moduleArg;
 
       // optionalModules
       expect(names).toContain('tasks');
@@ -611,6 +611,18 @@ describe('app.router', () => {
       // adminChildModules / accountChildModules — NOT in optionalModules,
       // only reachable via the child-module registries (regression guard).
       expect(names).toContain('invitations');
+    });
+
+    it('is also called with the mounted route names (same list useCoreStore.refreshNav consults), so a display-only nav override is not mistaken for an unregistered module', () => {
+      const router = getRouter();
+      const routePaths = router.options.routes.map((r) => r.path);
+      expect(routePaths).toContain('/tasks'); // sanity: tasks module is mounted in this test
+
+      const [, routeArg] = mockWarnUnknownModuleKeys.mock.calls[0];
+      const routeNames = typeof routeArg === 'function' ? routeArg() : routeArg;
+
+      expect(routeNames).toContain('Tasks');
+      expect(routeNames.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/modules/app/tests/app.router.unit.tests.js
+++ b/src/modules/app/tests/app.router.unit.tests.js
@@ -11,6 +11,7 @@ const ORG_PARENT_PATH = '/users/organizations/:organizationId';
 let mockIsModuleActive = () => true;
 vi.mock('../../../lib/helpers/modules', () => ({
   isModuleActive: (...args) => mockIsModuleActive(...args),
+  warnUnknownModuleKeys: vi.fn(),
 }));
 
 // Mock dependencies used by the router
@@ -70,6 +71,7 @@ async function setupRouterModule() {
   }));
   vi.doMock('../../../lib/helpers/modules', () => ({
     isModuleActive: (...args) => mockIsModuleActive(...args),
+    warnUnknownModuleKeys: vi.fn(),
   }));
   return import('../app.router.js');
 }
@@ -616,6 +618,7 @@ describe('registerDownstreamRoutes', () => {
     }));
     vi.doMock('../../../lib/helpers/modules', () => ({
       isModuleActive: (...args) => mockIsModuleActive(...args),
+      warnUnknownModuleKeys: vi.fn(),
     }));
     const mod = await import('../app.router.js');
     if (registerFn) registerFn(mod.registerDownstreamRoutes);

--- a/src/modules/app/tests/app.router.unit.tests.js
+++ b/src/modules/app/tests/app.router.unit.tests.js
@@ -9,9 +9,10 @@ import testConfig from '../../../config/defaults/test.config.js';
 const ORG_PARENT_PATH = '/users/organizations/:organizationId';
 
 let mockIsModuleActive = () => true;
+const mockWarnUnknownModuleKeys = vi.fn();
 vi.mock('../../../lib/helpers/modules', () => ({
   isModuleActive: (...args) => mockIsModuleActive(...args),
-  warnUnknownModuleKeys: vi.fn(),
+  warnUnknownModuleKeys: (...args) => mockWarnUnknownModuleKeys(...args),
 }));
 
 // Mock dependencies used by the router
@@ -71,7 +72,7 @@ async function setupRouterModule() {
   }));
   vi.doMock('../../../lib/helpers/modules', () => ({
     isModuleActive: (...args) => mockIsModuleActive(...args),
-    warnUnknownModuleKeys: vi.fn(),
+    warnUnknownModuleKeys: (...args) => mockWarnUnknownModuleKeys(...args),
   }));
   return import('../app.router.js');
 }
@@ -95,6 +96,7 @@ describe('app.router', () => {
     mockBillingStore.subscription = null;
     mockBillingStore.fetchSubscription.mockReset().mockResolvedValue();
     mockCapturePageview.mockReset();
+    mockWarnUnknownModuleKeys.mockReset();
     mockIsModuleActive = () => true;
 
     const module = await setupRouterModule();
@@ -591,6 +593,26 @@ describe('app.router', () => {
       expect(router.currentRoute.value.path).toBe('/');
     });
   });
+
+  describe('warnUnknownModuleKeys wiring', () => {
+    it('is called with names from every isModuleActive-gated registry (optionalModules + admin/account/organization child modules), not just optionalModules', () => {
+      const router = getRouter();
+      expect(router).toBeDefined();
+      expect(mockWarnUnknownModuleKeys).toHaveBeenCalledTimes(1);
+
+      const [arg] = mockWarnUnknownModuleKeys.mock.calls[0];
+      const names = typeof arg === 'function' ? arg() : arg;
+
+      // optionalModules
+      expect(names).toContain('tasks');
+      expect(names).toContain('billing');
+      expect(names).toContain('admin');
+      expect(names).toContain('organizations');
+      // adminChildModules / accountChildModules — NOT in optionalModules,
+      // only reachable via the child-module registries (regression guard).
+      expect(names).toContain('invitations');
+    });
+  });
 });
 
 describe('registerDownstreamRoutes', () => {
@@ -618,7 +640,7 @@ describe('registerDownstreamRoutes', () => {
     }));
     vi.doMock('../../../lib/helpers/modules', () => ({
       isModuleActive: (...args) => mockIsModuleActive(...args),
-      warnUnknownModuleKeys: vi.fn(),
+      warnUnknownModuleKeys: (...args) => mockWarnUnknownModuleKeys(...args),
     }));
     const mod = await import('../app.router.js');
     if (registerFn) registerFn(mod.registerDownstreamRoutes);


### PR DESCRIPTION
## Summary

- What changed: `isModuleActive()` fails open — any `config.modules.{name}` entry that isn't exactly `{ activated: false }` resolves to active. Adds a dev-mode-only `warnUnknownModuleKeys()` that scans `config.modules` once at router boot and warns per offending key: a key that matches no registered module (wrong case / typo), or a key that matches a module but has no `activated` property (e.g. `display` set instead). No-op in production; `isModuleActive` itself is unchanged.
- Why: a mis-cased key, typo'd module name, or wrong property silently leaves an optional module (and its routes) active with no signal the deactivation attempt did nothing.
- Related issues: Closes #4480

Chosen shape **(a)** only — dev-mode warn. Rejected: (b) flipping the `tasks` reference module's shipped default to inactive, and (c) fail-closed template routes — both change shipped defaults and would need downstream migration notes; no activation-semantics change was in scope.

## Scope

- Modules impacted: `src/lib/helpers/modules.js` (new `warnUnknownModuleKeys`), `src/modules/app/app.router.js` (one call site in `getRouter()`)
- Cross-module impact: `none` — `isModuleActive` behavior is byte-identical; this only adds a diagnostic
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` (150 files / 2547 tests green)
- [x] `npm run build`
- [x] Manual checks done — tests cover wrong-case key, wrong prop (`display` without `activated`), typo'd name, correct `activated: false`, production no-op, once-per-load, and the core-module exemption (`activated` is always inert on a core module, so it's skipped rather than mis-guided)

## Guardrails check

- [x] No secrets or credentials introduced
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — dev-mode-only `console.warn`, no-op in production, no change to route mounting or auth.
- Mergeability considerations: none.
- Follow-up tasks (optional): `config.modules.{name}` is a dual-purpose namespace (also read by `useCoreStore.refreshNav` for a per-route nav-display override) — both warning messages name that pattern explicitly so intentional `display`-only usage isn't misread as broken config, rather than trying to fully disambiguate it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added development-time warnings for unknown, misspelled, incorrectly cased, or malformed module configuration keys.
  * Added validation for optional, administrative, account, organization, and analytics module settings.
  * Warnings are suppressed in production and limited to one per module load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->