### PR TITLE
feat(billing): skip live plans fetch under SEO prerender + shared isPrerenderCrawl helper

### DIFF
--- a/src/lib/helpers/prerender.js
+++ b/src/lib/helpers/prerender.js
@@ -1,0 +1,17 @@
+/**
+ * Prerender crawl detection helper.
+ */
+
+/**
+ * @desc Detects a headless-Chrome SEO prerender crawl via UA sniffing. UA-based
+ * detection is used instead of `navigator.webdriver`, which JSDOM/happy-dom also
+ * set on the test `navigator`, which would otherwise break unit tests run under
+ * those environments. SSR-safe: returns false when `navigator` is undefined.
+ * @returns {boolean} True when the current UA matches a HeadlessChrome crawl, false otherwise.
+ */
+export const isPrerenderCrawl = () => typeof navigator !== 'undefined' && /HeadlessChrome/.test(navigator.userAgent || '');
+
+/**
+ * Exports.
+ */
+export default { isPrerenderCrawl };

--- a/src/lib/helpers/prerender.js
+++ b/src/lib/helpers/prerender.js
@@ -3,12 +3,12 @@
  */
 
 /**
- * @desc Detects a headless-Chrome SEO prerender crawl via UA sniffing. UA-based
- * detection is used instead of `navigator.webdriver`, which JSDOM/happy-dom also
- * set on the test `navigator`, which would otherwise break unit tests run under
- * those environments. SSR-safe: returns false when `navigator` is undefined.
+ * @desc Detects a headless-Chrome SEO prerender crawl via UA sniffing.
  * @returns {boolean} True when the current UA matches a HeadlessChrome crawl, false otherwise.
  */
