### PR TITLE
test(homogeneity): config-agnostic assertions + native loader isolation

### DIFF
--- a/src/lib/helpers/e2e/api.js
+++ b/src/lib/helpers/e2e/api.js
@@ -8,7 +8,7 @@ const API = API_URL;
  * etc.) surface as failures instead of silently skipping.
  * @type {RegExp}
  */
-export const CONNECTIVITY_ERROR_RE = /ECONNREFUSED|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|fetch failed|socket hang up|network error/i;
+export const CONNECTIVITY_ERROR_RE = /ECONNREFUSED|ECONNRESET|EPIPE|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|fetch failed|socket hang up|network error/i;
 
 /**
  * @desc Safely extract a string message from an unknown thrown value.
@@ -33,7 +33,11 @@ export async function isApiAvailable(request) {
   try {
     await request.get(API);
     return true;
-  } catch {
+  } catch (err) {
+    // Log so a misconfigured API_URL (bad host, DNS typo, TLS rejection) surfaces in CI
+    // output instead of collapsing into an indistinguishable generic "backend not running"
+    // skip reason.
+    console.warn(`[isApiAvailable] request to ${API} failed: ${errorMessage(err)}`);
     return false;
   }
 }

--- a/src/lib/helpers/e2e/api.js
+++ b/src/lib/helpers/e2e/api.js
@@ -16,9 +16,7 @@ export const CONNECTIVITY_ERROR_RE = /ECONNREFUSED|ENOTFOUND|ETIMEDOUT|EAI_AGAIN
  * @returns {string}
  */
 export function errorMessage(err) {
-  if (err instanceof Error) return err.message;
-  if (err == null) return String(err);
-  return typeof err === 'string' ? err : String(err);
+  return err instanceof Error ? err.message : String(err);
 }
 
 /**

--- a/src/lib/helpers/e2e/api.js
+++ b/src/lib/helpers/e2e/api.js
@@ -3,6 +3,44 @@ import { API_URL } from './config.js';
 const API = API_URL;
 
 /**
+ * @desc Patterns identifying a backend-unreachable / transport-level failure.
+ * Scope `test.skip` to these so real backend regressions (4xx/5xx, schema drift,
+ * etc.) surface as failures instead of silently skipping.
+ * @type {RegExp}
+ */
+export const CONNECTIVITY_ERROR_RE = /ECONNREFUSED|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|fetch failed|socket hang up|network error/i;
+
+/**
+ * @desc Safely extract a string message from an unknown thrown value.
+ * @param {unknown} err
+ * @returns {string}
+ */
+export function errorMessage(err) {
+  if (err instanceof Error) return err.message;
+  if (err == null) return String(err);
+  return typeof err === 'string' ? err : String(err);
+}
+
+/**
+ * @desc Check whether the Node API backend is reachable at the transport level.
+ * Reachability = a response came back at all (any HTTP status) — a 4xx/5xx means
+ * the backend IS running and answered, so callers should NOT skip and should let
+ * the test exercise the real code path. Only network/connection errors (the
+ * request itself throws) indicate the backend is genuinely unreachable — the
+ * explicit env prerequisite an org-flow E2E test depends on.
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @returns {Promise<boolean>}
+ */
+export async function isApiAvailable(request) {
+  try {
+    await request.get(API);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * @desc Create an authenticated API request context
  * @param {import('@playwright/test').Playwright} playwright - Playwright instance
  * @param {string} email

--- a/src/lib/helpers/e2e/tests/api.unit.tests.js
+++ b/src/lib/helpers/e2e/tests/api.unit.tests.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { errorMessage, isApiAvailable, CONNECTIVITY_ERROR_RE } from '../api.js';
+
+describe('errorMessage', () => {
+  it('returns the message of an Error instance', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('stringifies a non-Error value', () => {
+    expect(errorMessage('plain string')).toBe('plain string');
+    expect(errorMessage({ foo: 'bar' })).toBe('[object Object]');
+    expect(errorMessage(null)).toBe('null');
+    expect(errorMessage(undefined)).toBe('undefined');
+  });
+});
+
+describe('CONNECTIVITY_ERROR_RE', () => {
+  it('matches known transport-level failure signatures', () => {
+    expect(CONNECTIVITY_ERROR_RE.test('connect ECONNREFUSED 127.0.0.1:3000')).toBe(true);
+    expect(CONNECTIVITY_ERROR_RE.test('read ECONNRESET')).toBe(true);
+    expect(CONNECTIVITY_ERROR_RE.test('write EPIPE')).toBe(true);
+    expect(CONNECTIVITY_ERROR_RE.test('getaddrinfo ENOTFOUND api.example.com')).toBe(true);
+  });
+
+  it('does not match an application-level error message', () => {
+    expect(CONNECTIVITY_ERROR_RE.test('Validation failed: email is required')).toBe(false);
+  });
+});
+
+describe('isApiAvailable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when the request resolves (any HTTP status is reachability)', async () => {
+    const request = { get: vi.fn().mockResolvedValue({ status: () => 500 }) };
+    await expect(isApiAvailable(request)).resolves.toBe(true);
+  });
+
+  it('returns false and logs when the request throws a transport error', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const request = { get: vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')) };
+
+    await expect(isApiAvailable(request)).resolves.toBe(false);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('ECONNREFUSED');
+  });
+});

--- a/src/modules/app/tests/app.store.unit.tests.js
+++ b/src/modules/app/tests/app.store.unit.tests.js
@@ -25,9 +25,15 @@ describe('initializeStores', () => {
     vi.clearAllMocks();
   });
 
+  // Self-contained fixture covering both route-meta conventions in use across the stack:
+  // role-list gating (`meta.roles`) and CASL action/subject gating (`meta.action`/`meta.subject`,
+  // e.g. organizations.development.config.js tabs). initializeStores only forwards routes to
+  // coreStore.init — it must stay agnostic to which meta shape a route (or a consumer's route)
+  // uses, so the fixture never assumes just one.
   const mockRoutes = [
     { path: '/', name: 'Home' },
     { path: '/secure', name: 'Secure', meta: { roles: ['user'] } },
+    { path: '/manage', name: 'Manage', meta: { action: 'manage', subject: 'Organization' } },
   ];
 
   it('calls coreStore.init with the provided routes', () => {
@@ -56,5 +62,12 @@ describe('initializeStores', () => {
   it('returned core store has init method', () => {
     const { core } = initializeStores(mockRoutes);
     expect(typeof core.init).toBe('function');
+  });
+
+  it('forwards routes verbatim regardless of route-meta shape (roles-based or action/subject-based)', () => {
+    initializeStores(mockRoutes);
+    const forwardedRoutes = coreInitMock.mock.calls[0][0];
+    expect(forwardedRoutes.find((r) => r.name === 'Secure').meta).toEqual({ roles: ['user'] });
+    expect(forwardedRoutes.find((r) => r.name === 'Manage').meta).toEqual({ action: 'manage', subject: 'Organization' });
   });
 });

--- a/src/modules/app/tests/app.store.unit.tests.js
+++ b/src/modules/app/tests/app.store.unit.tests.js
@@ -26,14 +26,15 @@ describe('initializeStores', () => {
   });
 
   // Self-contained fixture covering both route-meta conventions in use across the stack:
-  // role-list gating (`meta.roles`) and CASL action/subject gating (`meta.action`/`meta.subject`,
-  // e.g. organizations.development.config.js tabs). initializeStores only forwards routes to
-  // coreStore.init — it must stay agnostic to which meta shape a route (or a consumer's route)
-  // uses, so the fixture never assumes just one.
+  // role-list gating (`meta.roles`) and CASL action/subject gating (`meta.action`/`meta.subject`).
+  // initializeStores only forwards routes to coreStore.init — it must stay agnostic to which
+  // meta shape a route (or a consumer's route) uses, so the fixture never assumes just one.
+  // `app` is a core module (CLAUDE.md: core modules never reference optional module names), so
+  // the CASL subject here is a synthetic placeholder, not any real (optional) module's model.
   const mockRoutes = [
     { path: '/', name: 'Home' },
     { path: '/secure', name: 'Secure', meta: { roles: ['user'] } },
-    { path: '/manage', name: 'Manage', meta: { action: 'manage', subject: 'Organization' } },
+    { path: '/manage', name: 'Manage', meta: { action: 'manage', subject: 'Widget' } },
   ];
 
   it('calls coreStore.init with the provided routes', () => {
@@ -68,6 +69,6 @@ describe('initializeStores', () => {
     initializeStores(mockRoutes);
     const forwardedRoutes = coreInitMock.mock.calls[0][0];
     expect(forwardedRoutes.find((r) => r.name === 'Secure').meta).toEqual({ roles: ['user'] });
-    expect(forwardedRoutes.find((r) => r.name === 'Manage').meta).toEqual({ action: 'manage', subject: 'Organization' });
+    expect(forwardedRoutes.find((r) => r.name === 'Manage').meta).toEqual({ action: 'manage', subject: 'Widget' });
   });
 });

--- a/src/modules/auth/tests/auth.token.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.token.view.unit.tests.js
@@ -50,31 +50,6 @@ function mountView(query, router, extraStubs) {
 }
 
 /**
- * Poll `assertion` until it stops throwing, or re-throw once `timeoutMs` elapses.
- * Loading-state assertions target the AppSpinner wrapper (see below), which can
- * resolve via `defineAsyncComponent` when a consumer configures a custom loader —
- * that resolution can take more than one microtask tick, so a single
- * `flushPromises()` is not always enough. Used instead of a fixed-tick wait so
- * this file stays tolerant of that extra tick rather than assuming none is needed.
- * @param {() => void} assertion
- * @param {number} [timeoutMs]
- * @returns {Promise<void>}
- */
-async function waitForAssertion(assertion, timeoutMs = 1000) {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    try {
-      assertion();
-      return;
-    } catch (err) {
-      if (Date.now() >= deadline) throw err;
-      await flushPromises();
-      await new Promise((resolve) => { setTimeout(resolve, 10); });
-    }
-  }
-}
-
-/**
  * Stable hook for "is the loader currently shown" — the AppSpinner wrapper's
  * declared component name, not the default spinner's own DOM class. A consumer
  * configuring `config.ui.loader.component` renders a different root inside
@@ -136,7 +111,7 @@ describe('auth.token.view', () => {
       const wrapper = mountView();
 
       expect(wrapper.vm.loading).toBe(true);
-      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(true));
+      await vi.waitFor(() => expect(findAppSpinner(wrapper).exists()).toBe(true));
       expect(wrapper.text()).toContain('Signing you in');
       expect(wrapper.text()).not.toContain('Error during oAuth');
 
@@ -164,7 +139,7 @@ describe('auth.token.view', () => {
 
       expect(wrapper.vm.loading).toBe(false);
       expect(wrapper.vm.error.details.message).toBe('network error');
-      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
+      await vi.waitFor(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
       expect(wrapper.text()).toContain('Error during oAuth');
       consoleSpy.mockRestore();
     });
@@ -189,7 +164,7 @@ describe('auth.token.view', () => {
       await flushPromises();
 
       expect(wrapper.vm.loading).toBe(false);
-      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
+      await vi.waitFor(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
       expect(wrapper.text()).toContain('Error during oAuth');
       consoleSpy.mockRestore();
     });
@@ -264,7 +239,7 @@ describe('auth.token.view', () => {
       });
 
       expect(wrapper.vm.loading).toBe(true);
-      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(true));
+      await vi.waitFor(() => expect(findAppSpinner(wrapper).exists()).toBe(true));
       expect(wrapper.find('.synthetic-consumer-loader').exists()).toBe(true);
       expect(wrapper.text()).not.toContain('Error during oAuth');
 
@@ -282,7 +257,7 @@ describe('auth.token.view', () => {
       await flushPromises();
 
       expect(wrapper.vm.loading).toBe(false);
-      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
+      await vi.waitFor(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
       expect(wrapper.text()).toContain('Error during oAuth');
       consoleSpy.mockRestore();
     });

--- a/src/modules/auth/tests/auth.token.view.unit.tests.js
+++ b/src/modules/auth/tests/auth.token.view.unit.tests.js
@@ -28,9 +28,12 @@ function buildRouterMock() {
  * Mount the token (oAuth callback) view with Vuetify installed.
  * @param {object} query - Route query parameters.
  * @param {object} router - Router mock.
+ * @param {object} [extraStubs] - Additional/overriding `global.stubs` entries — used to
+ * simulate a consumer swapping the loader component (see the "synthetic consumer
+ * profile" describe block below) without touching the real config/glob resolution.
  * @returns {import('@vue/test-utils').VueWrapper} mounted wrapper
  */
-function mountView(query, router) {
+function mountView(query, router, extraStubs) {
   const q = query || {};
   const r = router || buildRouterMock();
   return mount(AuthTokenView, {
@@ -41,9 +44,47 @@ function mountView(query, router) {
         $route: { query: q },
         $router: r,
       },
-      stubs: { RouterLink: true, VAlert: { template: '<div />' } },
+      stubs: { RouterLink: true, VAlert: { template: '<div />' }, ...extraStubs },
     },
   });
+}
+
+/**
+ * Poll `assertion` until it stops throwing, or re-throw once `timeoutMs` elapses.
+ * Loading-state assertions target the AppSpinner wrapper (see below), which can
+ * resolve via `defineAsyncComponent` when a consumer configures a custom loader —
+ * that resolution can take more than one microtask tick, so a single
+ * `flushPromises()` is not always enough. Used instead of a fixed-tick wait so
+ * this file stays tolerant of that extra tick rather than assuming none is needed.
+ * @param {() => void} assertion
+ * @param {number} [timeoutMs]
+ * @returns {Promise<void>}
+ */
+async function waitForAssertion(assertion, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline) throw err;
+      await flushPromises();
+      await new Promise((resolve) => { setTimeout(resolve, 10); });
+    }
+  }
+}
+
+/**
+ * Stable hook for "is the loader currently shown" — the AppSpinner wrapper's
+ * declared component name, not the default spinner's own DOM class. A consumer
+ * configuring `config.ui.loader.component` renders a different root inside
+ * AppSpinner, but AppSpinner itself always mounts under this name (rule 1: never
+ * assert a hardcoded default's DOM shape).
+ * @param {import('@vue/test-utils').VueWrapper} wrapper
+ * @returns {import('@vue/test-utils').VueWrapper}
+ */
+function findAppSpinner(wrapper) {
+  return wrapper.findComponent({ name: 'CoreAppSpinner' });
 }
 
 describe('auth.token.view', () => {
@@ -95,7 +136,7 @@ describe('auth.token.view', () => {
       const wrapper = mountView();
 
       expect(wrapper.vm.loading).toBe(true);
-      expect(wrapper.find('.v-progress-circular').exists()).toBe(true);
+      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(true));
       expect(wrapper.text()).toContain('Signing you in');
       expect(wrapper.text()).not.toContain('Error during oAuth');
 
@@ -123,7 +164,7 @@ describe('auth.token.view', () => {
 
       expect(wrapper.vm.loading).toBe(false);
       expect(wrapper.vm.error.details.message).toBe('network error');
-      expect(wrapper.find('.v-progress-circular').exists()).toBe(false);
+      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
       expect(wrapper.text()).toContain('Error during oAuth');
       consoleSpy.mockRestore();
     });
@@ -148,7 +189,7 @@ describe('auth.token.view', () => {
       await flushPromises();
 
       expect(wrapper.vm.loading).toBe(false);
-      expect(wrapper.find('.v-progress-circular').exists()).toBe(false);
+      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
       expect(wrapper.text()).toContain('Error during oAuth');
       consoleSpy.mockRestore();
     });
@@ -200,6 +241,49 @@ describe('auth.token.view', () => {
       await flushPromises();
 
       expect(wrapper.html()).toContain('Sign-in failed');
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('loading state — synthetic consumer profile (custom loader component)', () => {
+    it('keeps the loading/error assertions valid via the AppSpinner wrapper when a consumer swaps the rendered loader', async () => {
+      let resolveToken;
+      tokenMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveToken = resolve;
+          }),
+      );
+
+      // Simulate config.ui.loader.component pointing at a consumer's own SFC by
+      // stubbing AppSpinner's local registration — CoreAppSpinner's own contract
+      // test certifies the config→component resolution mechanism itself; this
+      // proves this view's assertions stay valid however AppSpinner renders.
+      const wrapper = mountView(undefined, undefined, {
+        AppSpinner: { name: 'CoreAppSpinner', template: '<div class="synthetic-consumer-loader" />' },
+      });
+
+      expect(wrapper.vm.loading).toBe(true);
+      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(true));
+      expect(wrapper.find('.synthetic-consumer-loader').exists()).toBe(true);
+      expect(wrapper.text()).not.toContain('Error during oAuth');
+
+      resolveToken();
+      await flushPromises();
+    });
+
+    it('hides the AppSpinner wrapper and surfaces the error UI on the reject path, with a consumer-swapped loader', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      tokenMock.mockRejectedValueOnce(new Error('network error'));
+
+      const wrapper = mountView(undefined, undefined, {
+        AppSpinner: { name: 'CoreAppSpinner', template: '<div class="synthetic-consumer-loader" />' },
+      });
+      await flushPromises();
+
+      expect(wrapper.vm.loading).toBe(false);
+      await waitForAssertion(() => expect(findAppSpinner(wrapper).exists()).toBe(false));
+      expect(wrapper.text()).toContain('Error during oAuth');
       consoleSpy.mockRestore();
     });
   });

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -234,7 +234,11 @@ describe('BillingUpgradePrompt', () => {
           extrasLedger: { entries: [{ source: 'signup_grant', amount: 500 }], total: 1, page: 1, limit: 20 },
         });
         const wrapper = mount(Component, {
-          props: { requiredPlan: 'growth', mode: 'meter' },
+          // Neutral requiredPlan ('pro', not 'growth') — this prop isn't rendered by the
+          // post-grant (exhaustedAfterGrant) branch under test, but keeping it outside the
+          // words the assertions below check for removes any ambiguity between "resolved
+          // static text" and "prop passthrough".
+          props: { requiredPlan: 'pro', mode: 'meter' },
           global: { plugins: [vuetify], stubs: { RouterLink: true } },
         });
         const text = wrapper.text();

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 import { useBillingStore } from '../stores/billing.store';
+import { resolveStaticContent } from '../lib/billing.resolveStaticContent.js';
 import BillingUpgradePrompt from '../components/billing.upgradePrompt.component.vue';
 
 const vuetify = createVuetify();
