### PR TITLE
refactor(shared): extract sanitizeApiError into shared helper

### DIFF
--- a/src/lib/helpers/apiError.js
+++ b/src/lib/helpers/apiError.js
@@ -1,0 +1,12 @@
+/**
+ * Sanitize API error messages to avoid leaking internal details (stack traces, DB paths, etc.).
+ * @param {unknown} err - The caught error object.
+ * @returns {string} A safe, user-facing error message.
+ */
+export const sanitizeApiError = (err) => {
+  const msg = err?.response?.data?.message || '';
+  if (msg && msg.length <= 200 && !/\b(collection|stack)\b|Error:|^\s*at\s+|\/[a-z]+\/|\.[jt]s:\d+/.test(msg)) {
+    return msg;
+  }
+  return 'Failed to load data. Please try again.';
+};

--- a/src/lib/helpers/tests/apiError.unit.tests.js
+++ b/src/lib/helpers/tests/apiError.unit.tests.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeApiError } from '../apiError.js';
+
+describe('apiError Helper', () => {
+  describe('sanitizeApiError', () => {
+    it('should pass through a clean, short server message', () => {
+      const err = { response: { data: { message: 'User not found' } } };
+      expect(sanitizeApiError(err)).toBe('User not found');
+    });
+
+    it('should redact a message containing a stack frame', () => {
+      const err = {
+        response: { data: { message: 'Error: at Object.<anonymous> (/app/path/to/file.js:42)' } },
+      };
+      expect(sanitizeApiError(err)).toBe('Failed to load data. Please try again.');
+    });
+
+    it('should redact a message mentioning an internal collection name', () => {
+      const err = {
+        response: { data: { message: 'E11000 duplicate key error collection: users index: email_1' } },
+      };
+      expect(sanitizeApiError(err)).toBe('Failed to load data. Please try again.');
+    });
+
+    it('should redact a message longer than 200 characters', () => {
+      const err = { response: { data: { message: 'x'.repeat(201) } } };
+      expect(sanitizeApiError(err)).toBe('Failed to load data. Please try again.');
+    });
+
+    it('should allow a message of exactly 200 characters', () => {
+      const safeMsg = 'x'.repeat(200);
+      const err = { response: { data: { message: safeMsg } } };
+      expect(sanitizeApiError(err)).toBe(safeMsg);
+    });
+
+    it('should fall back to the generic message when no message is present', () => {
+      expect(sanitizeApiError(new Error('Network error'))).toBe('Failed to load data. Please try again.');
+      expect(sanitizeApiError({})).toBe('Failed to load data. Please try again.');
+      expect(sanitizeApiError(undefined)).toBe('Failed to load data. Please try again.');
+    });
+  });
+});

--- a/src/lib/helpers/tests/apiError.unit.tests.js
+++ b/src/lib/helpers/tests/apiError.unit.tests.js
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { sanitizeApiError } from '../apiError.js';
 
