### PR TITLE
feat(seo): serve a build-time docs API snapshot during prerender capture

### DIFF
--- a/src/lib/plugins/docs-seo.js
+++ b/src/lib/plugins/docs-seo.js
@@ -209,7 +209,9 @@ export function deriveDocsSnapshotEntries(tree, contentUrl) {
   ];
   for (const cat of normalizeCategories(tree)) {
     for (const guide of cat.guides) {
-      const path = `${basePath}/${guide.slug}.md`;
+      // Encode the slug exactly like the runtime docs service does — the page
+      // requests the ENCODED pathname, and matchSnapshot compares literally.
+      const path = `${basePath}/${encodeURIComponent(guide.slug)}.md`;
       entries.push({ path, url: `${origin}${path}`, kind: 'article' });
     }
   }
@@ -234,11 +236,18 @@ export async function fetchDocsSnapshot(tree, contentUrl, options = {}) {
   const { timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = globalThis.fetch } = options;
   const snapshot = {};
   const treeBody = JSON.stringify(tree);
+  // Mirror fetchDocsTree's guard: a missing/non-function fetch keeps the layer
+  // fail-soft (tree entries need no I/O; articles are skipped with a warning).
+  const canFetch = typeof fetchImpl === 'function';
+  if (!canFetch) {
+    console.warn('[docs-seo] No fetch implementation available, article snapshot entries skipped.');
+  }
   for (const entry of deriveDocsSnapshotEntries(tree, contentUrl)) {
     if (entry.kind === 'tree') {
       snapshot[entry.path] = { body: treeBody, contentType: 'application/json' };
       continue;
     }
+    if (!canFetch) continue;
     try {
       const res = await fetchImpl(entry.url, { signal: AbortSignal.timeout(timeoutMs) });
       if (!res?.ok) {

--- a/src/lib/plugins/docs-seo.js
+++ b/src/lib/plugins/docs-seo.js
@@ -180,6 +180,81 @@ export function deriveDocsLlmsSections(tree, baseUrl, basePath = DEFAULT_BASE_PA
 }
 
 /**
+ * Derive the API-snapshot entries the prerender page will request at capture
+ * time: the docs tree endpoint (both slash forms, since runtime clients may
+ * request the trailing-slash form) plus one raw-markdown twin per guide.
+ * Entries are keyed by URL PATHNAME so the prerender-time match stays
+ * origin-agnostic — the runtime API origin can differ from `contentUrl`'s.
+ * Pure — no I/O.
+ *
+ * @param {object|null} tree - the docs tree (`{ categories: [...] }`)
+ * @param {string} contentUrl - absolute URL of the docs tree endpoint
+ * @returns {Array<{ path: string, url: string, kind: 'tree'|'article' }>}
+ *   snapshot entries (`path` = pathname the page will request, `url` = absolute
+ *   URL to fetch at build time); empty when contentUrl is absent or malformed
+ */
+export function deriveDocsSnapshotEntries(tree, contentUrl) {
+  if (!contentUrl) return [];
+  let parsed;
+  try {
+    parsed = new URL(contentUrl);
+  } catch {
+    return [];
+  }
+  const basePath = parsed.pathname.replace(/\/+$/, '');
+  const origin = parsed.origin;
+  const entries = [
+    { path: basePath, url: `${origin}${basePath}`, kind: 'tree' },
+    { path: `${basePath}/`, url: `${origin}${basePath}`, kind: 'tree' },
+  ];
+  for (const cat of normalizeCategories(tree)) {
+    for (const guide of cat.guides) {
+      const path = `${basePath}/${guide.slug}.md`;
+      entries.push({ path, url: `${origin}${path}`, kind: 'article' });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Fetch the API-snapshot bodies at build time. The tree is NOT refetched — it
+ * is re-serialised from the already-fetched object. Articles are fetched
+ * FAIL-SOFT one by one: a failed article logs a warning and is skipped, so
+ * that page simply prerenders without a body (exactly today's behaviour).
+ *
+ * @param {object|null} tree - the already-fetched docs tree
+ * @param {string} contentUrl - absolute URL of the docs tree endpoint
+ * @param {object} [options]
+ * @param {number} [options.timeoutMs=5000] - per-request timeout in milliseconds
+ * @param {typeof fetch} [options.fetchImpl=globalThis.fetch] - injectable fetch (tests)
+ * @returns {Promise<Record<string, { body: string, contentType: string }>>}
+ *   pathname → response snapshot, served to the page during prerender capture
+ */
+export async function fetchDocsSnapshot(tree, contentUrl, options = {}) {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = globalThis.fetch } = options;
+  const snapshot = {};
+  const treeBody = JSON.stringify(tree);
+  for (const entry of deriveDocsSnapshotEntries(tree, contentUrl)) {
+    if (entry.kind === 'tree') {
+      snapshot[entry.path] = { body: treeBody, contentType: 'application/json' };
+      continue;
+    }
+    try {
+      const res = await fetchImpl(entry.url, { signal: AbortSignal.timeout(timeoutMs) });
+      if (!res?.ok) {
+        console.warn(`[docs-seo] Snapshot fetch HTTP ${res?.status ?? '??'} for ${entry.url}, page will prerender without this body.`);
+        continue;
+      }
+      snapshot[entry.path] = { body: await res.text(), contentType: 'text/markdown' };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[docs-seo] Snapshot fetch failed for ${entry.url}, page will prerender without this body:`, message);
+    }
+  }
+  return snapshot;
+}
+
+/**
  * Build-time entry point. When `app.seo.docs.enabled` and `app.seo.docs.contentUrl`
  * are set, fetch the docs tree and return a NEW config object whose `app.seo` has
  * the docs-derived prerender routes, sitemap routes, and llms.txt sections merged
@@ -212,6 +287,13 @@ export async function augmentSeoConfigWithDocs(config, options = {}) {
   if (routes.length === 0) return config;
 
   const llmsSections = deriveDocsLlmsSections(tree, baseUrl, basePath, { mdTwin: docs.mdTwin === true });
+  // Build-time API snapshot: served to the page by `prerenderPlugin` via request
+  // interception, so the capture never depends on the API being reachable from
+  // the build environment (container builds, origin mismatches).
+  const apiSnapshot = await fetchDocsSnapshot(tree, docs.contentUrl, {
+    timeoutMs: docs.timeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
   const seo = app.seo || {};
 
   // Merge: append docs routes to whatever prerender/sitemap/llms already emit,
@@ -233,7 +315,7 @@ export async function augmentSeoConfigWithDocs(config, options = {}) {
       ...app,
       seo: {
         ...seo,
-        prerender: { ...seo.prerender, routes: mergedPrerender },
+        prerender: { ...seo.prerender, routes: mergedPrerender, apiSnapshot },
         sitemap: { ...seo.sitemap, routes: [...existingSitemap, ...docsSitemap] },
         llms: { ...seo.llms, sections: [...existingLlmsSections, ...llmsSections] },
       },

--- a/src/lib/plugins/docs-seo.js
+++ b/src/lib/plugins/docs-seo.js
@@ -235,7 +235,9 @@ export function deriveDocsSnapshotEntries(tree, contentUrl) {
 export async function fetchDocsSnapshot(tree, contentUrl, options = {}) {
   const { timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = globalThis.fetch } = options;
   const snapshot = {};
-  const treeBody = JSON.stringify(tree);
+  // Mirror the real wire shape (`{ data: { categories } }` envelope) so any
+  // consumer reading the raw response sees exactly what the API would return.
+  const treeBody = JSON.stringify({ data: tree });
   // Mirror fetchDocsTree's guard: a missing/non-function fetch keeps the layer
   // fail-soft (tree entries need no I/O; articles are skipped with a warning).
   const canFetch = typeof fetchImpl === 'function';

--- a/src/lib/plugins/prerender.js
+++ b/src/lib/plugins/prerender.js
@@ -227,6 +227,23 @@ async function renderRoute(browser, port, route, distDir, apiSnapshot) {
     if (apiSnapshot && Object.keys(apiSnapshot).length > 0) {
       await page.setRequestInterception(true);
       page.on('request', (req) => {
+        // Answer CORS preflights for snapshot-covered paths ourselves — a
+        // continue()d OPTIONS would depend on the real API being reachable,
+        // which is exactly what the snapshot exists to avoid.
+        if (req.method() === 'OPTIONS' && matchSnapshot(apiSnapshot, req.url(), 'GET')) {
+          const preflightOrigin = req.headers()?.origin;
+          req.respond({
+            status: 204,
+            headers: {
+              'Access-Control-Allow-Origin': preflightOrigin || '*',
+              'Access-Control-Allow-Methods': 'GET, OPTIONS',
+              'Access-Control-Allow-Headers': req.headers()?.['access-control-request-headers'] || '*',
+              ...(preflightOrigin ? { 'Access-Control-Allow-Credentials': 'true' } : {}),
+            },
+            body: '',
+          });
+          return;
+        }
         const hit = matchSnapshot(apiSnapshot, req.url(), req.method());
         if (hit) {
           // Reflect the page origin instead of '*': the app's HTTP client may

--- a/src/lib/plugins/prerender.js
+++ b/src/lib/plugins/prerender.js
@@ -232,16 +232,18 @@ async function renderRoute(browser, port, route, distDir, apiSnapshot) {
         // which is exactly what the snapshot exists to avoid.
         if (req.method() === 'OPTIONS' && matchSnapshot(apiSnapshot, req.url(), 'GET')) {
           const preflightOrigin = req.headers()?.origin;
-          req.respond({
-            status: 204,
-            headers: {
-              'Access-Control-Allow-Origin': preflightOrigin || '*',
-              'Access-Control-Allow-Methods': 'GET, OPTIONS',
-              'Access-Control-Allow-Headers': req.headers()?.['access-control-request-headers'] || '*',
-              ...(preflightOrigin ? { 'Access-Control-Allow-Credentials': 'true' } : {}),
-            },
-            body: '',
-          });
+          req
+            .respond({
+              status: 204,
+              headers: {
+                'Access-Control-Allow-Origin': preflightOrigin || '*',
+                'Access-Control-Allow-Methods': 'GET, OPTIONS',
+                'Access-Control-Allow-Headers': req.headers()?.['access-control-request-headers'] || '*',
+                ...(preflightOrigin ? { 'Access-Control-Allow-Credentials': 'true' } : {}),
+              },
+              body: '',
+            })
+            .catch(() => {});
           return;
         }
         const hit = matchSnapshot(apiSnapshot, req.url(), req.method());
@@ -250,15 +252,17 @@ async function renderRoute(browser, port, route, distDir, apiSnapshot) {
           // send credentialed (withCredentials) requests, and browsers reject a
           // wildcard ACAO for those.
           const origin = req.headers()?.origin;
-          req.respond({
-            status: 200,
-            contentType: hit.contentType,
-            headers: {
-              'Access-Control-Allow-Origin': origin || '*',
-              ...(origin ? { 'Access-Control-Allow-Credentials': 'true' } : {}),
-            },
-            body: hit.body,
-          });
+          req
+            .respond({
+              status: 200,
+              contentType: hit.contentType,
+              headers: {
+                'Access-Control-Allow-Origin': origin || '*',
+                ...(origin ? { 'Access-Control-Allow-Credentials': 'true' } : {}),
+              },
+              body: hit.body,
+            })
+            .catch(() => {});
           return;
         }
         req.continue().catch(() => {});

--- a/src/lib/plugins/prerender.js
+++ b/src/lib/plugins/prerender.js
@@ -34,9 +34,34 @@ export function routeToOutputPath(distDir, route) {
 }
 
 /**
+ * Match an intercepted page request against the build-time API snapshot by URL
+ * PATHNAME only — origin-agnostic, because the runtime API origin baked into
+ * the bundle can differ from the origin the snapshot was fetched from. GET only.
+ *
+ * @param {Record<string, { body: string, contentType: string }>|null|undefined} apiSnapshot
+ *   pathname → response snapshot (built by docs-seo's `fetchDocsSnapshot`)
+ * @param {string} url - the intercepted request's absolute URL
+ * @param {string} method - the intercepted request's HTTP method
+ * @returns {{ body: string, contentType: string }|null} the snapshot entry, or null
+ */
+export function matchSnapshot(apiSnapshot, url, method) {
+  if (!apiSnapshot || method !== 'GET') return null;
+  try {
+    return apiSnapshot[new URL(url).pathname] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Vite plugin — pre-renders configured routes at build time using Puppeteer.
  * Captures fully rendered HTML so crawlers receive meaningful content
  * without waiting for JavaScript execution.
+ *
+ * When `config.app.seo.prerender.apiSnapshot` is present (built by docs-seo's
+ * `fetchDocsSnapshot`), matching page API requests are served from that
+ * snapshot via request interception — the capture never depends on the API
+ * being reachable from the build environment.
  *
  * Only active when mode is 'production' AND config.app.seo.prerender.enabled is true.
  *
@@ -84,7 +109,7 @@ export function prerenderPlugin(config, mode) {
 
         for (const route of routes) {
           try {
-            await renderRoute(browser, port, route, distDir);
+            await renderRoute(browser, port, route, distDir, prerender?.apiSnapshot);
           } catch (routeError) {
             console.warn(
               `[prerender] Failed to pre-render route "${route}":`,
@@ -190,12 +215,38 @@ function startStaticServer(distDir) {
  * @param {number} port - local server port
  * @param {string} route - route path to render (e.g. '/')
  * @param {string} distDir - absolute path to the dist/ directory
+ * @param {Record<string, { body: string, contentType: string }>} [apiSnapshot]
+ *   build-time API snapshot served to the page instead of live API calls
  * @returns {Promise<void>}
  */
-async function renderRoute(browser, port, route, distDir) {
+async function renderRoute(browser, port, route, distDir, apiSnapshot) {
   const page = await browser.newPage();
   try {
     const url = `http://127.0.0.1:${port}${route}`;
+
+    if (apiSnapshot && Object.keys(apiSnapshot).length > 0) {
+      await page.setRequestInterception(true);
+      page.on('request', (req) => {
+        const hit = matchSnapshot(apiSnapshot, req.url(), req.method());
+        if (hit) {
+          // Reflect the page origin instead of '*': the app's HTTP client may
+          // send credentialed (withCredentials) requests, and browsers reject a
+          // wildcard ACAO for those.
+          const origin = req.headers()?.origin;
+          req.respond({
+            status: 200,
+            contentType: hit.contentType,
+            headers: {
+              'Access-Control-Allow-Origin': origin || '*',
+              ...(origin ? { 'Access-Control-Allow-Credentials': 'true' } : {}),
+            },
+            body: hit.body,
+          });
+          return;
+        }
+        req.continue().catch(() => {});
+      });
+    }
 
     await page.goto(url, { waitUntil: 'networkidle0', timeout: 30_000 });
     const html = await page.content();

--- a/src/lib/plugins/tests/docs-seo.unit.tests.js
+++ b/src/lib/plugins/tests/docs-seo.unit.tests.js
@@ -3,6 +3,8 @@ import {
   fetchDocsTree,
   deriveDocsRoutes,
   deriveDocsLlmsSections,
+  deriveDocsSnapshotEntries,
+  fetchDocsSnapshot,
   augmentSeoConfigWithDocs,
 } from '../docs-seo.js';
 
@@ -337,5 +339,96 @@ describe('augmentSeoConfigWithDocs', () => {
     const routes = deriveDocsRoutes(treeFixture, 42);
     // '42' starts with a digit, not '/', so normalizeBasePath prefixes '/'.
     expect(routes[0]).toBe('/42');
+  });
+
+  it('ON path: attaches the prerender apiSnapshot (tree + article entries)', async () => {
+    const fetchImpl = vi.fn().mockImplementation((url) => {
+      if (String(url).endsWith('.md')) {
+        return Promise.resolve({ ok: true, text: async () => `# md for ${url}` });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ data: treeFixture }) });
+    });
+    const config = baseConfig();
+    config.app.seo.docs = { enabled: true, contentUrl: 'https://api.example.com/api/public/docs', basePath: '/docs' };
+
+    const out = await augmentSeoConfigWithDocs(config, { fetchImpl });
+
+    const snapshot = out.app.seo.prerender.apiSnapshot;
+    expect(Object.keys(snapshot).sort()).toEqual([
+      '/api/public/docs',
+      '/api/public/docs/',
+      '/api/public/docs/quickstart.md',
+      '/api/public/docs/webhooks.md',
+      '/api/public/docs/welcome.md',
+    ]);
+    expect(snapshot['/api/public/docs/'].contentType).toBe('application/json');
+    expect(JSON.parse(snapshot['/api/public/docs/'].body)).toEqual(treeFixture);
+    expect(snapshot['/api/public/docs/welcome.md'].contentType).toBe('text/markdown');
+    expect(snapshot['/api/public/docs/welcome.md'].body).toContain('welcome.md');
+  });
+});
+
+describe('deriveDocsSnapshotEntries', () => {
+  it('derives tree entries (both slash forms) plus one .md entry per guide, keyed by pathname', () => {
+    const entries = deriveDocsSnapshotEntries(treeFixture, 'https://api.example.com/api/public/docs');
+    expect(entries).toEqual([
+      { path: '/api/public/docs', url: 'https://api.example.com/api/public/docs', kind: 'tree' },
+      { path: '/api/public/docs/', url: 'https://api.example.com/api/public/docs', kind: 'tree' },
+      { path: '/api/public/docs/welcome.md', url: 'https://api.example.com/api/public/docs/welcome.md', kind: 'article' },
+      { path: '/api/public/docs/quickstart.md', url: 'https://api.example.com/api/public/docs/quickstart.md', kind: 'article' },
+      { path: '/api/public/docs/webhooks.md', url: 'https://api.example.com/api/public/docs/webhooks.md', kind: 'article' },
+    ]);
+  });
+
+  it('normalises a trailing slash on contentUrl', () => {
+    const entries = deriveDocsSnapshotEntries(treeFixture, 'https://api.example.com/api/public/docs/');
+    expect(entries[0].path).toBe('/api/public/docs');
+    expect(entries[2].path).toBe('/api/public/docs/welcome.md');
+  });
+
+  it('returns an empty list for a missing or malformed contentUrl', () => {
+    expect(deriveDocsSnapshotEntries(treeFixture, '')).toEqual([]);
+    expect(deriveDocsSnapshotEntries(treeFixture, 'not a url')).toEqual([]);
+    expect(deriveDocsSnapshotEntries(null, 'https://api.example.com/docs')).toEqual([
+      { path: '/docs', url: 'https://api.example.com/docs', kind: 'tree' },
+      { path: '/docs/', url: 'https://api.example.com/docs', kind: 'tree' },
+    ]);
+  });
+});
+
+describe('fetchDocsSnapshot', () => {
+  it('serialises the already-fetched tree WITHOUT refetching it and fetches each article', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, text: async () => '# body' });
+    const snapshot = await fetchDocsSnapshot(treeFixture, 'https://api.example.com/api/public/docs', { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3); // articles only, never the tree URL
+    expect(fetchImpl).not.toHaveBeenCalledWith('https://api.example.com/api/public/docs', expect.anything());
+    expect(snapshot['/api/public/docs'].body).toBe(JSON.stringify(treeFixture));
+    expect(snapshot['/api/public/docs/'].body).toBe(JSON.stringify(treeFixture));
+    expect(snapshot['/api/public/docs/welcome.md']).toEqual({ body: '# body', contentType: 'text/markdown' });
+  });
+
+  it('FAIL-SOFT: a non-OK article response is skipped with a warning, others survive', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchImpl = vi.fn().mockImplementation((url) => {
+      if (String(url).endsWith('/quickstart.md')) return Promise.resolve({ ok: false, status: 404 });
+      return Promise.resolve({ ok: true, text: async () => '# ok' });
+    });
+    const snapshot = await fetchDocsSnapshot(treeFixture, 'https://api.example.com/api/public/docs', { fetchImpl });
+
+    expect(snapshot['/api/public/docs/quickstart.md']).toBeUndefined();
+    expect(snapshot['/api/public/docs/welcome.md']).toEqual({ body: '# ok', contentType: 'text/markdown' });
+    expect(snapshot['/api/public/docs/webhooks.md']).toEqual({ body: '# ok', contentType: 'text/markdown' });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('FAIL-SOFT: a rejecting article fetch is skipped with a warning, never throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('offline'));
+    const snapshot = await fetchDocsSnapshot(treeFixture, 'https://api.example.com/api/public/docs', { fetchImpl });
+
+    // Tree entries still present (no I/O needed), all articles skipped.
+    expect(Object.keys(snapshot).sort()).toEqual(['/api/public/docs', '/api/public/docs/']);
+    expect(warn).toHaveBeenCalled();
   });
 });

--- a/src/lib/plugins/tests/docs-seo.unit.tests.js
+++ b/src/lib/plugins/tests/docs-seo.unit.tests.js
@@ -386,6 +386,16 @@ describe('deriveDocsSnapshotEntries', () => {
     expect(entries[2].path).toBe('/api/public/docs/welcome.md');
   });
 
+  it('URL-encodes slugs, matching the encoded pathname the runtime client requests', () => {
+    const spaced = { categories: [{ id: 'c', label: 'C', guides: [{ slug: 'my guide', title: 'MG' }] }] };
+    const entries = deriveDocsSnapshotEntries(spaced, 'https://api.example.com/api/public/docs');
+    expect(entries[2]).toEqual({
+      path: '/api/public/docs/my%20guide.md',
+      url: 'https://api.example.com/api/public/docs/my%20guide.md',
+      kind: 'article',
+    });
+  });
+
   it('returns an empty list for a missing or malformed contentUrl', () => {
     expect(deriveDocsSnapshotEntries(treeFixture, '')).toEqual([]);
     expect(deriveDocsSnapshotEntries(treeFixture, 'not a url')).toEqual([]);
@@ -430,5 +440,13 @@ describe('fetchDocsSnapshot', () => {
     // Tree entries still present (no I/O needed), all articles skipped.
     expect(Object.keys(snapshot).sort()).toEqual(['/api/public/docs', '/api/public/docs/']);
     expect(warn).toHaveBeenCalled();
+  });
+
+  it('FAIL-SOFT: a non-function fetchImpl keeps tree entries and skips articles with a warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const snapshot = await fetchDocsSnapshot(treeFixture, 'https://api.example.com/api/public/docs', { fetchImpl: 'not-a-fn' });
+
+    expect(Object.keys(snapshot).sort()).toEqual(['/api/public/docs', '/api/public/docs/']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('No fetch implementation'));
   });
 });

--- a/src/lib/plugins/tests/docs-seo.unit.tests.js
+++ b/src/lib/plugins/tests/docs-seo.unit.tests.js
@@ -362,7 +362,8 @@ describe('augmentSeoConfigWithDocs', () => {
       '/api/public/docs/welcome.md',
     ]);
     expect(snapshot['/api/public/docs/'].contentType).toBe('application/json');
-    expect(JSON.parse(snapshot['/api/public/docs/'].body)).toEqual(treeFixture);
+    // Wire-shape envelope, exactly what the real API returns.
+    expect(JSON.parse(snapshot['/api/public/docs/'].body)).toEqual({ data: treeFixture });
     expect(snapshot['/api/public/docs/welcome.md'].contentType).toBe('text/markdown');
     expect(snapshot['/api/public/docs/welcome.md'].body).toContain('welcome.md');
   });
