### PR TITLE
fix(auth): re-fetch serverConfig after in-SPA signin/signup

### DIFF
--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -143,15 +143,6 @@ export const useAuthStore = defineStore('auth', {
         this.user = res.data.user;
         this.lockout = { locked: false, retryAfter: 0 };
 
-        // Re-fetch server config now that we're authenticated: the earlier
-        // anonymous fetch (pre-login) never carries auth-gated keys such as
-        // billing.{enabled,meterMode,equivalences} (Node#3566), so without this
-        // the whole first in-SPA session runs on stale anonymous config. Must
-        // happen before the meterMode guard below so it evaluates the
-        // authenticated config, not the anonymous one. Failure semantics are
-        // unchanged: fetchServerConfig() sets serverConfig=null on failure.
-        await this.fetchServerConfig();
-
         if (res.data.user.lastLoginAt) {
           localStorage.setItem(`${config.cookie.prefix}LastLoginAt`, res.data.user.lastLoginAt);
         }
@@ -160,6 +151,18 @@ export const useAuthStore = defineStore('auth', {
         this.pendingRequests = res.data.pendingRequests || [];
 
         coreStore.refreshNav(this.isLoggedIn);
+
+        // Re-fetch server config now that we're authenticated: the earlier
+        // anonymous fetch (pre-login) never carries auth-gated keys such as
+        // billing.{enabled,meterMode,equivalences} (Node#3566), so without this
+        // the whole first in-SPA session runs on stale anonymous config. Must
+        // happen before the meterMode guard below so it evaluates the
+        // authenticated config, not the anonymous one. Failure semantics are
+        // unchanged: fetchServerConfig() sets serverConfig=null on failure.
+        // Deferred until here (not right after the auth-state block above) so
+        // it never delays the nav/abilities/pendingRequests updates above,
+        // which don't depend on it.
+        await this.fetchServerConfig();
 
         // Refresh compute meter immediately on login so the sidenav gauge
         // populates without waiting for mount/focus (guard: only when meterMode is on).
@@ -264,11 +267,6 @@ export const useAuthStore = defineStore('auth', {
         this.cookieExpire = res.data.tokenExpiresIn;
         this.user = res.data.user;
 
-        // Re-fetch server config now that we're authenticated (same rationale
-        // as signin() above): signup() has no meterMode guard of its own, but
-        // serverConfig must be authenticated for the rest of the session.
-        await this.fetchServerConfig();
-
         if (res.data.suggestedJoin) {
           this.setSuggestedJoin(res.data.suggestedJoin);
         }
@@ -276,6 +274,15 @@ export const useAuthStore = defineStore('auth', {
         coreStore.refreshNav(this.isLoggedIn);
         capture('signup_completed', { email: res.data.user.email });
         identify(res.data.user.id || res.data.user._id, { email: res.data.user.email, plan: res.data.user.plan });
+
+        // Re-fetch server config now that we're authenticated (same rationale
+        // as signin() above, see that comment) — deferred until here so it
+        // never delays suggestedJoin/nav/analytics above, none of which
+        // depend on it. signup() has no meterMode guard of its own; the
+        // point is that serverConfig is authenticated for the rest of the
+        // session.
+        await this.fetchServerConfig();
+
         return res.data;
       } catch (err) {
         localStorage.removeItem('token');

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -143,6 +143,15 @@ export const useAuthStore = defineStore('auth', {
         this.user = res.data.user;
         this.lockout = { locked: false, retryAfter: 0 };
 
+        // Re-fetch server config now that we're authenticated: the earlier
+        // anonymous fetch (pre-login) never carries auth-gated keys such as
+        // billing.{enabled,meterMode,equivalences} (Node#3566), so without this
+        // the whole first in-SPA session runs on stale anonymous config. Must
+        // happen before the meterMode guard below so it evaluates the
+        // authenticated config, not the anonymous one. Failure semantics are
+        // unchanged: fetchServerConfig() sets serverConfig=null on failure.
+        await this.fetchServerConfig();
+
         if (res.data.user.lastLoginAt) {
           localStorage.setItem(`${config.cookie.prefix}LastLoginAt`, res.data.user.lastLoginAt);
         }
@@ -254,6 +263,11 @@ export const useAuthStore = defineStore('auth', {
         this.auth = true;
         this.cookieExpire = res.data.tokenExpiresIn;
         this.user = res.data.user;
+
+        // Re-fetch server config now that we're authenticated (same rationale
+        // as signin() above): signup() has no meterMode guard of its own, but
+        // serverConfig must be authenticated for the rest of the session.
+        await this.fetchServerConfig();
 
         if (res.data.suggestedJoin) {
           this.setSuggestedJoin(res.data.suggestedJoin);

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -339,10 +339,13 @@ describe('Auth Store', () => {
 
     // ── #4261 — fetchUsageMeter called on signin when meterMode is on ────────
 
-    it('calls billingStore.fetchUsageMeter after signin when meterMode is true (#4261)', async () => {
+    it('calls billingStore.fetchUsageMeter after signin when the post-auth re-fetch returns meterMode true (#4261, #4538)', async () => {
       const authStore = useAuthStore();
-      // Pre-set serverConfig with meterMode enabled (simulates router guard having run before login)
-      authStore.serverConfig = { billing: { meterMode: true } };
+      // Anonymous pre-auth config: no auth-gated `billing` key (that key only
+      // ever appears once fetchServerConfig() re-runs authenticated below —
+      // pre-setting it here, as the old #4261 test did, was unreachable and
+      // is exactly what masked #4538).
+      authStore.serverConfig = { sign: { in: true, up: true } };
 
       const mockResponse = {
         data: {
@@ -351,6 +354,8 @@ describe('Auth Store', () => {
         },
       };
       axios.post.mockResolvedValueOnce(mockResponse);
+      // Post-auth fetchServerConfig() re-fetch: authenticated config now carries billing.
+      axios.get.mockResolvedValueOnce({ data: { data: { sign: { in: true, up: true }, billing: { meterMode: true } } } });
       // fetchUsageMeter uses GET /billing/usage — stub to avoid throwing
       axios.get.mockResolvedValue({ data: { data: { meterUsed: 0, meterQuota: 500 } } });
 
@@ -359,12 +364,13 @@ describe('Auth Store', () => {
 
       await authStore.signin({ email: 'test@test.com', password: 'password' });
 
+      expect(authStore.serverConfig).toEqual({ sign: { in: true, up: true }, billing: { meterMode: true } });
       expect(fetchUsageMeterSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('does NOT call billingStore.fetchUsageMeter after signin when meterMode is false (#4261)', async () => {
+    it('does NOT call billingStore.fetchUsageMeter after signin when the post-auth re-fetch returns meterMode false (#4261, #4538)', async () => {
       const authStore = useAuthStore();
-      authStore.serverConfig = { billing: { meterMode: false } };
+      authStore.serverConfig = { sign: { in: true, up: true } };
 
       const mockResponse = {
         data: {
@@ -373,18 +379,20 @@ describe('Auth Store', () => {
         },
       };
       axios.post.mockResolvedValueOnce(mockResponse);
+      axios.get.mockResolvedValueOnce({ data: { data: { sign: { in: true, up: true }, billing: { meterMode: false } } } });
 
       const billingStore = useBillingStore();
       const fetchUsageMeterSpy = vi.spyOn(billingStore, 'fetchUsageMeter');
 
       await authStore.signin({ email: 'test@test.com', password: 'password' });
 
+      expect(authStore.serverConfig).toEqual({ sign: { in: true, up: true }, billing: { meterMode: false } });
       expect(fetchUsageMeterSpy).not.toHaveBeenCalled();
     });
 
-    it('does NOT call billingStore.fetchUsageMeter after signin when serverConfig is null (#4261)', async () => {
+    it('does NOT call billingStore.fetchUsageMeter and leaves serverConfig null when the post-auth re-fetch fails (#4261, #4538)', async () => {
       const authStore = useAuthStore();
-      authStore.serverConfig = null;
+      authStore.serverConfig = { sign: { in: true, up: true } };
 
       const mockResponse = {
         data: {
@@ -393,12 +401,16 @@ describe('Auth Store', () => {
         },
       };
       axios.post.mockResolvedValueOnce(mockResponse);
+      axios.get.mockRejectedValueOnce(new Error('Network error'));
 
       const billingStore = useBillingStore();
       const fetchUsageMeterSpy = vi.spyOn(billingStore, 'fetchUsageMeter');
 
-      await authStore.signin({ email: 'test@test.com', password: 'password' });
+      await expect(authStore.signin({ email: 'test@test.com', password: 'password' })).resolves.not.toThrow();
 
+      // Failure semantics unchanged (decision 2026-08-04): fetchServerConfig()
+      // sets serverConfig=null on failure — no keep-previous-value fallback.
+      expect(authStore.serverConfig).toBe(null);
       expect(fetchUsageMeterSpy).not.toHaveBeenCalled();
     });
   });
@@ -465,6 +477,33 @@ describe('Auth Store', () => {
 
       expect(authStore.auth).toBe(false);
       expect(authStore.user).toBe(null);
+    });
+
+    it('re-fetches serverConfig after a successful signup so auth-gated keys are present for the session (#4538)', async () => {
+      const authStore = useAuthStore();
+      const fetchServerConfigSpy = vi.spyOn(authStore, 'fetchServerConfig').mockResolvedValue(null);
+
+      const mockResponse = {
+        data: {
+          user: { id: '456', email: 'new@test.com', roles: ['user'] },
+          tokenExpiresIn: Date.now() + 3600000,
+        },
+      };
+
+      axios.post.mockResolvedValueOnce(mockResponse);
+      await authStore.signup({ email: 'new@test.com', password: 'password123' });
+
+      expect(fetchServerConfigSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT re-fetch serverConfig when signup fails (#4538)', async () => {
+      const authStore = useAuthStore();
+      const fetchServerConfigSpy = vi.spyOn(authStore, 'fetchServerConfig').mockResolvedValue(null);
+
+      axios.post.mockRejectedValueOnce(new Error('Signup failed'));
+      await expect(authStore.signup({ email: 'new@test.com', password: 'password' })).rejects.toThrow('Signup failed');
+
+      expect(fetchServerConfigSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- What changed: `signin()` and `signup()` now `await this.fetchServerConfig()` right after auth state is set (before signin()'s `meterMode` guard; before signup()'s `return`), so `serverConfig` carries auth-gated keys for the rest of the session.
- Why: `serverConfig` was only ever fetched once, pre-auth (anonymous). Config keys the API returns only to authenticated callers (`billing.{enabled,meterMode,equivalences}`, Node#3566) were absent from `serverConfig` for the **entire first in-SPA session**. `signin()`'s own `meterMode` guard was dead code in that window, and any consumer gated on those keys (e.g. the nav compute gauge) silently failed until a full page reload re-fetched with the cookie. OAuth was unaffected (full-page redirect already gets a fresh fetch).
- Related issues: Closes #4538

## Scope

- Modules impacted: `src/modules/auth/stores/auth.store.js` (signin/signup only — `app.vue`, the gauge components, and the router guard are untouched per the issue's decision)
- Cross-module impact: `none` — `fetchServerConfig()` is a pre-existing action on the same store; no new cross-module store import
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable) — reworked/added tests independently verified to FAIL against master's pre-fix behavior (4/4 fail), and pass with the fix (99/99 in the auth store suite, 2582/2582 full suite)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — no new input surface, no auth logic changed (still the same cookie-based `/auth/config` GET, same failure→null semantics).
- Mergeability considerations: none.
- Tests: the `#4261` tests pre-set `serverConfig` with an authenticated `billing` key already present — a state unreachable pre-auth, which is exactly what masked this bug. Reworked to start from an anonymous config (no `billing` key) and assert against a mocked post-auth re-fetch. Added 2 new tests covering the signup path (re-fetch called on success, not called on failure).
- Failure semantics unchanged (issue decision, 2026-08-04): `fetchServerConfig()` still sets `serverConfig = null` on failure — no keep-previous-value fallback.
- Follow-up tasks (optional): `signout()` does not currently null `serverConfig`, so a stale authenticated config (including `billing.*`) can persist into the next anonymous session until the router guard's `serverConfig === null` check re-triggers a fetch — that check never fires because the value isn't null. Out of scope here (the issue explicitly scoped this fix to `signin()`/`signup()` and excluded the router guard); flagging as a discovery, not implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server configuration, including billing settings, now refreshes after successful sign-in and sign-up.
  * Usage-meter features now use the latest authenticated configuration.
  * Improved handling when configuration retrieval fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->