### PR TITLE
test(e2e): adopt shared connectivity helpers in domainJoin + fix doctrine citation

### DIFF
--- a/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.upgradePrompt.component.unit.tests.js
@@ -247,7 +247,8 @@ describe('BillingUpgradePrompt', () => {
       // ambient generated config (bare stack today, a consumer's own build tomorrow) — a
       // consumer whose OWN static content legitimately contains "growth"/"boost" must never
       // make this assertion spuriously fail. Isolated the same way core.appSpinner's default-
-      // rendering contract is (mock the config service, not a consumer value, rule 2).
+      // rendering contract is (mock the config service, not a consumer value — a rule-1
+      // default-certification exception, not rule-2 extension-point/hook-registry mocking).
       try {
         const { Component, useBillingStore: useIsolatedBillingStore, resolveStaticContent: resolveIsolated } = await loadWithConfig({});
 

--- a/src/modules/organizations/tests/organizations.domainJoin.e2e.tests.js
+++ b/src/modules/organizations/tests/organizations.domainJoin.e2e.tests.js
@@ -1,27 +1,14 @@
 import { test, expect } from '@playwright/test';
 import { signin, signupViaAPI } from '../../../lib/helpers/e2e/auth.js';
-import { authenticatedContext, createOrgViaAPI, API } from '../../../lib/helpers/e2e/api.js';
-import { API_URL, COOKIE_PREFIX } from '../../../lib/helpers/e2e/config.js';
-
-/**
- * @desc Patterns that identify a backend-unreachable / transport-level failure.
- * Used to scope `test.skip` so real backend regressions (4xx/5xx, schema drift,
- * etc.) surface as failures instead of silent skips.
- * @type {RegExp}
- */
-const CONNECTIVITY_ERROR_RE = /ECONNREFUSED|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|fetch failed|socket hang up|network error/i;
-
-/**
- * @desc Safely extract a string message from an unknown thrown value.
- * Avoids crashing when something throws `null` / `undefined` / a non-Error.
- * @param {unknown} err
- * @returns {string}
- */
-function errorMessage(err) {
-  if (err instanceof Error) return err.message;
-  if (err == null) return String(err);
-  return typeof err === 'string' ? err : String(err);
-}
+import {
+  authenticatedContext,
+  createOrgViaAPI,
+  API,
+  isApiAvailable,
+  errorMessage,
+  CONNECTIVITY_ERROR_RE,
+} from '../../../lib/helpers/e2e/api.js';
+import { COOKIE_PREFIX } from '../../../lib/helpers/e2e/config.js';
 
 const timestamp = Date.now();
 const domain = `domain${timestamp}.com`;
@@ -30,26 +17,6 @@ const memberEmail = `e2e-djmember-${timestamp}@${domain}`;
 const password = 'E2eTestPass99xyz';
 
 let orgId;
-
-/**
- * @desc Check whether the Node API backend is reachable at the transport level.
- * Reachability = a response came back at all (any HTTP status). A 4xx/5xx means
- * the backend IS running and answered — so we should NOT skip the suite; we
- * should let the test exercise the real code path. Only network/connection
- * errors (request.get throws) indicate the backend is genuinely unreachable.
- * @param {import('@playwright/test').APIRequestContext} request
- * @returns {Promise<boolean>}
- */
-async function isApiAvailable(request) {
-  try {
-    // Use the fully-configured API URL (honors api.protocol/host/port/base) so
-    // we don't false-negative on projects that customize `config.api.base`.
-    await request.get(API_URL);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * @desc Predicate for `page.waitForURL` — true once the SPA has left the auth /


### PR DESCRIPTION
## Summary

- What changed:
  - `organizations.domainJoin.e2e.tests.js` now imports `CONNECTIVITY_ERROR_RE`,
    `errorMessage`, and `isApiAvailable` from the shared
    `src/lib/helpers/e2e/api.js` helper instead of keeping its own local copies.
  - Corrected a doctrine-citation comment in
    `billing.upgradePrompt.component.unit.tests.js`.
- Why:
  - `organizations.domainJoin.e2e.tests.js` originated the connectivity-check
    pattern, but a prior refactor extracted it into a shared helper and
    migrated the sibling suites (`organizations.join`,
    `organizations.lifecycle`) — domainJoin itself was missed. It kept a
    narrower `CONNECTIVITY_ERROR_RE` (missing `ECONNRESET`/`EPIPE`) and a
    local `isApiAvailable` without the shared version's diagnostic
    `console.warn`. Net effect: an `ECONNRESET`/`EPIPE` mid-request hard-fails
    domainJoin while the sibling suites gracefully skip on the identical
    backend-reachability prerequisite.
  - The billing unit test comment cited "rule 2" for the bare-default-
    certification isolation technique (forcing config empty to pin the
    devkit's own hardcoded default). That technique is actually a rule-1
    exception (default-certification pins the literal); rule 2 covers
    extension-point/hook-registry mocking, a different technique entirely.
    Comment-only correction, no behavior change.
- Related issues: none — audit finding from a plan-level review pass, not
  tied to a tracked issue.

## Scope

- Modules impacted: `organizations` (e2e tests), `billing` (unit test comment)
- Cross-module impact: `none`
- Risk level: `low` — one file drops local duplicate code in favor of an
  already-adopted shared helper (same contract, strictly broader/safer
  behavior); the other is a comment-only fix.

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` (154 files / 2602 tests passed,
      `NODE_OPTIONS=--max-old-space-size=4096`)
- [ ] `npm run build`
- [x] Manual checks done: `npx playwright test ... --list` confirms the
      migrated e2e file still parses/collects (9 tests found); running it
      with no backend confirms the skip path works end-to-end (9 skipped,
      0 failed), and the shared helper's diagnostic `console.warn` now fires
      (visible proof the import swap is live). CI's real-backend E2E job is
      the runtime proof beyond that.

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed (test-only diff; no
      production code touched)

## Optional: Infra/Stack alignment details

### Before vs After (key changes only)

| Area | Before | After | Notes |
| ---- | ------ | ----- | ----- |
| `organizations.domainJoin.e2e.tests.js` | Local `CONNECTIVITY_ERROR_RE` / `errorMessage` / `isApiAvailable` (narrower regex, no diagnostic log) | Imports the shared versions from `src/lib/helpers/e2e/api.js`, matching `organizations.join.e2e.tests.js`'s import style | No test-logic or call-site changes — only the connectivity-check source |
| `src/lib/helpers/e2e/api.js` | 3 importers (`organizations.join`, `organizations.lifecycle`, `billing.e2e`) | 4 importers (+ `organizations.domainJoin`) | No exported-signature change |
| `billing.upgradePrompt.component.unit.tests.js` | Comment mislabeled the isolation technique as "rule 2" | Comment corrected to "rule-1 default-certification exception, not rule-2 extension-point/hook-registry mocking" | Comment-only, zero behavior change |

Deterministic blast-radius (codemap 1-hop): 1 dependent
(`src/modules/auth/components/pendingRequestBanner.component.vue`, via the
pre-existing billing.upgradePrompt component relationship), same-repo, no
cross-repo impact, no wide blast radius flag.

- Upstream parity target / source: n/a (this repo IS the devkit upstream)
- Automation or policy impact (CI, Dependabot, auto-merge, majors, permissions): none
- Rollback plan: revert this PR — no data/schema/config changes

## Notes for reviewers

- Security considerations: none — test-file-only diff, no production code path touched
- Mergeability considerations: none, isolated to two test files
- Follow-up tasks (optional): none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified test documentation around default rendering behavior.
  * Improved connectivity handling in organization domain-join tests by using shared API utilities.
  * Removed duplicated local connectivity-checking and error-handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->