@@ -413,8 +414,8 @@ describe('fetchDocsSnapshot', () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(3); // articles only, never the tree URL
     expect(fetchImpl).not.toHaveBeenCalledWith('https://api.example.com/api/public/docs', expect.anything());
-    expect(snapshot['/api/public/docs'].body).toBe(JSON.stringify(treeFixture));
-    expect(snapshot['/api/public/docs/'].body).toBe(JSON.stringify(treeFixture));
+    expect(snapshot['/api/public/docs'].body).toBe(JSON.stringify({ data: treeFixture }));
+    expect(snapshot['/api/public/docs/'].body).toBe(JSON.stringify({ data: treeFixture }));
     expect(snapshot['/api/public/docs/welcome.md']).toEqual({ body: '# body', contentType: 'text/markdown' });
   });
 

--- a/src/lib/plugins/tests/prerender.unit.tests.js
+++ b/src/lib/plugins/tests/prerender.unit.tests.js
@@ -324,6 +324,44 @@ describe('prerenderPlugin apiSnapshot interception', () => {
     expect(miss.continue).toHaveBeenCalled();
     logSpy.mockRestore();
   });
+
+  it('answers CORS preflights for snapshot-covered paths itself (204 + reflected origin)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await prerenderPlugin(snapshotConfig(), 'production').closeBundle();
+    const handler = mockPage.on.mock.calls.find(([event]) => event === 'request')[1];
+
+    const preflight = {
+      url: () => 'https://api.example.com/api/public/docs/',
+      method: () => 'OPTIONS',
+      headers: () => ({ origin: 'http://127.0.0.1:54321', 'access-control-request-headers': 'x-custom' }),
+      respond: vi.fn(),
+      continue: vi.fn().mockResolvedValue(undefined),
+    };
+    handler(preflight);
+    expect(preflight.respond).toHaveBeenCalledWith({
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': 'http://127.0.0.1:54321',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'x-custom',
+        'Access-Control-Allow-Credentials': 'true',
+      },
+      body: '',
+    });
+    expect(preflight.continue).not.toHaveBeenCalled();
+
+    const preflightMiss = {
+      url: () => 'https://api.example.com/api/unrelated',
+      method: () => 'OPTIONS',
+      headers: () => ({ origin: 'http://127.0.0.1:54321' }),
+      respond: vi.fn(),
+      continue: vi.fn().mockResolvedValue(undefined),
+    };
+    handler(preflightMiss);
+    expect(preflightMiss.respond).not.toHaveBeenCalled();
+    expect(preflightMiss.continue).toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
 });
 
 describe('sanitizePath', () => {

--- a/src/lib/plugins/tests/prerender.unit.tests.js
+++ b/src/lib/plugins/tests/prerender.unit.tests.js
@@ -7,6 +7,8 @@ const { mockPage, mockBrowser, mockCreateServer, mockFsFns } = vi.hoisted(() => 
     goto: vi.fn().mockResolvedValue(undefined),
     content: vi.fn().mockResolvedValue('<html><body>rendered</body></html>'),
     close: vi.fn().mockResolvedValue(undefined),
+    setRequestInterception: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(),
   };
   const mockBrowser = {
     newPage: vi.fn().mockResolvedValue(mockPage),
@@ -47,7 +49,7 @@ vi.mock('node:http', () => ({
   default: { createServer: mockCreateServer },
 }));
 
-import { prerenderPlugin, sanitizePath, routeToOutputPath } from '../prerender.js';
+import { prerenderPlugin, sanitizePath, routeToOutputPath, matchSnapshot } from '../prerender.js';
 
 describe('prerenderPlugin', () => {
   beforeEach(() => {
@@ -187,6 +189,139 @@ describe('prerenderPlugin', () => {
     );
 
     await expect(plugin.closeBundle()).rejects.toThrow(/4502/);
+    logSpy.mockRestore();
+  });
+});
+
+describe('matchSnapshot', () => {
+  const snapshot = {
+    '/api/public/docs/': { body: '{"categories":[]}', contentType: 'application/json' },
+    '/api/public/docs/welcome.md': { body: '# Welcome', contentType: 'text/markdown' },
+  };
+
+  it('matches a GET by pathname on ANY origin (origin-agnostic)', () => {
+    expect(matchSnapshot(snapshot, 'https://api.example.com/api/public/docs/welcome.md', 'GET')).toEqual({
+      body: '# Welcome',
+      contentType: 'text/markdown',
+    });
+    expect(matchSnapshot(snapshot, 'https://other-origin.example.org/api/public/docs/welcome.md', 'GET')).toEqual({
+      body: '# Welcome',
+      contentType: 'text/markdown',
+    });
+  });
+
+  it('never matches non-GET methods', () => {
+    expect(matchSnapshot(snapshot, 'https://api.example.com/api/public/docs/', 'POST')).toBeNull();
+  });
+
+  it('returns null for an unknown pathname', () => {
+    expect(matchSnapshot(snapshot, 'https://api.example.com/api/other', 'GET')).toBeNull();
+  });
+
+  it('returns null for a malformed URL or an absent snapshot', () => {
+    expect(matchSnapshot(snapshot, 'not a url', 'GET')).toBeNull();
+    expect(matchSnapshot(null, 'https://api.example.com/api/public/docs/', 'GET')).toBeNull();
+    expect(matchSnapshot(undefined, 'https://api.example.com/api/public/docs/', 'GET')).toBeNull();
+  });
+});
+
+describe('prerenderPlugin apiSnapshot interception', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPage.goto.mockResolvedValue(undefined);
+    mockPage.content.mockResolvedValue('<html><body>rendered</body></html>');
+    mockPage.close.mockResolvedValue(undefined);
+    mockBrowser.newPage.mockResolvedValue(mockPage);
+    mockBrowser.close.mockResolvedValue(undefined);
+  });
+
+  const snapshotConfig = () => ({
+    app: {
+      seo: {
+        prerender: {
+          enabled: true,
+          routes: ['/docs'],
+          apiSnapshot: {
+            '/api/public/docs/': { body: '{"categories":[]}', contentType: 'application/json' },
+          },
+        },
+      },
+    },
+  });
+
+  it('enables request interception and wires a request handler when a snapshot is present', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await prerenderPlugin(snapshotConfig(), 'production').closeBundle();
+
+    expect(mockPage.setRequestInterception).toHaveBeenCalledWith(true);
+    expect(mockPage.on).toHaveBeenCalledWith('request', expect.any(Function));
+    logSpy.mockRestore();
+  });
+
+  it('skips interception entirely when no snapshot is configured', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await prerenderPlugin(
+      { app: { seo: { prerender: { enabled: true, routes: ['/docs'] } } } },
+      'production',
+    ).closeBundle();
+
+    expect(mockPage.setRequestInterception).not.toHaveBeenCalled();
+    expect(mockPage.on).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it('the wired handler responds to snapshot hits and continues everything else', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await prerenderPlugin(snapshotConfig(), 'production').closeBundle();
+
+    const handler = mockPage.on.mock.calls.find(([event]) => event === 'request')[1];
+
+    const hit = {
+      url: () => 'https://api.example.com/api/public/docs/',
+      method: () => 'GET',
+      headers: () => ({ origin: 'http://127.0.0.1:54321' }),
+      respond: vi.fn(),
+      continue: vi.fn().mockResolvedValue(undefined),
+    };
+    handler(hit);
+    // Origin reflected (not '*') + credentials allowed: the app's HTTP client
+    // may send credentialed requests, and browsers reject wildcard ACAO there.
+    expect(hit.respond).toHaveBeenCalledWith({
+      status: 200,
+      contentType: 'application/json',
+      headers: {
+        'Access-Control-Allow-Origin': 'http://127.0.0.1:54321',
+        'Access-Control-Allow-Credentials': 'true',
+      },
+      body: '{"categories":[]}',
+    });
+    expect(hit.continue).not.toHaveBeenCalled();
+
+    const hitNoOrigin = {
+      url: () => 'https://api.example.com/api/public/docs/',
+      method: () => 'GET',
+      headers: () => ({}),
+      respond: vi.fn(),
+      continue: vi.fn().mockResolvedValue(undefined),
+    };
+    handler(hitNoOrigin);
+    expect(hitNoOrigin.respond).toHaveBeenCalledWith({
+      status: 200,
+      contentType: 'application/json',
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: '{"categories":[]}',
+    });
+
+    const miss = {
+      url: () => 'https://api.example.com/api/unrelated',
+      method: () => 'GET',
+      headers: () => ({}),
+      respond: vi.fn(),
+      continue: vi.fn().mockResolvedValue(undefined),
+    };
+    handler(miss);
+    expect(miss.respond).not.toHaveBeenCalled();
+    expect(miss.continue).toHaveBeenCalled();
     logSpy.mockRestore();
   });
 });