+const FALLBACK = 'Failed to load data. Please try again.';
+
 describe('apiError Helper', () => {
   describe('sanitizeApiError', () => {
     it('should pass through a clean, short server message', () => {
@@ -12,19 +14,19 @@ describe('apiError Helper', () => {
       const err = {
         response: { data: { message: 'Error: at Object.<anonymous> (/app/path/to/file.js:42)' } },
       };
-      expect(sanitizeApiError(err)).toBe('Failed to load data. Please try again.');
+      expect(sanitizeApiError(err)).toBe(FALLBACK);
     });
 
     it('should redact a message mentioning an internal collection name', () => {
       const err = {
         response: { data: { message: 'E11000 duplicate key error collection: users index: email_1' } },
       };
-      expect(sanitizeApiError(err)).toBe('Failed to load data. Please try again.');
+      expect(sanitizeApiError(err)).toBe(FALLBACK);
     });
 
     it('should redact a message longer than 200 characters', () => {
       const err = { response: { data: { message: 'x'.repeat(201) } } };
-      expect(sanitizeApiError(err)).toBe('Failed to load data. Please try again.');
+      expect(sanitizeApiError(err)).toBe(FALLBACK);
     });
 
     it('should allow a message of exactly 200 characters', () => {
@@ -34,9 +36,9 @@ describe('apiError Helper', () => {
     });
 
     it('should fall back to the generic message when no message is present', () => {
-      expect(sanitizeApiError(new Error('Network error'))).toBe('Failed to load data. Please try again.');
-      expect(sanitizeApiError({})).toBe('Failed to load data. Please try again.');
-      expect(sanitizeApiError(undefined)).toBe('Failed to load data. Please try again.');
+      expect(sanitizeApiError(new Error('Network error'))).toBe(FALLBACK);
+      expect(sanitizeApiError({})).toBe(FALLBACK);
+      expect(sanitizeApiError(undefined)).toBe(FALLBACK);
     });
   });
 });

--- a/src/modules/admin/stores/admin.store.js
+++ b/src/modules/admin/stores/admin.store.js
@@ -7,6 +7,7 @@ import axios from '../../../lib/services/axios';
 import config from '../../../lib/services/config';
 import model from '../../../lib/middlewares/model';
 import { createLogger } from '../../../lib/helpers/logger';
+import { sanitizeApiError } from '../../../lib/helpers/apiError';
 
 const logger = createLogger('admin');
 
@@ -14,19 +15,6 @@ const logger = createLogger('admin');
  * Whitelists.
  */
 const whitelists = ['firstName', 'lastName', 'bio', 'position', 'email', 'avatar', 'roles'];
-
-/**
- * Sanitize API error messages to avoid leaking internal details (stack traces, DB paths, etc.).
- * @param {unknown} err - The caught error object.
- * @returns {string} A safe, user-facing error message.
- */
-const sanitizeApiError = (err) => {
-  const msg = err?.response?.data?.message || '';
-  if (msg && msg.length <= 200 && !/\b(collection|stack)\b|Error:|^\s*at\s+|\/[a-z]+\/|\.[jt]s:\d+/.test(msg)) {
-    return msg;
-  }
-  return 'Failed to load data. Please try again.';
-};
 
 /**
  * Build the base API URL from config.

--- a/src/modules/invitations/stores/invitations.store.js
+++ b/src/modules/invitations/stores/invitations.store.js
@@ -6,21 +6,9 @@ import axios from '../../../lib/services/axios';
 import config from '../../../lib/services/config';
 import { capture } from '../../../lib/helpers/analytics';
 import { createLogger } from '../../../lib/helpers/logger';
+import { sanitizeApiError } from '../../../lib/helpers/apiError';
 
 const logger = createLogger('invitations');
-
-/**
- * Sanitize API error messages to avoid leaking internal details (stack traces, DB paths, etc.).
- * @param {unknown} err - The caught error object.
- * @returns {string} A safe, user-facing error message.
- */
-const sanitizeApiError = (err) => {
-  const msg = err?.response?.data?.message || '';
-  if (msg && msg.length <= 200 && !/\b(collection|stack)\b|Error:|^\s*at\s+|\/[a-z]+\/|\.[jt]s:\d+/.test(msg)) {
-    return msg;
-  }
-  return 'Failed to load data. Please try again.';
-};
 
 /**
  * Build the base API URL from config.


### PR DESCRIPTION
## Summary

- What changed: extracted the `sanitizeApiError` helper (previously duplicated byte-for-byte in `admin.store.js` and `invitations.store.js`) into a new shared module, `src/lib/helpers/apiError.js`, and imported it from both stores.
- Why: two copies of a leak-prevention rule mean fixing one can leave the other leaking internal details (stack traces, DB paths) to end users.
- Related issues: Closes #4515

## Scope

- Modules impacted: `lib/helpers` (new), `modules/admin/stores`, `modules/invitations/stores`
- Cross-module impact: `none` — pure extraction, no behavior change, no new dependency between stores
- Risk level: `low`

## Verbatim-copy contract

The function body (including the leak-prevention regex) is copied **verbatim** from both original call sites — confirmed byte-identical on baseline before extraction. Nothing in the redaction logic was changed or "improved": same 200-char cap, same internal-marker checks (collection/stack words, `Error:` prefix, stack frame, path segment, file-and-line reference), same generic fallback string.

## Tests

New `src/lib/helpers/tests/apiError.unit.tests.js` — one test per redaction arm:
- clean short message passes through
- message with a stack frame → redacted
- message mentioning an internal collection name → redacted
- message over 200 characters → redacted
- exactly 200 characters → allowed (boundary)
- missing/absent message → generic fallback

Both `admin.store` and `invitations.store` unit suites stay green unchanged (they already exercised `sanitizeApiError` indirectly through store actions).

DoD grep `grep -rn "const sanitizeApiError" src` now only matches the helper's own `export const` declaration.

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable) — n/a, no UI/behavior change

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: this refactor centralizes a leak-prevention control (regex that strips stack traces/internal paths from user-facing error messages). Behavior is unchanged; a future fix now only needs to touch one file instead of two.
- Mergeability considerations: this PR blocks #4516 (also edits `admin.store.js` and `invitations.store.js` on adjacent lines per that issue) — land this first, then rebase #4516.
- Follow-up tasks (optional): none