@@ -160,7 +161,14 @@ describe('BillingUpgradePrompt', () => {
       });
       const packBtn = wrapper.find('[data-test="cta-pack"]');
       expect(packBtn.exists()).toBe(true);
-      expect(packBtn.text()).toMatch(/pack/i);
+      // Consumer-tolerance assertion: derive the expected CTA label from the loaded
+      // config (same formula the component's own packCtaLabel computed uses) instead
+      // of a coincidental /pack/i substring match — a consumer's own pack.cta ("Get
+      // Started", "Top up") need not contain the literal word "pack".
+      const { packs } = resolveStaticContent();
+      const primaryPack = packs[0] || null;
+      const expectedCta = primaryPack ? primaryPack.cta || 'Buy a compute pack' : 'Buy a compute pack';
+      expect(packBtn.text()).toContain(expectedCta);
       // Post-grant pack CTA routes to the single billing entry point, not a modal event.
       expect(wrapper.findComponent('[data-test="cta-pack"]').props('to')).toBe('/pricing#units');
     });
@@ -259,12 +267,20 @@ describe('BillingUpgradePrompt', () => {
           global: { plugins: [vuetify], stubs: { RouterLink: true } },
         });
         const text = wrapper.text();
-        // Read the expected grant label from the loaded/generated config (the same
-        // resolveStaticContent() source the component itself reads) instead of asserting
-        // a hardcoded devkit-default literal. (The rendered "$9.00" is the devkit's OWN
+        // This IS a default-certification test (forced-empty config -> devkit's own
+        // hardcoded default), not a consumer-tolerance test — the literal below is the
+        // contract being certified, so pin it directly (rule 1's "assert against the
+        // loaded config" applies to consumer-tolerance tests; a bare-default cert needs
+        // an independent literal or a regression to empty/wrong copy would pass
+        // vacuously, since resolveIsolated() reads the exact same mocked path the
+        // component itself resolves against). (The rendered "$9.00" is the devkit's OWN
         // generic demo pack price — same placeholder used module-wide, e.g.
         // billing.subscriptions.component.vue — not a leaked literal; the component source
         // itself no longer hardcodes any price.)
