### PR TITLE
fix(billing): compute gauge and weekly meter go quota-only, matching quota-threshold alerts

### DIFF
--- a/src/modules/billing/components/billing.navComputeGauge.component.vue
+++ b/src/modules/billing/components/billing.navComputeGauge.component.vue
@@ -23,7 +23,7 @@
       <v-list-item
         v-bind="tooltipProps"
         :to="'/users/billing'"
-        :aria-label="isAdmin ? 'Compute usage: unlimited (admin)' : `Compute usage: ${usageMeter ? pctUsed + '% used' : '—'}`"
+        :aria-label="isAdmin ? 'Compute usage: unlimited (admin)' : `Compute usage: ${usageMeter ? pctUsed + '% of quota' : '—'}`"
         aria-haspopup="true"
         :aria-expanded="tooltipOpen ? 'true' : 'false'"
         @touchstart.passive="onTouchActivate"
@@ -46,7 +46,7 @@
         <v-list-item-title v-if="isAdmin">
           <span class="admin-rainbow admin-rainbow--text" aria-hidden="true">∞</span>
         </v-list-item-title>
-        <v-list-item-title v-else>{{ usageMeter ? `${pctUsed}% used` : '—' }}</v-list-item-title>
+        <v-list-item-title v-else>{{ usageMeter ? `${pctUsed}% of quota` : '—' }}</v-list-item-title>
       </v-list-item>
     </template>
     <div v-if="isAdmin">Admin — unlimited compute</div>
@@ -65,6 +65,7 @@
 <script>
 import { useBillingStore } from '../stores/billing.store.js';
 import { useAuthStore } from '../../auth/stores/auth.store.js';
