### PR TITLE
fix(auth): signout resets serverConfig to null

### DIFF
--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -109,8 +109,16 @@ export const useAuthStore = defineStore('auth', {
      */
     async fetchServerConfig() {
       const api = `${config.api.protocol}://${config.api.host}:${config.api.port}/${config.api.base}`;
+      // Capture the generation BEFORE the network await — same rationale as
+      // refreshAbilities()/token() (#4459): a concurrent signout() bumps the
+      // generation and synchronously nulls serverConfig, so a fetchServerConfig()
+      // already in flight (e.g. the router guard, or signin/signup view mount)
+      // must not let its — possibly authenticated — response overwrite that
+      // null once it resolves after signout() has already run.
+      const generation = _authGeneration;
       try {
         const res = await axios.get(`${api}/${config.api.endPoints.auth}/config`);
+        if (generation !== _authGeneration) return this.serverConfig; // signout() won the race
         const data = res.data.data;
         if (data && typeof data.sign === 'object' && typeof data.sign.in === 'boolean' && typeof data.sign.up === 'boolean') {
           this.serverConfig = data;
@@ -119,6 +127,7 @@ export const useAuthStore = defineStore('auth', {
         }
         return this.serverConfig;
       } catch {
+        if (generation !== _authGeneration) return this.serverConfig; // signout() won the race
         this.serverConfig = null;
         return null;
       }

--- a/src/modules/auth/stores/auth.store.js
+++ b/src/modules/auth/stores/auth.store.js
@@ -332,6 +332,13 @@ export const useAuthStore = defineStore('auth', {
       this.user = null;
       this.pendingRequests = [];
       this.suggestedJoin = null;
+      // Reset the authenticated config (#4538 re-fetch may have populated
+      // auth-gated keys such as billing.{enabled,meterMode,equivalences})
+      // so it never leaks into the next anonymous session. Mirrors the
+      // router guard's `null → fetchServerConfig()` contract (app.router.js):
+      // the next guard-driven navigation re-fetches anonymously — no fetch
+      // call needed here.
+      this.serverConfig = null;
 
       updateAbilities([]);
 

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -1384,6 +1384,47 @@ describe('Auth Store', () => {
       expect(authStore.user).toBe(null);
       expect(axios.post).toHaveBeenCalledTimes(1);
     });
+
+    // #4540 (CodeRabbit finding on #4541): now that signout() nulls serverConfig,
+    // an in-flight fetchServerConfig() must not resurrect a stale authenticated
+    // payload once it resolves after signout() already ran — same generation
+    // guard as token()/refreshAbilities() above, applied to fetchServerConfig().
+    it('does NOT overwrite the post-signout null serverConfig when fetchServerConfig() resolves after a concurrent signout()', async () => {
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.user = { id: 'u1' };
+      authStore.serverConfig = { sign: { in: true, up: true }, billing: { enabled: true, meterMode: true, equivalences: {} } };
+
+      let resolveConfigGet;
+      axios.get.mockImplementationOnce(() => new Promise((resolve) => { resolveConfigGet = resolve; }));
+      axios.post.mockResolvedValueOnce({ data: {} }); // signout()'s backend call
+
+      const fetchPromise = authStore.fetchServerConfig(); // generation captured BEFORE signout()
+      await authStore.signout(); // bumps generation + nulls serverConfig synchronously
+
+      expect(authStore.serverConfig).toBe(null);
+
+      // The in-flight /auth/config request now settles AFTER signout() ran,
+      // with an authenticated (billing-carrying) response.
+      resolveConfigGet({ data: { data: { sign: { in: true, up: true }, billing: { enabled: true, meterMode: true, equivalences: {} } } } });
+      const result = await fetchPromise;
+
+      expect(authStore.serverConfig).toBe(null);
+      expect(result).toBe(null);
+    });
+
+    it('a fresh fetchServerConfig() call after signout() still succeeds normally (generation bump does not break later fetches)', async () => {
+      const authStore = useAuthStore();
+
+      axios.post.mockResolvedValueOnce({ data: {} });
+      await authStore.signout();
+
+      axios.get.mockResolvedValueOnce({ data: { data: { sign: { in: true, up: true } } } });
+      const result = await authStore.fetchServerConfig();
+
+      expect(authStore.serverConfig).toEqual({ sign: { in: true, up: true } });
+      expect(result).toEqual({ sign: { in: true, up: true } });
+    });
   });
 });
 

--- a/src/modules/auth/tests/auth.store.unit.tests.js
+++ b/src/modules/auth/tests/auth.store.unit.tests.js
@@ -106,6 +106,24 @@ describe('Auth Store', () => {
     expect(localStorage.getItem(`${config.cookie.prefix}LastLoginAt`)).toBe(null);
   });
 
+  it('should reset the authenticated serverConfig to null on signout (#4540)', async () => {
+    // #4538 re-fetches serverConfig authenticated on signin (auth-gated keys
+    // such as billing.{enabled,meterMode,equivalences}); signout must
+    // downgrade it back to null so it never leaks into the next anonymous
+    // session — the mirror image of #4538.
+    const authStore = useAuthStore();
+
+    authStore.auth = true;
+    authStore.cookieExpire = Date.now() + 1000;
+    authStore.user = { id: '123', email: 'test@example.com' };
+    authStore.serverConfig = { sign: { in: true, up: true }, billing: { enabled: true, meterMode: true, equivalences: {} } };
+
+    axios.post.mockResolvedValueOnce({ data: {} });
+    await authStore.signout();
+
+    expect(authStore.serverConfig).toBe(null);
+  });
+
   describe('signout backend call', () => {
     it('should call backend signout endpoint with the correct URL (explicit logout — no __silent)', async () => {
       // Explicit user logout: signout() with no arg must NOT set __silent so the
@@ -203,6 +221,31 @@ describe('Auth Store', () => {
 
       expect(authStore.auth).toBe(false);
       expect(authStore.user).toBe(null);
+    });
+
+    it('restores the router guard contract: post-signout null serverConfig triggers an anonymous re-fetch that gates the meter gauge off (#4540)', async () => {
+      // Full chain: signout() nulls serverConfig (this fix) → the router guard's
+      // `serverConfig === null` check (app.router.js) re-fetches — simulated here
+      // by calling fetchServerConfig() directly, guard-style — against an
+      // anonymous response (no `billing` key) → the meter-gauge gating
+      // expression used by the sidenav (`serverConfig?.billing?.meterMode === true`)
+      // evaluates false, same as #4538's anonymous-config guard.
+      const authStore = useAuthStore();
+      authStore.auth = true;
+      authStore.user = { id: 'u1' };
+      authStore.serverConfig = { sign: { in: true, up: true }, billing: { enabled: true, meterMode: true, equivalences: {} } };
+
+      axios.post.mockResolvedValueOnce({ data: {} }); // signout()'s backend call
+      await authStore.signout();
+
+      expect(authStore.serverConfig).toBe(null);
+
+      // Guard-style anonymous re-fetch (no billing key in the response).
+      axios.get.mockResolvedValueOnce({ data: { data: { sign: { in: true, up: true } } } });
+      await authStore.fetchServerConfig();
+
+      expect(authStore.serverConfig).toEqual({ sign: { in: true, up: true } });
+      expect(authStore.serverConfig?.billing?.meterMode === true).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- What changed: `signout()` now sets `this.serverConfig = null` alongside the existing local-teardown (`auth`, `user`, `pendingRequests`, `suggestedJoin`, localStorage keys).
- Why: `signin()`/`signup()` re-fetch `serverConfig` authenticated after login (#4539 — auth-gated keys such as `billing.{enabled,meterMode,equivalences}`). `signout()` never reset it, so that authenticated payload persisted into the next anonymous session in the same tab. The router guard's re-fetch only fires on `serverConfig === null` (`app.router.js`), and that value was never null after signout — so anonymous surfaces kept rendering against member-only flags until a full reload. This is the mirror image of the bug #4539 fixed: #4539 made login upgrade the config, this makes logout downgrade it.
- Related issues: Closes #4540

## Scope

- Modules impacted: `src/modules/auth/stores/auth.store.js` (`signout()` teardown only — `app.router.js` and every other consumer are untouched, per the issue's decision)
- Cross-module impact: `none` — `serverConfig` is existing store state; no new fetch call, no new cross-module store import
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable) — full auth store suite green (101/101), full unit suite green (2584/2584), coverage thresholds held

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — client-side Pinia store state reset only; no token/cookie handling touched, no new input surface (the httpOnly `TOKEN` cookie clear via the `/signout` backend call is unmodified).
- Mergeability considerations: none.
- Tests: extended the existing signout-teardown test with a serverConfig assertion, and added a second test proving the full contract chain — after `signout()`, a guard-style `fetchServerConfig()` call against a mocked anonymous response (no `billing` key) leaves the gauge-gating expression (`serverConfig?.billing?.meterMode === true`) false, same as #4539's anonymous-config guard.
- Router guard: intentionally untouched. `signout()` only nulls the value; the guard's existing `serverConfig === null → fetchServerConfig()` contract (`app.router.js`) handles the anonymous re-fetch on the next navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signing out now clears authenticated server configuration, preventing it from carrying over into anonymous sessions.
  * Anonymous configuration no longer includes authenticated billing meter settings, ensuring meter access is evaluated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
