### PR TITLE
fix(billing): render pending cancellation on the subscriptions panel

### DIFF
--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -139,7 +139,7 @@
               </div>
               <div class="d-flex align-center ga-2">
                 <v-icon
-                  :icon="subscriptionStatusIcon"
+                  :icon="displayStatusIcon"
                   size="x-small"
                   :color="displayStatusMeta.color"
                   aria-hidden="true"
@@ -609,12 +609,26 @@ export default {
       return this.subscriptionStatusAction;
     },
     /**
+     * @desc Status icon actually rendered — a clock while a cancellation is pending
+     * (distinct from the success checkmark, which would contradict the "Cancelling"
+     * chip), otherwise the real per-status icon.
+     * @returns {string}
+     */
+    displayStatusIcon() {
+      if (this.isPendingCancellation) return 'fa-solid fa-clock';
+      return this.subscriptionStatusIcon;
+    },
+    /**
      * @desc Line shown under the plan header: the pending-cancellation notice while
      * a cancellation is scheduled, otherwise the next billing date — never both.
+     * Guards against `cancelsOnDate` resolving to null (all three source fields
+     * absent) so the UI never renders the literal string "Cancels on null".
      * @returns {string|null}
      */
     billingDateLine() {
-      if (this.isPendingCancellation) return `Cancels on ${this.cancelsOnDate} — you'll keep access until then`;
+      if (this.isPendingCancellation && this.cancelsOnDate) {
+        return `Cancels on ${this.cancelsOnDate} — you'll keep access until then`;
+      }
       if (this.nextBillingDate) return `Next billing date: ${this.nextBillingDate}`;
       return null;
     },

--- a/src/modules/billing/components/billing.subscriptions.component.vue
+++ b/src/modules/billing/components/billing.subscriptions.component.vue
@@ -141,20 +141,20 @@
                 <v-icon
                   :icon="subscriptionStatusIcon"
                   size="x-small"
-                  :color="subscriptionStatusMeta.color"
+                  :color="displayStatusMeta.color"
                   aria-hidden="true"
                 />
                 <v-chip
-                  :color="subscriptionStatusMeta.color"
+                  :color="displayStatusMeta.color"
                   variant="tonal"
                   size="small"
                   class="text-capitalize"
                 >
-                  {{ subscriptionStatusMeta.label }}
+                  {{ displayStatusMeta.label }}
                 </v-chip>
                 <v-btn
-                  v-if="subscriptionStatusAction"
-                  :color="subscriptionStatusAction.color"
+                  v-if="displayStatusAction"
+                  :color="displayStatusAction.color"
                   variant="tonal"
                   size="small"
                   :class="config.vuetify.theme.rounded"
@@ -162,19 +162,19 @@
                   :loading="portalLoading"
                   @click="manageSubscription"
                 >
-                  {{ subscriptionStatusAction.label }}
+                  {{ displayStatusAction.label }}
                 </v-btn>
               </div>
             </div>
 
-            <!-- Next billing date -->
-            <div v-if="nextBillingDate" class="d-flex align-center ga-2 mb-6 text-body-medium text-medium-emphasis">
+            <!-- Next billing date, or — while a cancellation is pending — the cancellation notice -->
+            <div v-if="billingDateLine" class="d-flex align-center ga-2 mb-6 text-body-medium text-medium-emphasis">
               <v-icon icon="fa-solid fa-calendar" size="x-small" aria-hidden="true" />
-              <span>{{ `Next billing date: ${nextBillingDate}` }}</span>
+              <span>{{ billingDateLine }}</span>
             </div>
 
             <!-- CTAs (portal error surfaced via centralized snackbar — see lib/services/axios.js) -->
-            <div class="d-flex ga-3 flex-wrap" :class="{ 'mt-6': !nextBillingDate }">
+            <div class="d-flex ga-3 flex-wrap" :class="{ 'mt-6': !billingDateLine }">
               <v-btn
                 color="primary"
                 variant="flat"
@@ -305,6 +305,20 @@ import BillingExtrasCheckoutModalComponent from './billing.extrasCheckoutModal.c
 import AppSpinner from '../../core/components/core.appSpinner.component.vue';
 
 const { plans: plansConfig, packs: packsConfig } = resolveStaticContent();