+import { useMeter } from '../composables/billing.useMeter';
 import BillingEquivalencesChipsComponent from './billing.equivalencesChips.component.vue';
 
 export default {
@@ -72,10 +73,22 @@ export default {
 
   components: { BillingEquivalencesChipsComponent },
 
+  /**
+   * @desc Wires billingStore + authStore + useMeter's quota-only `progress`.
+   * pollIntervalMs: 0 disables the composable's own polling interval; refreshOnFocus:
+   * false skips its document-visibilitychange listener too — the mounted()/
+   * beforeUnmount() window-focus listener below already covers "refresh when the
+   * user returns to this tab", so enabling both would just be a second mechanism
+   * doing the same job. fetchMissingMeterData still runs immediately during
+   * composable creation to populate initial meter state, which supersedes this
+   * component's own former mount-time fetch (removed from mounted() below).
+   * @returns {Object}
+   */
   setup() {
     const billingStore = useBillingStore();
     const authStore = useAuthStore();
-    return { billingStore, authStore };
+    const { progress: meterProgress } = useMeter({ pollIntervalMs: 0, refreshOnFocus: false });
+    return { billingStore, authStore, meterProgress };
   },
 
   data() {
@@ -130,9 +143,17 @@ export default {
       return meterQuota + extrasRemaining;
     },
 
+    /**
+     * @desc Percentage of the included weekly quota consumed — quota-only, matching
+     * the server's threshold-alert formula exactly (useMeter's `progress`). Deliberately
+     * NOT based on totalQuota (quota + extras): mixing an extras-inclusive denominator
+     * into this figure is what let the gauge sit green while the server was alerting
+     * at 80%/100% on the same account. totalQuota stays for totalRemaining/totalDisplay/
+     * equivalenceChips, which legitimately describe extras-inclusive capacity.
+     * @returns {number}
+     */
     pctUsed() {
-      if (this.totalQuota <= 0) return 0;
-      return Math.max(0, Math.min(100, Math.round((this.meterUsed / this.totalQuota) * 100)));
+      return this.meterProgress;
     },
 
     /**
@@ -226,7 +247,9 @@ export default {
   },
 
   mounted() {
-    this.billingStore.fetchUsageMeter();
+    // Initial fetch is now owned by useMeter() in setup() (fetchMissingMeterData
+    // runs during composable creation, before this hook) — calling it again here
+    // would double the mount-time request.
     this._onFocus = () => this.billingStore.fetchUsageMeter();
     window.addEventListener('focus', this._onFocus);
   },

--- a/src/modules/billing/components/billing.navComputeGauge.component.vue
+++ b/src/modules/billing/components/billing.navComputeGauge.component.vue
@@ -74,7 +74,14 @@ export default {
   components: { BillingEquivalencesChipsComponent },
 
   /**
-   * @desc Wires billingStore + authStore + useMeter's quota-only `progress`.
+   * @desc Wires billingStore + authStore + useMeter's quota-only `progress`, exposed
+   * directly as `pctUsed` (matches the server's threshold-alert formula exactly —
+   * see the computed docblock removed from here, kept as this comment). Deliberately
+   * NOT based on totalQuota (quota + extras): mixing an extras-inclusive denominator
+   * into this figure is what let the gauge sit green while the server was alerting
+   * at 80%/100% on the same account. totalQuota (computed below) stays for
+   * totalRemaining/totalDisplay/equivalenceChips, which legitimately describe
+   * extras-inclusive capacity.
    * pollIntervalMs: 0 disables the composable's own polling interval; refreshOnFocus:
    * false skips its document-visibilitychange listener too — the mounted()/
    * beforeUnmount() window-focus listener below already covers "refresh when the
@@ -87,8 +94,8 @@ export default {
   setup() {
     const billingStore = useBillingStore();
     const authStore = useAuthStore();
-    const { progress: meterProgress } = useMeter({ pollIntervalMs: 0, refreshOnFocus: false });
-    return { billingStore, authStore, meterProgress };
+    const { progress: pctUsed } = useMeter({ pollIntervalMs: 0, refreshOnFocus: false });
+    return { billingStore, authStore, pctUsed };
   },
 
   data() {
@@ -141,19 +148,6 @@ export default {
       if (!this.usageMeter) return 0;
       const { meterQuota = 0, extrasRemaining = 0 } = this.usageMeter;
       return meterQuota + extrasRemaining;
-    },
-
-    /**
-     * @desc Percentage of the included weekly quota consumed — quota-only, matching
-     * the server's threshold-alert formula exactly (useMeter's `progress`). Deliberately
-     * NOT based on totalQuota (quota + extras): mixing an extras-inclusive denominator
-     * into this figure is what let the gauge sit green while the server was alerting
-     * at 80%/100% on the same account. totalQuota stays for totalRemaining/totalDisplay/
-     * equivalenceChips, which legitimately describe extras-inclusive capacity.
-     * @returns {number}
-     */
-    pctUsed() {
-      return this.meterProgress;
     },
 
     /**

--- a/src/modules/billing/components/billing.navComputeGauge.component.vue
+++ b/src/modules/billing/components/billing.navComputeGauge.component.vue
@@ -240,10 +240,14 @@ export default {
     },
   },
 
+  /**
+   * @desc Installs a window-focus listener that re-fetches the usage meter when the
+   * user returns to this tab. The initial fetch itself is now owned by useMeter() in
+   * setup() (fetchMissingMeterData runs during composable creation, before this hook)
+   * — calling it again here would double the mount-time request.
+   * @returns {void}
+   */
   mounted() {
-    // Initial fetch is now owned by useMeter() in setup() (fetchMissingMeterData
-    // runs during composable creation, before this hook) — calling it again here
-    // would double the mount-time request.
     this._onFocus = () => this.billingStore.fetchUsageMeter();
     window.addEventListener('focus', this._onFocus);
   },

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -211,10 +211,10 @@
               <p class="text-title-medium font-weight-medium mb-2">Weekly meter</p>
               <BillingMeterProgressComponent
                 :used="meterUsed"
-                :quota="combinedPool"
-                :extras="0"
-                :overage="0"
-                :net-remaining-raw="combinedPool - meterUsed"
+                :quota="meterQuota"
+                :extras="meterExtras"
+                :overage="meterQuota > 0 ? meterOverage : 0"
+                :net-remaining-raw="meterNetRemainingRaw"
                 label=""
               />
             </v-card>
@@ -394,15 +394,6 @@ export default {
     };
   },
   computed: {
-    /**
-     * @desc Combined compute pool = subscription quota + extras + already-used.
-     * Used as denominator for "Weekly compute" % so Free plan (quota=0) doesn't
-     * false-alarm 100% red. Matches the sidenav gauge formula.
-     * @returns {number}
-     */
-    combinedPool() {
-      return this.meterQuota + this.meterExtras + this.meterUsed;
-    },
     fetchLoading() {
       return this.billingStore.loading;
     },

--- a/src/modules/billing/tests/billing.navComputeGauge.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.navComputeGauge.component.unit.tests.js
@@ -89,17 +89,16 @@ describe('BillingNavComputeGaugeComponent', () => {
     expect(wrapper.findComponent({ name: 'VProgressLinear' }).exists()).toBe(false);
   });
 
-  it('shows "X% used" in v-list-item-title when usageMeter is available', () => {
+  it('shows "X% of quota" in v-list-item-title when usageMeter is available', () => {
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
     authStore.cookieExpire = Date.now() + 86400000;
     authStore.serverConfig = { billing: { meterMode: true } };
-    // totalQuota = meterQuota + extrasRemaining = 1600 + 0 = 1600
-    // pctUsed = meterUsed / totalQuota = 800 / 1600 = 50%
+    // pctUsed = meterUsed / meterQuota (quota-only) = 800 / 1600 = 50%
     billingStore.usageMeter = { meterUsed: 800, meterQuota: 1600, extrasRemaining: 0, weekResetAt: null };
 
     wrapper = mountComponent();
-    expect(wrapper.text()).toContain('50% used');
+    expect(wrapper.text()).toContain('50% of quota');
   });
 
   it('shows "—" in v-list-item-title when usageMeter is null', () => {
@@ -111,21 +110,21 @@ describe('BillingNavComputeGaugeComponent', () => {
     expect(wrapper.text()).toContain('—');
   });
 
-  // ── pctUsed formula: meterUsed / (meterQuota + extrasRemaining) ──────────
+  // ── pctUsed formula: quota-only (meterUsed / meterQuota), matches server ──
 
-  it('computes pctUsed = meterUsed / (meterQuota + extrasRemaining)', () => {
+  it('computes pctUsed = meterUsed / meterQuota (quota-only, ignores extrasRemaining)', () => {
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
     authStore.cookieExpire = Date.now() + 86400000;
     authStore.serverConfig = { billing: { meterMode: true } };
-    // totalQuota = 1600 + 400 = 2000, pct = 800 / 2000 = 40%
+    // quota-only: pct = 800 / 1600 = 50% (previously blended with extrasRemaining → 40%)
     billingStore.usageMeter = { meterUsed: 800, meterQuota: 1600, extrasRemaining: 400, weekResetAt: null };
 
     wrapper = mountComponent();
-    expect(wrapper.vm.pctUsed).toBe(40);
+    expect(wrapper.vm.pctUsed).toBe(50);
   });
 
-  it('returns pctUsed=0 when totalQuota=0 (division-by-zero guard)', () => {
+  it('returns pctUsed=0 when meterQuota=0 (division-by-zero guard)', () => {
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
     authStore.cookieExpire = Date.now() + 86400000;
@@ -136,28 +135,42 @@ describe('BillingNavComputeGaugeComponent', () => {
     expect(wrapper.vm.pctUsed).toBe(0);
   });
 
-  it('clamps pctUsed to 100 when meterUsed exceeds totalQuota', () => {
+  it('clamps pctUsed to 100 when meterUsed exceeds meterQuota', () => {
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
     authStore.cookieExpire = Date.now() + 86400000;
     authStore.serverConfig = { billing: { meterMode: true } };
-    // totalQuota = 50 + 0 = 50, meterUsed = 200 → pct = 200/50 = 400% → clamp to 100
+    // meterQuota = 50, meterUsed = 200 → pct = 200/50 = 400% → clamp to 100
     billingStore.usageMeter = { meterUsed: 200, meterQuota: 50, extrasRemaining: 0, weekResetAt: null };
 
     wrapper = mountComponent();
     expect(wrapper.vm.pctUsed).toBe(100);
   });
 
-  it('returns pctUsed=50 for meterUsed=800, meterQuota=1600, extrasRemaining=0', () => {
+  it('returns pctUsed=50 for meterUsed=800, meterQuota=1600, extrasRemaining=0 (no-op proof: extras absent)', () => {
     const authStore = useAuthStore();
     const billingStore = useBillingStore();
     authStore.cookieExpire = Date.now() + 86400000;
     authStore.serverConfig = { billing: { meterMode: true } };
-    // totalQuota = 1600 + 0 = 1600, pct = 800/1600 = 50%
     billingStore.usageMeter = { meterUsed: 800, meterQuota: 1600, extrasRemaining: 0, weekResetAt: null };
 
     wrapper = mountComponent();
     expect(wrapper.vm.pctUsed).toBe(50);
+  });
+
+  it('clamps pctUsed to 100 and iconColor to "error" when quota is exceeded while extras remain (#4548 regression)', () => {
+    const authStore = useAuthStore();
+    const billingStore = useBillingStore();
+    authStore.cookieExpire = Date.now() + 86400000;
+    authStore.serverConfig = { billing: { meterMode: true } };
+    // Reproduces the reported bug: meterQuota 1000, extrasRemaining 5000, meterUsed 1020.
+    // Blended formula rendered 17%; quota-only clamps to 100 and flags error, matching
+    // the server's quota-threshold alert on this same account.
+    billingStore.usageMeter = { meterUsed: 1020, meterQuota: 1000, extrasRemaining: 5000, weekResetAt: null };
+
+    wrapper = mountComponent();
+    expect(wrapper.vm.pctUsed).toBe(100);
+    expect(wrapper.vm.iconColor).toBe('error');
   });
 
   // ── iconColor thresholds (matches billing.computeGauge: 80% / 100%) ──────
@@ -436,11 +449,11 @@ describe('BillingNavComputeGaugeComponent', () => {
       expect(wrapper.vm.isAdmin).toBe(false);
     });
 
-    it('renders ∞ glyph for admin instead of "X% used"', () => {
+    it('renders ∞ glyph for admin instead of "X% of quota"', () => {
       setupAdmin();
       wrapper = mountComponent();
       expect(wrapper.text()).toContain('∞');
-      expect(wrapper.text()).not.toContain('% used');
+      expect(wrapper.text()).not.toContain('% of quota');
       expect(wrapper.text()).not.toContain('—');
     });
 

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -178,12 +178,18 @@ describe('BillingSubscriptionsComponent — meter mode (meterMode: true)', () =>
     expect(wrapper.find('.billing-meter-breakdown-chart').exists()).toBe(true);
   });
 
-  it('renders meter usage values against combinedPool denominator', async () => {
+  it('passes raw meter values as props to BillingMeterProgressComponent (no combinedPool blending)', async () => {
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    // combinedPool = meterQuota(500) + meterExtras(50) + meterUsed(120) = 670
-    // used(120) / combinedPool(670) = ~18%
-    expect(wrapper.text()).toContain('18%');
+    // mockUsageMeterNormal: meterUsed=120, meterQuota=500, extrasRemaining=50
+    const meterProgress = wrapper.findComponent({ name: 'BillingMeterProgressComponent' });
+    expect(meterProgress.props('used')).toBe(120);
+    expect(meterProgress.props('quota')).toBe(500);
+    expect(meterProgress.props('extras')).toBe(50);
+    expect(meterProgress.props('overage')).toBe(0);
+    expect(meterProgress.props('netRemainingRaw')).toBe(430); // 500 - 120 + 50
+    // Quota-only %: 120 / 500 = 24% (previously blended combinedPool denominator gave ~18%)
+    expect(wrapper.text()).toContain('24%');
   });
 
   it('renders "Buy compute extras" CTA in meter mode (T6 redesign: /pricing#units redirect)', async () => {
@@ -853,13 +859,16 @@ describe('BillingSubscriptionsComponent — meterError (centralized snackbar, no
     expect(wrapper.text()).not.toContain('Could not refresh usage');
   });
 
-  it('combinedPool computed equals meterQuota + meterExtras + meterUsed', async () => {
-    // useMeter returns values seeded from billingStore.usageMeter
+  it('gates the overage prop to 0 when meterQuota is 0 (prevents pinned-100%/red bar on quota-0 plans funded by extras)', async () => {
+    // meterQuota: 0 with usage funded entirely from extras — meterOverage = max(0, used - quota)
+    // would be positive from the first action; the template must gate it to 0, since the
+    // server never alerts on quota 0 and the UI must not contradict it.
+    seedMeterStore(store, { ...mockUsageMeterNormal, meterQuota: 0, meterUsed: 30, extrasRemaining: 500 });
     wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: true } } });
     await flushPromises();
-    // mockUsageMeterNormal: meterUsed=120, meterQuota=500, extrasRemaining=50
-    // combinedPool = 500 + 50 + 120 = 670
-    expect(wrapper.vm.combinedPool).toBe(670);
+    const meterProgress = wrapper.findComponent({ name: 'BillingMeterProgressComponent' });
+    expect(meterProgress.props('quota')).toBe(0);
+    expect(meterProgress.props('overage')).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- What changed: the nav compute gauge and the billing subscriptions page's "weekly meter" card now derive their usage percentage from `useMeter()`'s existing quota-only `progress` export, instead of a hand-rolled `quota + extras` blend. The weekly meter card also drops its local `combinedPool` computed and passes the raw meter values straight through, gating `overage` to 0 when quota is 0.
- Why: the server's quota-threshold alert emails compute against `quota` alone. On an account carrying a meaningful extras balance, the two widgets disagreed widely with the server — it could send an 80%/100% warning while both widgets stayed green.
- Related issues: Closes #4548

## Scope

- Modules impacted: `billing` (2 components + their unit tests)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit` (full suite: 154 files / 2603 tests, including coverage gate via `test:unit:coverage`)
- [x] `npm run build`
- [x] Manual checks done (if applicable) — mutation check per issue: reverted the fix locally, confirmed the two targeted tests go red and nothing else, then restored

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects — this is a strict no-op for any deployment with no extras concept (`extrasRemaining` always 0 there), only alters behavior for orgs carrying a nonzero extras balance
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — pure display-formula fix, no new data flow.
- Mergeability considerations: none, single-repo change, no consumer break.
- Follow-up tasks (optional): `billing.usageBar.component.vue` passes `:overage="meterOverage"` into the same shared `BillingMeterProgressComponent` with no quota-0 guard — same latent class of bug, out of scope here since this issue only covers the nav gauge + weekly meter card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated billing usage gauges to clearly show progress as a percentage of quota.
  * Improved usage calculations when quotas are exceeded or set to zero.
  * Usage meters now separately account for quota, extras, overage, and remaining amounts.
  * Refreshed billing displays and accessibility text for clearer usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->