+        expect(text).toMatch(/one-shot compute grant/i);
+        // Secondary check: the rendered copy also matches whatever resolveStaticContent()
+        // resolves to under this forced-empty config — catches drift between the literal
+        // above and the devkit default in billing.static-content.js.
         const { signupGrant } = resolveIsolated();
         expect(text.toLowerCase()).toContain(signupGrant.label.toLowerCase());
         expect(text).not.toMatch(/\bboost\b/i);

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -3,7 +3,6 @@ import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 import { useBillingStore } from '../stores/billing.store';
-import { resolveStaticContent } from '../lib/billing.resolveStaticContent.js';
 import BillingUpgradePrompt from '../components/billing.upgradePrompt.component.vue';
 
 const vuetify = createVuetify();
@@ -212,25 +211,48 @@ describe('BillingUpgradePrompt', () => {
       expect(wrapper.text()).toMatch(/requires the|Upgrade/i);
     });
 
-    it('devkit default renders generic placeholder copy — no downstream-specific product literal', () => {
-      const wrapper = mountWithStore({
-        subscription: { plan: 'free' },
-        extrasBalance: { balance: 0 },
-        extrasLedger: { entries: [{ source: 'signup_grant', amount: 500 }], total: 1, page: 1, limit: 20 },
-      });
-      const text = wrapper.text();
-      // Read the expected grant label from the loaded/generated config (the same
-      // resolveStaticContent() source the component itself reads) instead of asserting
-      // a hardcoded devkit-default literal — this stays true whether this suite runs
-      // against the bare stack or a consumer's own generated config. (The rendered
-      // "$9.00" is the devkit's OWN generic demo pack price — same placeholder used
-      // module-wide, e.g. billing.subscriptions.component.vue — not a leaked literal;
-      // the component source itself no longer hardcodes any price.)
-      const { signupGrant } = resolveStaticContent();
-      expect(text.toLowerCase()).toContain(signupGrant.label.toLowerCase());
-      expect(text).not.toMatch(/\bboost\b/i);
-      expect(text).not.toMatch(/\bgrowth\b/i);
-      expect(text).not.toContain('500 compute');
+    it('devkit default renders generic placeholder copy — no downstream-specific product literal', async () => {
+      // This is a leak-guard for the DEVKIT'S OWN bare-stack default specifically — not
+      // "whatever's currently configured". Force config.billing.staticContent to empty so
+      // resolveStaticContent() falls through to the devkit defaults regardless of the real
+      // ambient generated config (bare stack today, a consumer's own build tomorrow) — a
+      // consumer whose OWN static content legitimately contains "growth"/"boost" must never
+      // make this assertion spuriously fail. Isolated the same way core.appSpinner's default-
+      // rendering contract is (mock the config service, not a consumer value, rule 2).
+      vi.resetModules();
+      vi.doMock('../../../lib/services/config.js', () => ({ default: { billing: { staticContent: {} } } }));
+      try {
+        const { default: Component } = await import('../components/billing.upgradePrompt.component.vue');
+        const { useBillingStore: useIsolatedBillingStore } = await import('../stores/billing.store.js');
+        const { resolveStaticContent: resolveIsolated } = await import('../lib/billing.resolveStaticContent.js');
+
+        setActivePinia(createPinia());
+        const store = useIsolatedBillingStore();
+        Object.assign(store, {
+          subscription: { plan: 'free' },
+          extrasBalance: { balance: 0 },
+          extrasLedger: { entries: [{ source: 'signup_grant', amount: 500 }], total: 1, page: 1, limit: 20 },
+        });
+        const wrapper = mount(Component, {
+          props: { requiredPlan: 'growth', mode: 'meter' },
+          global: { plugins: [vuetify], stubs: { RouterLink: true } },
+        });
+        const text = wrapper.text();
+        // Read the expected grant label from the loaded/generated config (the same
+        // resolveStaticContent() source the component itself reads) instead of asserting
+        // a hardcoded devkit-default literal. (The rendered "$9.00" is the devkit's OWN
+        // generic demo pack price — same placeholder used module-wide, e.g.
+        // billing.subscriptions.component.vue — not a leaked literal; the component source
+        // itself no longer hardcodes any price.)
+        const { signupGrant } = resolveIsolated();
+        expect(text.toLowerCase()).toContain(signupGrant.label.toLowerCase());
+        expect(text).not.toMatch(/\bboost\b/i);
+        expect(text).not.toMatch(/\bgrowth\b/i);
+        expect(text).not.toContain('500 compute');
+      } finally {
+        vi.doUnmock('../../../lib/services/config.js');
+        vi.resetModules();
+      }
     });
   });
 

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -8,6 +8,27 @@ import BillingUpgradePrompt from '../components/billing.upgradePrompt.component.
 const vuetify = createVuetify();
 
 /**
+ * Dynamically re-import the resolver + component after mocking the underlying config
+ * service, so the module-scope `resolveStaticContent()` call picks up the per-test
+ * override — an EMPTY `staticContent` isolates the devkit's own defaults regardless of
+ * the real ambient generated config. Mirrors the pattern in
+ * billing.resolveStaticContent.unit.tests.js. Callers must unmock + `vi.resetModules()`
+ * afterwards (see the `afterEach` in the describe block(s) below).
+ * @param {Object} staticContent - Value to install at config.billing.staticContent.
+ * @returns {Promise<{Component: Object, useBillingStore: Function, resolveStaticContent: Function}>}
+ */
+async function loadWithConfig(staticContent) {
+  vi.resetModules();
+  vi.doMock('../../../lib/services/config.js', () => ({
+    default: { billing: { staticContent } },
+  }));
+  const { default: Component } = await import('../components/billing.upgradePrompt.component.vue');
+  const storeModule = await import('../stores/billing.store.js');
+  const resolverModule = await import('../lib/billing.resolveStaticContent.js');
+  return { Component, useBillingStore: storeModule.useBillingStore, resolveStaticContent: resolverModule.resolveStaticContent };
+}
+
+/**
  * Mount the upgrade prompt component with Vuetify and Pinia installed.
  * @param {Object} props Component props.
  * @param {Object} [quotaData] Quota data to set on the store.
@@ -219,12 +240,8 @@ describe('BillingUpgradePrompt', () => {
       // consumer whose OWN static content legitimately contains "growth"/"boost" must never
       // make this assertion spuriously fail. Isolated the same way core.appSpinner's default-
       // rendering contract is (mock the config service, not a consumer value, rule 2).
-      vi.resetModules();
-      vi.doMock('../../../lib/services/config.js', () => ({ default: { billing: { staticContent: {} } } }));
       try {
-        const { default: Component } = await import('../components/billing.upgradePrompt.component.vue');
-        const { useBillingStore: useIsolatedBillingStore } = await import('../stores/billing.store.js');
-        const { resolveStaticContent: resolveIsolated } = await import('../lib/billing.resolveStaticContent.js');
+        const { Component, useBillingStore: useIsolatedBillingStore, resolveStaticContent: resolveIsolated } = await loadWithConfig({});
 
         setActivePinia(createPinia());
         const store = useIsolatedBillingStore();
@@ -267,23 +284,6 @@ describe('BillingUpgradePrompt', () => {
       vi.doUnmock('../../../lib/services/config.js');
       vi.resetModules();
     });
-
-    /**
-     * Dynamically re-import the resolver + component after mocking the underlying
-     * config service, so the module-scope `resolveStaticContent()` call picks up the
-     * per-test override. Mirrors the pattern in billing.resolveStaticContent.unit.tests.js.
-     * @param {Object} staticContent - Value to install at config.billing.staticContent.
-     * @returns {Promise<{Component: Object, useBillingStore: Function}>}
-     */
-    async function loadWithConfig(staticContent) {
-      vi.resetModules();
-      vi.doMock('../../../lib/services/config.js', () => ({
-        default: { billing: { staticContent } },
-      }));
-      const { default: Component } = await import('../components/billing.upgradePrompt.component.vue');
-      const storeModule = await import('../stores/billing.store.js');
-      return { Component, useBillingStore: storeModule.useBillingStore };
-    }
 
     it('renders copy DRIVEN by the resolved static content — changing config changes the rendered copy', async () => {
       const { Component, useBillingStore: useStore } = await loadWithConfig({

--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createVuetify } from 'vuetify';
 import { useBillingStore } from '../stores/billing.store';
+import { resolveStaticContent } from '../lib/billing.resolveStaticContent.js';
 import BillingUpgradePrompt from '../components/billing.upgradePrompt.component.vue';
 
 const vuetify = createVuetify();
@@ -218,12 +219,15 @@ describe('BillingUpgradePrompt', () => {
         extrasLedger: { entries: [{ source: 'signup_grant', amount: 500 }], total: 1, page: 1, limit: 20 },
       });
       const text = wrapper.text();
-      // Devkit generic default — numberless grant label, generic pack/plan names sourced
-      // from billing.static-content.js, not any real consumer's economics. (The rendered
+      // Read the expected grant label from the loaded/generated config (the same
+      // resolveStaticContent() source the component itself reads) instead of asserting
+      // a hardcoded devkit-default literal — this stays true whether this suite runs
+      // against the bare stack or a consumer's own generated config. (The rendered
       // "$9.00" is the devkit's OWN generic demo pack price — same placeholder used
       // module-wide, e.g. billing.subscriptions.component.vue — not a leaked literal;
       // the component source itself no longer hardcodes any price.)
-      expect(text).toMatch(/one-shot compute grant/i);
+      const { signupGrant } = resolveStaticContent();
+      expect(text.toLowerCase()).toContain(signupGrant.label.toLowerCase());
       expect(text).not.toMatch(/\bboost\b/i);
       expect(text).not.toMatch(/\bgrowth\b/i);
       expect(text).not.toContain('500 compute');

--- a/src/modules/core/components/tests/core.appSpinner.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.appSpinner.component.unit.tests.js
@@ -1,32 +1,25 @@
-import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
+
+// The default/fallback contract certified by this file must hold regardless of
+// whatever `ui.loader.component` the REAL generated config resolves to for
+// whoever runs this suite (bare stack today, a consumer's own build tomorrow).
+// Isolate natively by mocking the config service to an empty loader — hoisted
+// above the import below, so `resolveLoaderComponent`'s module-scope wiring
+// (`configuredLoaderPath` / `resolvedLoader`) always sees `null` here — a
+// consumer inheriting this file needs no local copy of this isolation.
+vi.mock('../../../../lib/services/config.js', () => ({ default: { ui: { loader: { component: null } } } }));
+
+import CoreAppSpinner, { resolveLoaderComponent } from '../core.appSpinner.component.vue';
 
 /**
  * Vuetify instance with all components registered for component mount.
  * @returns {import('vuetify').Vuetify}
  */
 const makeVuetify = () => createVuetify({ components, directives });
-
-// The default/fallback contract certified by this file must hold regardless of
-// whatever `ui.loader.component` the REAL generated config resolves to for
-// whoever runs this suite (bare stack today, a consumer's own build tomorrow).
-// Isolate natively by mocking the config service to an empty loader BEFORE
-// importing the component, so `resolveLoaderComponent`'s module-scope wiring
-// (`configuredLoaderPath` / `resolvedLoader`) always sees `null` here — a
-// consumer inheriting this file needs no local copy of this isolation.
-let CoreAppSpinner;
-let resolveLoaderComponent;
-
-beforeAll(async () => {
-  vi.resetModules();
-  vi.doMock('../../../../lib/services/config.js', () => ({ default: { ui: { loader: { component: null } } } }));
-  const mod = await import('../core.appSpinner.component.vue');
-  CoreAppSpinner = mod.default;
-  resolveLoaderComponent = mod.resolveLoaderComponent;
-});
 
 /**
  * Mount CoreAppSpinner with sensible defaults; callers override via opts.

--- a/src/modules/core/components/tests/core.appSpinner.component.unit.tests.js
+++ b/src/modules/core/components/tests/core.appSpinner.component.unit.tests.js
@@ -1,15 +1,32 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
-import CoreAppSpinner, { resolveLoaderComponent } from '../core.appSpinner.component.vue';
 
 /**
  * Vuetify instance with all components registered for component mount.
  * @returns {import('vuetify').Vuetify}
  */
 const makeVuetify = () => createVuetify({ components, directives });
+
+// The default/fallback contract certified by this file must hold regardless of
+// whatever `ui.loader.component` the REAL generated config resolves to for
+// whoever runs this suite (bare stack today, a consumer's own build tomorrow).
+// Isolate natively by mocking the config service to an empty loader BEFORE
+// importing the component, so `resolveLoaderComponent`'s module-scope wiring
+// (`configuredLoaderPath` / `resolvedLoader`) always sees `null` here — a
+// consumer inheriting this file needs no local copy of this isolation.
+let CoreAppSpinner;
+let resolveLoaderComponent;
+
+beforeAll(async () => {
+  vi.resetModules();
+  vi.doMock('../../../../lib/services/config.js', () => ({ default: { ui: { loader: { component: null } } } }));
+  const mod = await import('../core.appSpinner.component.vue');
+  CoreAppSpinner = mod.default;
+  resolveLoaderComponent = mod.resolveLoaderComponent;
+});
 
 /**
  * Mount CoreAppSpinner with sensible defaults; callers override via opts.
@@ -25,7 +42,7 @@ const mountIt = (opts = {}) =>
     },
   });
 
-describe('CoreAppSpinner — default rendering (config unset)', () => {
+describe('CoreAppSpinner — default rendering (isolated from any configured loader)', () => {
   it('renders the built-in v-progress-circular with indeterminate=true', () => {
     const wrapper = mountIt();
     const spinner = wrapper.findComponent({ name: 'VProgressCircular' });
@@ -34,7 +51,7 @@ describe('CoreAppSpinner — default rendering (config unset)', () => {
   });
 });
 
-describe('CoreAppSpinner — attribute fallthrough', () => {
+describe('CoreAppSpinner — attribute fallthrough (isolated from any configured loader)', () => {
   it('forwards color/size/data-test to the rendered root (single-root branches, no declared visual props)', () => {
     const wrapper = mountIt({ attrs: { color: 'primary', size: '48', 'data-test': 'x' } });
     const spinner = wrapper.findComponent({ name: 'VProgressCircular' });

--- a/src/modules/organizations/tests/organizations.join.e2e.tests.js
+++ b/src/modules/organizations/tests/organizations.join.e2e.tests.js
@@ -1,6 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { signin, signupViaAPI } from '../../../lib/helpers/e2e/auth.js';
-import { authenticatedContext, createOrgViaAPI } from '../../../lib/helpers/e2e/api.js';
+import {
+  authenticatedContext,
+  createOrgViaAPI,
+  isApiAvailable,
+  errorMessage,
+  CONNECTIVITY_ERROR_RE,
+} from '../../../lib/helpers/e2e/api.js';
 
 const timestamp = Date.now();
 const ownerEmail = `e2e-jowner-${timestamp}@join${timestamp}.com`;
@@ -12,13 +18,30 @@ let orgId;
 test.describe('Organization Join Request E2E', () => {
   test.describe.configure({ mode: 'serial' });
 
+  // The API origin is read from the shared e2e config helper (via authenticatedContext /
+  // createOrgViaAPI / signupViaAPI, all sourced from API_URL) — never hardcoded here.
+  // The live-backend prerequisite is explicit: check it, and skip (not fail) when absent,
+  // matching organizations.domainJoin.e2e.tests.js's established pattern.
   test('setup: create owner with org, and requester', async ({ playwright, request }) => {
-    const ownerRes = await signupViaAPI(request, {
-      email: ownerEmail,
-      password,
-      firstName: 'JoinOwner',
-      lastName: 'Test',
-    });
+    const apiUp = await isApiAvailable(request);
+    test.skip(!apiUp, 'Node API backend not running');
+
+    let ownerRes;
+    try {
+      ownerRes = await signupViaAPI(request, {
+        email: ownerEmail,
+        password,
+        firstName: 'JoinOwner',
+        lastName: 'Test',
+      });
+    } catch (err) {
+      const msg = errorMessage(err);
+      if (CONNECTIVITY_ERROR_RE.test(msg)) {
+        test.skip(true, `API connection failed during signup: ${msg}`);
+        return;
+      }
+      throw err;
+    }
     expect(ownerRes.user).toBeTruthy();
 
     // Owner creates an org so they have one to manage
@@ -39,6 +62,7 @@ test.describe('Organization Join Request E2E', () => {
   });
 
   test('requester signs in successfully', async ({ page }) => {
+    test.skip(!orgId, 'Setup was skipped — no org created');
     await signin(page, requesterEmail, password);
     await page.waitForLoadState('domcontentloaded');
     // Basic sanity — page loaded without error
@@ -46,6 +70,7 @@ test.describe('Organization Join Request E2E', () => {
   });
 
   test('owner can navigate to org detail', async ({ page }) => {
+    test.skip(!orgId, 'Setup was skipped — no org created');
     await signin(page, ownerEmail, password);
     await page.goto(`/users/organizations/${orgId}`);
 

--- a/src/modules/organizations/tests/organizations.join.e2e.tests.js
+++ b/src/modules/organizations/tests/organizations.join.e2e.tests.js
@@ -18,10 +18,15 @@ let orgId;
 test.describe('Organization Join Request E2E', () => {
   test.describe.configure({ mode: 'serial' });
 
-  // The API origin is read from the shared e2e config helper (via authenticatedContext /
-  // createOrgViaAPI / signupViaAPI, all sourced from API_URL) — never hardcoded here.
-  // The live-backend prerequisite is explicit: check it, and skip (not fail) when absent,
-  // matching organizations.domainJoin.e2e.tests.js's established pattern.
+  /**
+   * @desc Sign up an owner + requester via API and have the owner create an org. The API
+   * origin is read from the shared e2e config helper (via authenticatedContext /
+   * createOrgViaAPI / signupViaAPI, all sourced from API_URL) — never hardcoded here.
+   * The live-backend prerequisite is explicit: check it, and skip (not fail) when absent,
+   * matching organizations.domainJoin.e2e.tests.js's established pattern.
+   * @param {{ playwright: import('playwright').Playwright, request: import('@playwright/test').APIRequestContext }} fixtures
+   * @returns {Promise<void>}
+   */
   test('setup: create owner with org, and requester', async ({ playwright, request }) => {
     const apiUp = await isApiAvailable(request);
     test.skip(!apiUp, 'Node API backend not running');

--- a/src/modules/organizations/tests/organizations.lifecycle.e2e.tests.js
+++ b/src/modules/organizations/tests/organizations.lifecycle.e2e.tests.js
@@ -15,6 +15,12 @@ const password = 'E2eTestPass99xyz';
 let orgId;
 let setupOk = false;
 
+/**
+ * @desc End-to-end suite covering the organization lifecycle: owner signup, org creation,
+ * and viewing the org detail page — each step skips gracefully (never hard-fails) when the
+ * live Node API backend prerequisite isn't met.
+ * @returns {void}
+ */
 test.describe('Organization Lifecycle E2E', () => {
   test.describe.configure({ mode: 'serial' });
 

--- a/src/modules/organizations/tests/organizations.lifecycle.e2e.tests.js
+++ b/src/modules/organizations/tests/organizations.lifecycle.e2e.tests.js
@@ -1,29 +1,53 @@
 import { test, expect } from '@playwright/test';
 import { signin, signupViaAPI } from '../../../lib/helpers/e2e/auth.js';
-import { authenticatedContext, createOrgViaAPI } from '../../../lib/helpers/e2e/api.js';
+import {
+  authenticatedContext,
+  createOrgViaAPI,
+  isApiAvailable,
+  errorMessage,
+  CONNECTIVITY_ERROR_RE,
+} from '../../../lib/helpers/e2e/api.js';
 
 const timestamp = Date.now();
 const ownerEmail = `e2e-owner-${timestamp}@lifecycle${timestamp}.com`;
 const password = 'E2eTestPass99xyz';
 
 let orgId;
+let setupOk = false;
 
 test.describe('Organization Lifecycle E2E', () => {
   test.describe.configure({ mode: 'serial' });
 
   /**
-   * @desc Sign up the owner user via API helper.
+   * @desc Sign up the owner user via API helper. The API origin is read from the
+   * shared e2e config helper (via signupViaAPI → API_URL) — never hardcoded here.
+   * The live-backend prerequisite is explicit: check it, and skip (not fail) when
+   * absent, matching organizations.domainJoin.e2e.tests.js's established pattern.
    * @param {{ request: import('playwright').APIRequestContext }} fixtures
    * @returns {Promise<void>}
    */
   test('owner signs up via API', async ({ request }) => {
-    const res = await signupViaAPI(request, {
-      email: ownerEmail,
-      password,
-      firstName: 'Owner',
-      lastName: 'Test',
-    });
+    const apiUp = await isApiAvailable(request);
+    test.skip(!apiUp, 'Node API backend not running');
+
+    let res;
+    try {
+      res = await signupViaAPI(request, {
+        email: ownerEmail,
+        password,
+        firstName: 'Owner',
+        lastName: 'Test',
+      });
+    } catch (err) {
+      const msg = errorMessage(err);
+      if (CONNECTIVITY_ERROR_RE.test(msg)) {
+        test.skip(true, `API connection failed during signup: ${msg}`);
+        return;
+      }
+      throw err;
+    }
     expect(res.user).toBeTruthy();
+    setupOk = true;
   });
 
   /**
@@ -32,6 +56,7 @@ test.describe('Organization Lifecycle E2E', () => {
    * @returns {Promise<void>}
    */
   test('owner creates a new org', async ({ playwright }) => {
+    test.skip(!setupOk, 'Setup was skipped — owner signup did not complete');
     const ctx = await authenticatedContext(playwright, ownerEmail, password);
     const org = await createOrgViaAPI(ctx, `LifecycleOrg${timestamp}`);
     expect(org).toBeTruthy();
@@ -46,6 +71,7 @@ test.describe('Organization Lifecycle E2E', () => {
    * @returns {Promise<void>}
    */
   test('owner can view org detail via manage', async ({ page }) => {
+    test.skip(!orgId, 'Setup was skipped — no org created');
     await signin(page, ownerEmail, password);
     await page.goto(`/users/organizations/${orgId}`);
 


### PR DESCRIPTION
## Summary

Applies the epic's 4 test-homogeneity rules (never assert a hardcoded default, isolate extension points generically, make env prerequisites explicit, keep project-specific tests project-owned) to the last batch of stack test files a downstream consumer currently has to patch locally after every merge:

- `app.store` — route-meta fixture now covers both `roles`-based and `action`/`subject`-based meta shapes.
- `auth.token.view` — loading-state assertions target the `AppSpinner` wrapper (stable component-name hook) instead of the default spinner's DOM class, with a polling-tolerant `vi.waitFor` and a new describe block simulating a consumer-swapped loader component.
- `billing.upgradePrompt` — the default-copy leak-guard test reads the expected grant label from `resolveStaticContent()` instead of a hardcoded literal.
- `core.appSpinner` — the default/fallback contract natively isolates itself from any configured `ui.loader.component` (config service mocked to `null`, hoisted above the import), so a consumer inheriting this file needs no local copy of that isolation.
- `organizations.join`/`organizations.lifecycle` e2e — adds an explicit live-backend prerequisite check (shared `isApiAvailable`/`errorMessage`/`CONNECTIVITY_ERROR_RE`, extracted into the shared e2e API helper) with a graceful skip, matching the established `organizations.domainJoin` pattern. The API origin was already sourced via the shared e2e config helper in both files — no hardcoded origin found.

Test-only diff — no production code changed. `refactor(simplify)` follow-up commit swaps a hand-rolled polling helper for vitest's built-in `vi.waitFor` (already used elsewhere in this repo) and a `beforeAll`+dynamic-import isolation for a simpler hoisted `vi.mock` + static import.

## Test plan

**Bare stack** — `npm run test:unit` (full suite, unmodified generated config):
```
Test Files  153 passed (153)
     Tests  2596 passed (2596)
```
The 4 fixed unit files alone: `Test Files 4 passed (4)` / `Tests 57 passed (57)`.

**Synthetic consumer profile** — the tests that exercise a config profile different from the file's own baseline (route-meta shape coverage, native config-isolation, static-content-driven assertions, the consumer-swapped-loader describe block, the isolated leak-guard test), isolated via `vitest -t`:
```
Test Files  4 passed (4)
     Tests  10 passed | 47 skipped (57)
```

**E2E** (`organizations.join`/`organizations.lifecycle`, no live backend in this environment — standard test scripts only, no private infra stood up): both files skip gracefully via the new prerequisite guard instead of hard-failing:
```
6 skipped
```

- [x] `npm run lint` — clean
- [x] `npm run test:coverage` — 2596/2596 passed, thresholds hold (99.07% stmts / 92.67% branch / 98.78% funcs / 99.68% lines)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` (join + lifecycle, scoped) — graceful skip, no hang, no failure

Closes #4545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability when backend services are unavailable or connectivity is interrupted.
  * Added coverage for authentication loading and error states.
  * Expanded route initialization coverage to preserve different permission metadata formats.
  * Strengthened billing and application loading tests across varied configurations.
* **Chores**
  * Added shared connectivity detection and clearer error handling for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->