--- a/src/lib/plugins/tests/prerender.unit.tests.js
+++ b/src/lib/plugins/tests/prerender.unit.tests.js
@@ -270,6 +270,18 @@ describe('prerenderPlugin apiSnapshot interception', () => {
     logSpy.mockRestore();
   });
 
+  it('skips interception when the snapshot is an empty object', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await prerenderPlugin(
+      { app: { seo: { prerender: { enabled: true, routes: ['/docs'], apiSnapshot: {} } } } },
+      'production',
+    ).closeBundle();
+
+    expect(mockPage.setRequestInterception).not.toHaveBeenCalled();
+    expect(mockPage.on).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
   it('the wired handler responds to snapshot hits and continues everything else', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await prerenderPlugin(snapshotConfig(), 'production').closeBundle();
@@ -280,7 +292,7 @@ describe('prerenderPlugin apiSnapshot interception', () => {
       url: () => 'https://api.example.com/api/public/docs/',
       method: () => 'GET',
       headers: () => ({ origin: 'http://127.0.0.1:54321' }),
-      respond: vi.fn(),
+      respond: vi.fn().mockResolvedValue(undefined),
       continue: vi.fn().mockResolvedValue(undefined),
     };
     handler(hit);
@@ -301,7 +313,7 @@ describe('prerenderPlugin apiSnapshot interception', () => {
       url: () => 'https://api.example.com/api/public/docs/',
       method: () => 'GET',
       headers: () => ({}),
-      respond: vi.fn(),
+      respond: vi.fn().mockResolvedValue(undefined),
       continue: vi.fn().mockResolvedValue(undefined),
     };
     handler(hitNoOrigin);
@@ -316,7 +328,7 @@ describe('prerenderPlugin apiSnapshot interception', () => {
       url: () => 'https://api.example.com/api/unrelated',
       method: () => 'GET',
       headers: () => ({}),
-      respond: vi.fn(),
+      respond: vi.fn().mockResolvedValue(undefined),
       continue: vi.fn().mockResolvedValue(undefined),
     };
     handler(miss);
@@ -334,7 +346,7 @@ describe('prerenderPlugin apiSnapshot interception', () => {
       url: () => 'https://api.example.com/api/public/docs/',
       method: () => 'OPTIONS',
       headers: () => ({ origin: 'http://127.0.0.1:54321', 'access-control-request-headers': 'x-custom' }),
-      respond: vi.fn(),
+      respond: vi.fn().mockResolvedValue(undefined),
       continue: vi.fn().mockResolvedValue(undefined),
     };
     handler(preflight);
@@ -354,7 +366,7 @@ describe('prerenderPlugin apiSnapshot interception', () => {
       url: () => 'https://api.example.com/api/unrelated',
       method: () => 'OPTIONS',
       headers: () => ({ origin: 'http://127.0.0.1:54321' }),
-      respond: vi.fn(),
+      respond: vi.fn().mockResolvedValue(undefined),
       continue: vi.fn().mockResolvedValue(undefined),
     };
     handler(preflightMiss);


### PR DESCRIPTION
## Summary

- What changed: prerendered routes whose components fetch content from the API at runtime used to capture the empty fail-soft state during prerender capture, because the page's API fetch depends on the API being reachable from the build environment (container builds and origin mismatches routinely break that reachability). `docs-seo.js` already fetches the guide tree at build time; it now also fetches each guide's raw markdown and attaches a build-time API snapshot (`app.seo.prerender.apiSnapshot`, keyed by URL pathname → `{ body, contentType }`, with a wire-shape envelope for the tree matching the runtime API response). `prerenderPlugin` serves that snapshot via Puppeteer request interception: GET requests are matched by pathname only (origin-agnostic), guide slugs are URL-encoded the same way the runtime client encodes them, CORS preflights (`OPTIONS`) are self-served, and the reflected origin + credentials are echoed back. Prerender capture becomes hermetic — it no longer depends on the API being reachable from wherever the build runs. Missing/failed per-guide fetches fail soft (that one route falls back to the empty state) rather than failing the whole prerender pass.
- Why: closes the gap where a build environment (CI runner, container, different origin) can't reach the live API, silently shipping empty prerendered pages for any route that fetches API content client-side.
- Related issues: Closes #4530

## Scope

- Modules impacted: `src/lib/plugins/docs-seo.js`, `src/lib/plugins/prerender.js` (+ their unit test files)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable) — verified end-to-end on a downstream consumer's production-mode build (prerendered article pages ship real bodies + nav, not the empty fail-soft state)

68 unit tests added/updated across the two plugin test files; full suite 2551 tests green; coverage 99% statements.

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: the interception only serves build-time-fetched, same-repo guide content back to the prerender browser context during the build step itself — it never runs at request-serving time and introduces no new runtime attack surface. CORS preflight responses reflect the request's own origin/credentials, matching the runtime API's existing CORS behavior rather than widening it.
- Mergeability considerations: additive-only change to the two plugin files; no touched shared config surface.
- Follow-up tasks (optional): none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot-backed API responses during prerendering for documentation pages.
  * Documentation guides can now include prerendered Markdown article content.
  * Supports endpoint URL normalization, encoded guide slugs, and CORS preflight requests.
  * Unmatched requests continue normally during prerendering.

* **Bug Fixes**
  * Added fail-soft handling for malformed URLs, unavailable fetch functionality, failed requests, and missing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->