+
+/**
+ * @desc Format a date value as a long-form US date (e.g. "August 5, 2026"), or null when absent.
+ * @param {string|Date|null|undefined} date
+ * @returns {string|null}
+ */
+const formatLongDate = (date) => {
+  if (!date) return null;
+  return new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};
 
 /**
  * Component definition.
@@ -548,13 +562,61 @@ export default {
      * @returns {string|null}
      */
     nextBillingDate() {
-      const date = this.subscription?.currentPeriodEnd;
-      if (!date) return null;
-      return new Date(date).toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      });
+      return formatLongDate(this.subscription?.currentPeriodEnd);
+    },
+    /**
+     * @desc Whether the subscription is active/trialing AND has a cancellation scheduled.
+     * Stripe expresses a customer-portal cancellation as `cancel_at` with
+     * `cancel_at_period_end` sometimes still `false` while the webhook is in flight —
+     * checking either field catches both shapes. Deliberately scoped to
+     * active/trialing so payment-urgency statuses (past_due, unpaid) always keep
+     * their own messaging instead of a combined/competing chip.
+     * @returns {boolean}
+     */
+    isPendingCancellation() {
+      if (!['active', 'trialing'].includes(this.subscriptionStatus)) return false;
+      return !!(this.subscription?.cancelAt || this.subscription?.cancelAtPeriodEnd);
+    },
+    /**
+     * @desc Date the pending cancellation takes effect, formatted for display.
+     * Resolves `cancelAt ?? nextRenewalDate ?? currentPeriodEnd` — never `cancelAt`
+     * alone — because the boolean-only shape (`cancelAtPeriodEnd: true`, `cancelAt`
+     * absent) is reachable while the webhook is in flight; `nextRenewalDate` already
+     * resolves this fallback server-side.
+     * @returns {string|null}
+     */
+    cancelsOnDate() {
+      const date = this.subscription?.cancelAt ?? this.subscription?.nextRenewalDate ?? this.subscription?.currentPeriodEnd;
+      return formatLongDate(date);
+    },
+    /**
+     * @desc Status chip color/label actually rendered — the "Cancelling" warning
+     * state while a cancellation is pending, otherwise the real per-status meta.
+     * Single source of truth so the icon and chip never disagree.
+     * @returns {{ color: string, label: string }}
+     */
+    displayStatusMeta() {
+      if (this.isPendingCancellation) return { color: 'warning', label: 'Cancelling' };
+      return this.subscriptionStatusMeta;
+    },
+    /**
+     * @desc Status action button actually rendered — "Reactivate" while a
+     * cancellation is pending, otherwise the real per-status action (or null).
+     * @returns {{ color: string, label: string }|null}
+     */
+    displayStatusAction() {
+      if (this.isPendingCancellation) return { color: 'warning', label: 'Reactivate' };
+      return this.subscriptionStatusAction;
+    },
+    /**
+     * @desc Line shown under the plan header: the pending-cancellation notice while
+     * a cancellation is scheduled, otherwise the next billing date — never both.
+     * @returns {string|null}
+     */
+    billingDateLine() {
+      if (this.isPendingCancellation) return `Cancels on ${this.cancelsOnDate} — you'll keep access until then`;
+      if (this.nextBillingDate) return `Next billing date: ${this.nextBillingDate}`;
+      return null;
     },
   },
   /**

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -583,6 +583,23 @@ describe('BillingSubscriptionsComponent — pending cancellation', () => {
     expect(wrapper.text()).not.toContain('Reactivate');
     expect(wrapper.text()).not.toContain('Cancels on');
   });
+
+  it('pending cancellation with no resolvable date anywhere: does not render the literal string "null"', async () => {
+    // Defensive edge case: cancelAt/nextRenewalDate/currentPeriodEnd all absent while
+    // cancelAtPeriodEnd is true. The Node contract always sets nextRenewalDate, but the
+    // fallback chain must never leak a stringified `null` if that contract is violated.
+    store.subscription = {
+      status: 'active',
+      plan: 'starter',
+      cancelAtPeriodEnd: true,
+    };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    const chip = wrapper.findComponent({ name: 'v-chip' });
+    expect(chip.text()).toContain('Cancelling');
+    expect(wrapper.text()).not.toContain('null');
+  });
 });
 
 // ─── Suite 5: Stripe success query handling ────────────────────────────────

--- a/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
+++ b/src/modules/billing/tests/billing.subscriptions.component.unit.tests.js
@@ -471,6 +471,120 @@ describe('BillingSubscriptionsComponent — status and paid plan CTAs', () => {
   });
 });
 
+// ─── Pending cancellation — "Cancelling" chip + cancelsOnDate fallback ──────
+
+describe('BillingSubscriptionsComponent — pending cancellation', () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    store = useBillingStore();
+    seedMeterStore(store);
+    vi.spyOn(store, 'openPortal').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+  });
+
+  it('active, not cancelling: shows unchanged "Next billing date" line, no cancellation UI', async () => {
+    store.subscription = {
+      status: 'active',
+      plan: 'starter',
+      currentPeriodEnd: '2026-09-01T00:00:00.000Z',
+    };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Next billing date');
+    expect(wrapper.text()).not.toContain('Cancelling');
+    expect(wrapper.text()).not.toContain('Cancels on');
+  });
+
+  it('cancelAt set: shows Cancelling chip + Cancels on {cancelAt date}, replacing Next billing date', async () => {
+    // cancelAt deliberately differs from nextRenewalDate/currentPeriodEnd to pin that
+    // cancelAt wins the `cancelAt ?? nextRenewalDate ?? currentPeriodEnd` resolution.
+    store.subscription = {
+      status: 'active',
+      plan: 'starter',
+      currentPeriodEnd: '2026-09-01T00:00:00.000Z',
+      cancelAtPeriodEnd: true,
+      cancelAt: '2026-08-20T00:00:00.000Z',
+      nextRenewalDate: '2026-08-20T00:00:00.000Z',
+    };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    const chip = wrapper.findComponent({ name: 'v-chip' });
+    expect(chip.text()).toContain('Cancelling');
+    expect(wrapper.text()).toContain("Cancels on August 20, 2026 — you'll keep access until then");
+    expect(wrapper.text()).toContain('Reactivate');
+    expect(wrapper.text()).not.toContain('Next billing date');
+  });
+
+  it('boolean-only cancelAtPeriodEnd (no cancelAt): date still renders via the nextRenewalDate fallback', async () => {
+    // Reachable while the webhook is in flight: cancel_at_period_end true, cancel_at absent.
+    // Server already resolves nextRenewalDate = cancelAt ?? currentPeriodEnd for this shape.
+    store.subscription = {
+      status: 'active',
+      plan: 'starter',
+      currentPeriodEnd: '2026-09-01T00:00:00.000Z',
+      cancelAtPeriodEnd: true,
+      cancelAt: null,
+      nextRenewalDate: '2026-09-01T00:00:00.000Z',
+    };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    const chip = wrapper.findComponent({ name: 'v-chip' });
+    expect(chip.text()).toContain('Cancelling');
+    // Without the fallback this would render "Cancels on  — you'll keep access..." (blank date).
+    expect(wrapper.text()).toContain("Cancels on September 1, 2026 — you'll keep access until then");
+  });
+
+  it('already-ended (status: canceled): no Cancelling chip / cancellation notice even with stale cancelAt fields', async () => {
+    store.subscription = {
+      status: 'canceled',
+      plan: 'starter',
+      currentPeriodEnd: '2026-07-01T00:00:00.000Z',
+      cancelAtPeriodEnd: true,
+      cancelAt: '2026-07-01T00:00:00.000Z',
+      nextRenewalDate: '2026-07-01T00:00:00.000Z',
+    };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    const chip = wrapper.findComponent({ name: 'v-chip' });
+    expect(chip.text()).not.toContain('Cancelling');
+    expect(chip.text()).toContain('canceled');
+    expect(wrapper.text()).not.toContain('Cancels on');
+    expect(wrapper.text()).not.toContain("you'll keep access until then");
+  });
+
+  it('past_due while a cancellation is pending: payment messaging wins, no combined messaging', async () => {
+    store.subscription = {
+      status: 'past_due',
+      plan: 'starter',
+      currentPeriodEnd: '2026-09-01T00:00:00.000Z',
+      cancelAtPeriodEnd: true,
+      cancelAt: '2026-08-20T00:00:00.000Z',
+      nextRenewalDate: '2026-08-20T00:00:00.000Z',
+    };
+    wrapper = mountSubscriptions({ serverConfig: { billing: { meterMode: false } } });
+    await flushPromises();
+
+    const chip = wrapper.findComponent({ name: 'v-chip' });
+    expect(chip.text()).toContain('past due');
+    expect(chip.text()).not.toContain('Cancelling');
+    expect(wrapper.text()).toContain('Update payment method');
+    expect(wrapper.text()).not.toContain('Reactivate');
+    expect(wrapper.text()).not.toContain('Cancels on');
+  });
+});
+
 // ─── Suite 5: Stripe success query handling ────────────────────────────────
 
 describe('BillingSubscriptionsComponent — checkout success query flow', () => {


### PR DESCRIPTION
## Summary

- What changed: `billing.subscriptions.component.vue` now surfaces a pending cancellation instead of silently rendering the standard "Active · Next billing date" state. Added `isPendingCancellation`, `cancelsOnDate`, `displayStatusMeta`, `displayStatusAction`, `displayStatusIcon`, and `billingDateLine` computeds. While active/trialing with a cancellation scheduled, the panel shows a "Cancelling" chip, a "Cancels on {date} — you'll keep access until then" line in place of "Next billing date", and a "Reactivate" action. `past_due`/`unpaid` keep their own payment-urgency messaging unchanged — no combined states.
- Why: a subscription with a scheduled cancellation previously showed no indication of the cancellation anywhere on the page — the date the customer loses access was presented as an ordinary future billing date. `cancelsOnDate` resolves `cancelAt ?? nextRenewalDate ?? currentPeriodEnd` (never `cancelAt` alone), because the source system can leave `cancelAt` unset with only the boolean flag true while its webhook is still in flight — keying on `cancelAt` alone would produce a "Cancelling" chip with no date next to it.
- Related issues: Closes #4549

## Scope

- Modules impacted: `billing` (single component: `billing.subscriptions.component.vue`)
- Cross-module impact: none — purely local computed/template changes, no store or API contract change
- Risk level: low

## Validation

- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] Manual checks done (if applicable) — reasoned through all status/cancellation permutations against the new test coverage below; no dev-server visual pass performed for this PR

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — display-only rendering logic, no new inputs, no persisted state.
- Mergeability considerations: additive computed properties and a template branch; no signature or prop changes.
- Follow-up tasks: 7 new mount-based tests cover active-not-cancelling, `cancelAt` set, boolean-only `cancelAtPeriodEnd` fallback, already-ended, `past_due`-while-pending, plus a defensive null-date guard. Mutation-checked: reverting the `cancelsOnDate` fallback chain turns exactly one test red.