+// UA-based detection is used instead of `navigator.webdriver`, which JSDOM/happy-dom
+// also set on the test `navigator` and would otherwise break unit tests. SSR-safe:
+// returns false when `navigator` is undefined.
 export const isPrerenderCrawl = () => typeof navigator !== 'undefined' && /HeadlessChrome/.test(navigator.userAgent || '');
 
 /**

--- a/src/lib/helpers/tests/prerender.unit.tests.js
+++ b/src/lib/helpers/tests/prerender.unit.tests.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { isPrerenderCrawl } from '../prerender';
+
+describe('isPrerenderCrawl Helper', () => {
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, configurable: true });
+  });
+
+  it('returns true when the UA contains HeadlessChrome', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/131.0.0.0 Safari/537.36',
+      configurable: true,
+    });
+    expect(isPrerenderCrawl()).toBe(true);
+  });
+
+  it('returns false for a normal browser UA', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      configurable: true,
+    });
+    expect(isPrerenderCrawl()).toBe(false);
+  });
+
+  it('returns false when navigator is undefined (SSR)', () => {
+    const originalNavigator = globalThis.navigator;
+    globalThis.navigator = undefined;
+    try {
+      expect(isPrerenderCrawl()).toBe(false);
+    } finally {
+      globalThis.navigator = originalNavigator;
+    }
+  });
+
+  it('returns false when userAgent is empty', () => {
+    Object.defineProperty(navigator, 'userAgent', { value: '', configurable: true });
+    expect(isPrerenderCrawl()).toBe(false);
+  });
+});

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -660,3 +660,56 @@ describe('BillingPricingView — resolvedPlanItems sections + inheritsFrom resol
     expect(starter.sections).toBeNull();
   });
 });
+
+// ─── Suite: prerender crawl detection — skip live fetch, no error toast ─────
+
+describe('BillingPricingView — prerender crawl detection', () => {
+  let wrapper;
+  let store;
+  let originalUserAgent;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    store = useBillingStore();
+    originalUserAgent = navigator.userAgent;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    sessionStorage.clear();
+    Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, configurable: true });
+  });
+
+  it('skips the live plans fetch and never sets an error toast when UA is HeadlessChrome (prerender crawl)', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/131.0.0.0 Safari/537.36',
+      configurable: true,
+    });
+    vi.spyOn(store, 'fetchPlans').mockRejectedValue(new Error('no API on the local prerender static server'));
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+
+    wrapper = mountPricing({ isLoggedIn: false });
+    await flushPromises();
+
+    // The plans fetch is never fired under the prerender crawl — static content
+    // (usePricing) already fully renders the cards, so there's nothing to fail on.
+    expect(store.fetchPlans).not.toHaveBeenCalled();
+    expect(wrapper.vm.error).toBeNull();
+  });
+
+  it('still fetches plans and surfaces the error toast on a genuine failure in a real browser', async () => {
+    // Regression lock: only the prerender crawl is suppressed — a real user whose
+    // live fetch genuinely fails must still see the retry toast (pre-existing UX).
+    vi.spyOn(store, 'fetchPlans').mockRejectedValue(new Error('network error'));
+    vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
+
+    wrapper = mountPricing({ isLoggedIn: false });
+    await flushPromises();
+
+    expect(store.fetchPlans).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.error).toBe('Failed to load pricing. Please try again.');
+  });
+});

--- a/src/modules/billing/tests/billing.pricing.view.unit.tests.js
+++ b/src/modules/billing/tests/billing.pricing.view.unit.tests.js
@@ -703,6 +703,12 @@ describe('BillingPricingView — prerender crawl detection', () => {
   it('still fetches plans and surfaces the error toast on a genuine failure in a real browser', async () => {
     // Regression lock: only the prerender crawl is suppressed — a real user whose
     // live fetch genuinely fails must still see the retry toast (pre-existing UX).
+    // UA set explicitly (not just inherited from the runner) so the assertion never
+    // depends on which environment this test happens to run under.
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      configurable: true,
+    });
     vi.spyOn(store, 'fetchPlans').mockRejectedValue(new Error('network error'));
     vi.spyOn(store, 'fetchSubscription').mockResolvedValue(null);
 

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -391,12 +391,9 @@ export default {
     },
   },
   async created() {
-    // The SEO prerender crawl hits a local static server with no API backend — the
-    // live plans fetch always fails there, baking this error toast into the
-    // prerendered HTML (hydration's later successful fetch never clears the
-    // captured node). Static content (usePricing) already fully renders the cards
-    // without live data, so skip the fetch entirely under prerender instead of ever
-    // letting it fail.
+    // The SEO prerender crawl hits a local static server with no API backend, so the
+    // live fetch would always fail and bake this error toast into the prerendered
+    // HTML. Static content already renders the cards, so skip the fetch under prerender.
     if (!isPrerenderCrawl()) {
       try {
         await this.billingStore.fetchPlans();

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -390,10 +390,14 @@ export default {
           };
     },
   },
+  /**
+   * Fetches live plans and subscription on component creation, and handles the
+   * Stripe checkout redirect query params. The live plans fetch is skipped under
+   * the SEO prerender crawl (see isPrerenderCrawl) since its local static server
+   * has no API backend and static content already renders the cards.
+   * @returns {Promise<void>}
+   */
   async created() {
-    // The SEO prerender crawl hits a local static server with no API backend, so the
-    // live fetch would always fail and bake this error toast into the prerendered
-    // HTML. Static content already renders the cards, so skip the fetch under prerender.
     if (!isPrerenderCrawl()) {
       try {
         await this.billingStore.fetchPlans();

--- a/src/modules/billing/views/billing.pricing.view.vue
+++ b/src/modules/billing/views/billing.pricing.view.vue
@@ -159,6 +159,7 @@ import { usePricing } from '../composables/billing.usePricing.js';
 import { useCurrencyFormat } from '../composables/billing.useCurrencyFormat.js';
 import { validateStripeUrl } from '../lib/stripeRedirect';
 import { computeAnnualSavingsPct } from '../lib/pricingMath.js';
+import { isPrerenderCrawl } from '../../../lib/helpers/prerender';
 import BillingPricingToggleComponent from '../components/billing.pricingToggle.component.vue';
 import BillingCardComponent from '../components/billing.card.component.vue';
 import BillingPacksComponent from '../components/billing.packs.component.vue';
@@ -390,11 +391,19 @@ export default {
     },
   },
   async created() {
-    try {
-      await this.billingStore.fetchPlans();
-    } catch (err) {
-      console.error('Failed to load pricing plans:', err);
-      this.error = 'Failed to load pricing. Please try again.';
+    // The SEO prerender crawl hits a local static server with no API backend — the
+    // live plans fetch always fails there, baking this error toast into the
+    // prerendered HTML (hydration's later successful fetch never clears the
+    // captured node). Static content (usePricing) already fully renders the cards
+    // without live data, so skip the fetch entirely under prerender instead of ever
+    // letting it fail.
+    if (!isPrerenderCrawl()) {
+      try {
+        await this.billingStore.fetchPlans();
+      } catch (err) {
+        console.error('Failed to load pricing plans:', err);
+        this.error = 'Failed to load pricing. Please try again.';
+      }
     }
 
     const orgsEnabled = this.authStore.serverConfig?.organizations?.enabled;

--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -49,6 +49,7 @@ import { computed, getCurrentInstance, onMounted, ref } from 'vue';
 import { useTheme } from 'vuetify';
 import { useCookieConsent } from '../composables/useCookieConsent';
 import { liquidGlassStyle } from '../../../lib/helpers/theme';
+import { isPrerenderCrawl } from '../../../lib/helpers/prerender';
 
 const instance = getCurrentInstance();
 const theme = useTheme();
@@ -56,15 +57,13 @@ const theme = useTheme();
 const isMounted = ref(false);
 
 /**
- * Sets the isMounted flag after hydration, skipping Puppeteer prerender
- * environments (UA contains 'HeadlessChrome') to prevent the banner from being
- * captured into static HTML and duplicated on hydration via Vue's Teleport.
- * UA-based detection is more specific than navigator.webdriver (which JSDOM
- * also sets, breaking unit tests).
+ * Sets the isMounted flag after hydration, skipping the SEO prerender crawl (see
+ * isPrerenderCrawl) to prevent the banner from being captured into static HTML and
+ * duplicated on hydration via Vue's Teleport.
  * @returns {void}
  */
 onMounted(() => {
-  if (typeof navigator !== 'undefined' && /HeadlessChrome/.test(navigator.userAgent || '')) return;
+  if (isPrerenderCrawl()) return;
   isMounted.value = true;
 });
 

--- a/src/modules/legal/components/legal.cookieBanner.component.vue
+++ b/src/modules/legal/components/legal.cookieBanner.component.vue
@@ -57,11 +57,11 @@ const theme = useTheme();
 const isMounted = ref(false);
 
 /**
- * Sets the isMounted flag after hydration, skipping the SEO prerender crawl (see
- * isPrerenderCrawl) to prevent the banner from being captured into static HTML and
- * duplicated on hydration via Vue's Teleport.
+ * Sets the isMounted flag after hydration, skipping the SEO prerender crawl.
  * @returns {void}
  */
+// Guards against the banner being captured into static HTML and duplicated on
+// hydration via Vue's Teleport (see isPrerenderCrawl).
 onMounted(() => {
   if (isPrerenderCrawl()) return;
   isMounted.value = true;

--- a/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
+++ b/src/modules/legal/tests/legal.cookieBanner.component.unit.tests.js
@@ -90,6 +90,21 @@ describe('legal.cookieBanner.component', () => {
     expect(buttons.some((b) => b.text() === 'Sounds good')).toBe(true);
   });
 
+  it('does not render banner content when the UA is a prerender crawl (isPrerenderCrawl guard)', async () => {
+    const originalUserAgent = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/131.0.0.0 Safari/537.36',
+      configurable: true,
+    });
+    try {
+      mountBanner();
+      await flushPromises();
+      expect(document.body.innerHTML).not.toContain('Sounds good');
+    } finally {
+      Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, configurable: true });
+    }
+  });
+
   it('does not render banner content when consentNeeded is false', async () => {
     consentNeeded.value = false;
     mountBanner();


### PR DESCRIPTION
## Summary

- What changed: added a shared `src/lib/helpers/prerender.js` helper exporting `isPrerenderCrawl()` (UA-based headless-Chrome detection, SSR-safe). The billing pricing view's `created()` now skips its live plans fetch when running under a prerender crawl (static content already renders the cards). The legal cookie-banner's existing inline copy of the same UA predicate is replaced with a call to the shared helper (no behavior change there).
- Why: the SEO prerender crawl hits a local static server with no API backend, so the live plans fetch always failed there and baked an error toast into the prerendered HTML — hydration's later successful fetch never cleared the captured node. The same detection predicate already existed inline in the cookie-banner component; extracting it removes the duplicate.
- Related issues: Closes #4542

## Scope

- Modules impacted: `lib/helpers` (new), `modules/billing` (view), `modules/legal` (component)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: `isPrerenderCrawl()` only reads `navigator.userAgent` (client-controlled, already fully controlled by the client) and returns a boolean gating a client-side fetch — no auth/authorization boundary or server-side check depends on it.
- Mergeability considerations: none — additive helper + two isolated call sites.
- Follow-up tasks (optional): none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added prerender-aware behavior for pricing and cookie consent experiences.
  - Pricing pages now avoid unnecessary plan requests during search-engine rendering.
  - Cookie banners remain hidden during prerendering to support cleaner rendered pages.

- **Bug Fixes**
  - Preserved existing pricing error handling for regular browsers.
  - Improved server-side rendering safety when browser information is unavailable.

- **Tests**
  - Added coverage for prerender detection, pricing requests, error states, and cookie banner visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->